### PR TITLE
chore(release): cut v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opik-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opik-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opik-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server to interact with Opik - Enables automated prompt optimization",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.comet-ml/opik-mcp",
   "title": "Opik MCP Server",
   "description": "Interact with Opik prompts, traces, datasets and metrics through the Model Context Protocol.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "websiteUrl": "https://comet-ml.github.io/opik-mcp/",
   "repository": {
     "source": "github",
@@ -32,7 +32,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "opik-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Details
- bump package metadata from `2.0.0` to `2.0.1`
- align `server.json` package metadata with the release version
- package the six merged Dependabot dependency updates into a patch release

## Change checklist
- [ ] User facing
- [x] Documentation updated (if needed)
- [ ] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- `npm ci`
- `make precommit`
- `npm run build`

## Documentation
- No documentation changes required for this release cut.