### PR TITLE
Improve prompt optimization tool discoverability and usability

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -150,6 +150,10 @@ function parseCommandLineArgs() {
         type: 'boolean',
         description: 'Disable metric-related tools',
       })
+      .option('disablePromptOptimizationTools', {
+        type: 'boolean',
+        description: 'Disable prompt optimization tools',
+      })
       .help()
       .parse() as {
       apiUrl?: string;
@@ -170,7 +174,7 @@ function parseCommandLineArgs() {
       disableProjectTools?: boolean;
       disableTraceTools?: boolean;
       disableMetricTools?: boolean;
-      mcpEnablePromptOptimizationTools?: boolean;
+      disablePromptOptimizationTools?: boolean;
       [key: string]: unknown;
     }
   );

--- a/src/tools/prompt_optimization.ts
+++ b/src/tools/prompt_optimization.ts
@@ -10,11 +10,20 @@ const config = loadConfig();
 export const loadPromptOptimizationTools = (server: any) => {
   if (config.mcpEnablePromptOptimizationTools) {
     server.tool(
-      'create-system-prompt',
-      'Create a new system prompt template based on the instructions provided by the user. Can also be used to edit an existing prompt.',
+      'create-system-prompt-for-evaluation',
+      'Create a specialized system prompt template for LLM-as-a-judge evaluation metrics, model evaluation, or other prompt engineering tasks. Particularly useful for creating evaluation prompts, benchmarking criteria, and structured assessment frameworks. Example usage: "create a system prompt for evaluating code quality" or "generate an LLM-as-a-judge metric for assessing factual accuracy".',
       {
-        instructions: z.string().describe('Instructions for the system prompt'),
-        system_prompt: z.string().describe('Existing system prompt').optional(),
+        instructions: z
+          .string()
+          .describe(
+            'Instructions for creating the system prompt. For LLM-as-a-judge metrics, include details about evaluation criteria, scoring methodology, and expected output format.'
+          ),
+        system_prompt: z
+          .string()
+          .describe(
+            'Existing system prompt to edit or refine. Provide this parameter when improving an existing evaluation prompt.'
+          )
+          .optional(),
       },
       async (args: any) => {
         const { instructions, system_prompt } = args;
@@ -37,8 +46,27 @@ export const loadPromptOptimizationTools = (server: any) => {
           ],
         });
 
+        // Add helpful context about how to use the generated prompt for LLM-as-a-judge metrics
+        const usageGuidance = `
+## How to Use This System Prompt for LLM-as-a-Judge Evaluation
+
+This system prompt is designed for evaluation tasks. To use it effectively:
+
+1. **Implementation**: Use this prompt as the system message when calling your evaluation model
+2. **User Message**: Provide the content to evaluate in the user message
+3. **Output Processing**: Parse the model's response according to the specified output format
+4. **Consistency**: For benchmark comparisons, use the same prompt across all evaluations
+
+For more information on LLM-as-a-judge metrics, see the [Opik documentation](https://www.comet.com/site/products/opik/).
+`;
+
         return {
-          content: [{ type: 'text', text: text }],
+          content: [
+            {
+              type: 'text',
+              text: text + (text.includes('# Output Format') ? '' : usageGuidance),
+            },
+          ],
         };
       }
     );


### PR DESCRIPTION
- Renamed tool to 'create-system-prompt-for-evaluation' for better discoverability
- Enhanced tool description with specific examples and use cases

Making everything more verbose seems to have fixed tool selection when prompting the model to create a prompt for LLM as a judge evals (without even mentioning that directly)