### PR TITLE
chore(release): drop GitHub Environments from publish workflow

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -46,7 +46,6 @@ jobs:
     needs: build
     if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
     runs-on: ubuntu-latest
-    environment: testpypi
     permissions:
       id-token: write
 
@@ -68,7 +67,6 @@ jobs:
       startsWith(github.ref, 'refs/tags/py-v') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
     runs-on: ubuntu-latest
-    environment: pypi
     permissions:
       id-token: write
 


### PR DESCRIPTION
## Summary

- Removed `environment: testpypi` and `environment: pypi` from `.github/workflows/python-release.yml`
- Unblocks the release flow without requiring repo-admin to create the two GitHub Environments first
- Trusted Publishing still works via OIDC — environments are an *optional* protection boundary, not a requirement

## Why

The previous workflow required two named GitHub Environments (`pypi`, `testpypi`) to exist in repo settings. Without admin access, creating them showed a 404, blocking any release.

PyPI Trusted Publishing supports OIDC matching against just `owner + repo + workflow filename`. The `environment` field on the PyPI Pending Publisher form is optional — if both sides leave it blank, OIDC still validates and publishes succeed.

For comparison, the main `opik` repo's `build_and_publish_sdk.yaml` skips environments entirely and uses an API token (`secrets.PYPI_API_TOKEN`). This PR keeps the more secure Trusted Publishing path but matches the "no environment" pattern.

## Required PyPI-side config

The PyPI **Pending Publisher** entries (both pypi.org and test.pypi.org) must have the Environment field **blank**:

| Field | Value |
| --- | --- |
| Owner | `comet-ml` |
| Repository | `opik-mcp` |
| Workflow filename | `python-release.yml` |
| Environment name | *(leave blank)* |

If the CTO already set an environment value on PyPI side, it must be cleared for OIDC matching to succeed.

## Test plan

- [ ] Merge this PR
- [ ] Confirm PyPI Pending Publishers have blank Environment field on both pypi.org and test.pypi.org
- [ ] Trigger TestPyPI dry-run: `gh workflow run python-release.yml --ref main -f target=testpypi`
- [ ] Verify artefact lands at https://test.pypi.org/project/opik-mcp/0.1.0/
- [ ] Smoke test: `uv tool install -i https://test.pypi.org/simple/ --index-strategy unsafe-best-match opik-mcp==0.1.0`
- [ ] Tag `py-v0.1.0` and push to trigger prod release

🤖 Generated with [Claude Code](https://claude.com/claude-code)