### PR TITLE
chore(release): bump version to 0.1.0 for first PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opik-mcp"
-version = "0.0.4"
-description = "MCP server for Opik (Phase 1 PoC)."
+version = "0.1.0"
+description = "Model Context Protocol server for Opik (Comet's LLM observability platform)."
 readme = "README.md"
 requires-python = ">=3.13"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "opik-mcp"
-version = "0.0.4"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bumps `opik-mcp` from `0.0.4` to **`0.1.0`** to cut the first public PyPI
release. Also retires the now-inaccurate "Phase 1 PoC" line from the package
description.

## Release plan (after merge)

Trusted Publishing is already wired (`.github/workflows/python-release.yml`).
The full sequence:

1. **Merge this PR.**
2. **TestPyPI dry-run** — trigger `python-release.yml` via workflow_dispatch
   on main with `target=testpypi`. The workflow runs `make check`, builds
   sdist + wheel, and uploads to TestPyPI via OIDC.
3. **Smoke-test the TestPyPI artefact** in a clean env:
   ```bash
   uv tool install -i https://test.pypi.org/simple/ \
     --index-strategy unsafe-best-match opik-mcp==0.1.0
   OPIK_API_KEY=<key> COMET_WORKSPACE=<ws> opik-mcp  # should start the stdio server
   ```
4. **Tag for production** — once TestPyPI looks good:
   ```bash
   git tag py-v0.1.0
   git push origin py-v0.1.0
   ```
   The tag push triggers the `publish-pypi` job, which uploads to real PyPI.
5. **Verify on PyPI** — `uvx opik-mcp` should resolve. The README's
   pre-release callout (`uvx --from git+…`) can then be removed in a
   follow-up.

## Prerequisites (CTO already configured)

- PyPI project `opik-mcp` exists with Trusted Publisher pointing at
  `comet-ml/opik-mcp` + workflow `python-release.yml` + environment `pypi`.
- Same for TestPyPI with environment `testpypi`.
- GitHub repo has Environments named `pypi` and `testpypi`.

## Test plan

- [x] `uv build` produces `opik_mcp-0.1.0-py3-none-any.whl` + sdist
- [x] `uvx twine check dist/*` — PASSED for both artefacts
- [x] `make check` — lint + typecheck + 447 tests pass
- [ ] TestPyPI dispatch run — to be performed after merge
- [ ] TestPyPI install smoke — to be performed after TestPyPI publish
- [ ] PyPI tag push — to be performed after TestPyPI smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)