### PR TITLE
chore(release): restore environment: pypi (revert #112) + drop testpypi job

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -5,13 +5,6 @@ on:
     tags:
       - "py-v*"
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Publish target"
-        required: true
-        default: "testpypi"
-        type: choice
-        options: [testpypi, pypi]
 
 jobs:
   build:
@@ -42,31 +35,10 @@ jobs:
           name: dist
           path: dist/
 
-  publish-testpypi:
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to TestPyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   publish-pypi:
     needs: build
-    if: |
-      startsWith(github.ref, 'refs/tags/py-v') ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write
 


### PR DESCRIPTION
## Summary

- Restores `environment: pypi` on the publish job — required to match the Pending Trusted Publisher the CTO registered on PyPI (which was configured with `environment: pypi`)
- Drops the `publish-testpypi` job entirely and the `workflow_dispatch` `target` input — CTO elected to skip the TestPyPI dry-run
- Workflow now publishes to PyPI on:
  - Tag push matching `py-v*`
  - Manual `workflow_dispatch`

## Why

Run [26167391314](https://github.com/comet-ml/opik-mcp/actions/runs/26167391314) failed with `invalid-publisher` because the OIDC token shipped `environment: MISSING` while the PyPI Pending Publisher expects `environment: pypi`. PR #112 dropped envs from the workflow on the assumption the PyPI side would also be blank — CTO confirmed it isn't.

## Requires (one-time, before this PR can succeed)

The repo needs a `pypi` GitHub Environment. **Repo admin required** — I hit 403 trying via the API:

1. Go to https://github.com/comet-ml/opik-mcp/settings/environments
2. Click **New environment** → name: `pypi`
3. Recommended protection rules:
   - **Required reviewers**: add 1+ (CTO mentioned this)
   - **Deployment branches**: restrict to `main` only

## After merge

```
# Option A: manual dispatch
gh workflow run python-release.yml --ref main --repo comet-ml/opik-mcp

# Option B: tag-driven (recommended — keeps GitHub release + version in sync)
git tag py-v0.1.0
git push origin py-v0.1.0
```

⚠️ **PyPI uploads are permanent.** Once `0.1.0` lands, that version is burned. Double-check the wheel before the required-reviewer approves the deployment.

## Test plan

- [ ] Admin creates `pypi` environment in repo settings
- [ ] Merge PR
- [ ] Dispatch workflow → confirm `publish-pypi` job runs and OIDC exchange succeeds
- [ ] Verify package at https://pypi.org/project/opik-mcp/0.1.0/
- [ ] Smoke test: `uvx opik-mcp --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)