### PR TITLE
chore(release): bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opik-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Model Context Protocol server for Opik (Comet's LLM observability platform)."
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
Cuts a 0.1.1 release picking up everything merged to `main` since 0.1.0 was published to PyPI:

- **#114 — elicitation + conformance**: user confirmations (tool-name-first prompt, session-scoped allowlist, Accept/Decline) with a wire-contract test suite covering the elicit timeout, progress notifications, and a few smaller review fixes.
- **#115 — `opik_mcp_startup_error` BI event** (just merged): fills the install-funnel blind spot by emitting on Settings validation crash, insecure-token bind refusal, and unhandled transport.run() exceptions. PII-safe (class-name + bucketed error_kind only) with a respx integration test guarding the config-fail emit path.

No breaking changes — additive features only, hence patch bump.

## Release flow
Once this PR merges, push tag `py-v0.1.1` against the merge commit to trigger `.github/workflows/python-release.yml` (runs `make check`, builds sdist+wheel, publishes to PyPI via Trusted Publishing).

## Test plan
- [x] `make check` passes locally on this branch (488 tests, 2 skipped)
- [ ] After merge: tag push triggers release workflow successfully
- [ ] After PyPI publish: `pip install opik-mcp==0.1.1` works
- [ ] After PyPI publish: GitHub release published with notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)