### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 A Model Context Protocol (MCP) implementation for the <a href="https://github.com/comet-ml/opik/">Opik platform</a> with support for multiple transport mechanisms, enabling seamless integration with IDEs and providing a unified interface for Opik's capabilities.
 </p>
 
+<a href="https://glama.ai/mcp/servers/@comet-ml/opik-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@comet-ml/opik-mcp/badge" alt="Opik Server MCP server" />
+</a>
+
 <div align="center">
 
 [![License](https://img.shields.io/github/license/comet-ml/opik-mcp)](https://github.com/comet-ml/opik-mcp/blob/main/LICENSE)


### PR DESCRIPTION
This PR adds a badge for the [Opik MCP Server](https://glama.ai/mcp/servers/@comet-ml/opik-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@comet-ml/opik-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@comet-ml/opik-mcp/badge" alt="Opik Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.