### PR TITLE
fix(analytics): startup_error reliability + bump to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opik-mcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "Model Context Protocol server for Opik (Comet's LLM observability platform)."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/capture_bi_listener.py
+++ b/scripts/capture_bi_listener.py
@@ -1,0 +1,42 @@
+"""Tiny local listener that records every BI POST and prints the body.
+
+Run in one terminal; point ``OPIK_MCP_ANALYTICS_URL`` at it from another.
+This is the realistic verification path: real opik-mcp subprocess, real
+httpx daemon thread, real flush() — only the destination URL changes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            body = json.loads(raw)
+            pretty = json.dumps(body, indent=2, sort_keys=True)
+        except json.JSONDecodeError:
+            pretty = raw.decode("utf-8", errors="replace")
+        print(f"\n--- POST {self.path} ---\n{pretty}\n", flush=True)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"success":true}')
+
+    def log_message(self, fmt: str, *args: object) -> None:  # silence noise
+        return
+
+
+def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8765
+    srv = HTTPServer(("127.0.0.1", port), _Handler)
+    print(f"BI capture listening on http://127.0.0.1:{port}/notify/event/", flush=True)
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/opik_mcp/__init__.py
+++ b/src/opik_mcp/__init__.py
@@ -1,3 +1,14 @@
-from opik_mcp.server import mcp
+"""opik-mcp package.
 
-__all__ = ["mcp"]
+Intentionally empty at import time. We previously re-exported
+``opik_mcp.server.mcp`` here for convenience, but ``server`` constructs the
+``FastMCP`` instance with ``instructions=render_instructions()`` — which
+eagerly calls ``get_settings()``. That made a ``ValidationError`` from
+malformed env (e.g. bad ``COMET_WORKSPACE_ID``) propagate out of
+``import opik_mcp`` itself, before ``__main__.main()`` could catch it and
+emit ``opik_mcp_startup_error``. The fallback-client emit path was dead
+code on the most common install-failure mode.
+
+Anything that needs the server should import it directly:
+``from opik_mcp.server import mcp``.
+"""

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import socket
 import sys
 
 import uvicorn
@@ -53,8 +54,62 @@ def _configure_logging(level: str) -> None:
 
 
 def _bucket_transport_exception_type(exc: BaseException) -> str:
-    name = type(exc).__name__
-    return name if name in _KNOWN_TRANSPORT_EXCEPTION_NAMES else "unknown"
+    """Map a transport exception to the most specific bucketed name in the allowlist.
+
+    Walks the MRO so common ``OSError`` subclasses — ``PermissionError``
+    (privileged port), ``ConnectionRefusedError``, ``BrokenPipeError`` —
+    bucket as ``"OSError"`` rather than expanding cardinality with each
+    new subclass. Returns ``"unknown"`` only when nothing in the chain
+    matches.
+    """
+    for cls in type(exc).__mro__:
+        if cls.__name__ in _KNOWN_TRANSPORT_EXCEPTION_NAMES:
+            return cls.__name__
+    return "unknown"
+
+
+def _preflight_bind_check(host: str, port: int) -> None:
+    """Bind+release the target socket before handing it to uvicorn.
+
+    Uvicorn handles bind failures (EADDRINUSE, permission denied, …)
+    *internally*: it logs an ``ERROR``, runs the ASGI shutdown lifespan,
+    and returns normally from ``uvicorn.run`` with exit code 0. Our outer
+    ``except BaseException`` never sees the ``OSError``, so the most common
+    real-world transport failure — port already in use — was invisible to
+    BI before this check.
+
+    Performing the bind ourselves surfaces the ``OSError`` to the caller,
+    which our error handler then tags as ``transport_crash`` and re-raises.
+
+    Address-family handling: ``getaddrinfo`` resolves ``host`` to the right
+    ``(AF_INET / AF_INET6, sockaddr)`` so this works for ``127.0.0.1``,
+    ``::1``, and ``localhost`` (which resolves to ``::1`` first on macOS
+    15+ and many modern Linux distros). Hardcoding ``AF_INET`` would
+    either raise a spurious ``Invalid argument`` for ``::1`` (false-
+    positive crash) or silently pass when uvicorn would actually fail.
+
+    The window between releasing this socket and uvicorn binding it is a
+    benign race: a process that grabs the port in that gap will still
+    cause uvicorn to log an error — we just miss the BI event for that
+    extremely narrow case. On Linux there is also a ``SO_REUSEPORT``
+    asymmetry: another process holding the port with only
+    ``SO_REUSEPORT`` can let our preflight succeed while uvicorn's
+    actual bind fails. Both gaps are accepted in exchange for catching
+    the common cases (port already taken at startup, privileged port
+    without permission).
+    """
+    infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    if not infos:
+        return  # Nothing resolved; let uvicorn report any failure itself.
+    af, socktype, proto, _canonname, sockaddr = infos[0]
+    sock = socket.socket(af, socktype, proto)
+    try:
+        # SO_REUSEADDR matches uvicorn's own bind so we don't reject a port
+        # uvicorn would have accepted (e.g. a recently-closed TIME_WAIT).
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(sockaddr)
+    finally:
+        sock.close()
 
 
 def _build_fallback_analytics_client() -> AnalyticsClient:
@@ -218,6 +273,9 @@ def _run_transport(settings: Settings, transport: str) -> None:
 
     # Imported lazily so stdio mode doesn't pay the Starlette import cost.
     from opik_mcp.server import build_app
+
+    # Surface bind failures to our error handler; see _preflight_bind_check.
+    _preflight_bind_check(settings.opik_mcp_host, settings.opik_mcp_port)
 
     if settings.opik_mcp_reload:
         uvicorn.run(

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -205,6 +205,37 @@ def test_startup_error_omits_pii_from_transport_crash_event(
 # --- exception_type bucketing -------------------------------------------- #
 
 
+def test_transport_crash_buckets_oserror_subclass_via_mro(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``PermissionError`` (and other ``OSError`` subclasses) must bucket as
+    ``"OSError"`` via MRO walk, not as ``"unknown"``.
+
+    Without MRO walking the most common real-world bind failure — port 80
+    on a non-root user → ``PermissionError`` — surfaces as ``"unknown"``,
+    making BI funnels for bind-permission issues invisible. Bucketing to
+    the parent ``OSError`` keeps cardinality bounded *and* gives BI a
+    semantic group it can act on.
+    """
+    recorder = _install_recorder(monkeypatch)
+
+    class _BoomMcp:
+        def run(self, *, transport: str) -> None:
+            raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("opik_mcp.server.mcp", _BoomMcp())
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+
+    with pytest.raises(PermissionError):
+        main_mod.main()
+
+    props = next(p for et, p in recorder.events if et == EVENT_STARTUP_ERROR)
+    assert props["exception_type"] == "OSError", (
+        f"PermissionError should bucket to its OSError parent via MRO walk, "
+        f"got {props['exception_type']!r}"
+    )
+
+
 def test_transport_crash_buckets_unknown_exception_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_analytics_subprocess.py
+++ b/tests/test_analytics_subprocess.py
@@ -1,0 +1,296 @@
+"""Real-subprocess startup_error tests.
+
+These spawn a fresh ``python -m opik_mcp`` process so the entire import chain
+runs with the broken env in place. They exist because respx-based tests in
+``test_analytics_server_startup.py`` cannot catch bugs where the failure
+happens at module-import time — by the time ``monkeypatch.setenv`` runs in
+the test process, ``opik_mcp`` is already imported and any import-time
+``get_settings()`` calls have already succeeded with whatever env the test
+runner started with.
+
+The motivating regression: ``opik_mcp/__init__.py`` used to re-export
+``mcp`` from ``opik_mcp.server``, which eagerly called ``get_settings()`` via
+``render_instructions()``. A bad ``COMET_WORKSPACE_ID`` raised
+``ValidationError`` out of ``import opik_mcp`` itself — before ``main()``
+could catch it and emit. The respx test for the fallback path passed
+green but the real subprocess silently dropped the event.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _CaptureServer:
+    """Tiny local listener that records POST bodies for assertion."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        # Pass port 0 so the OS assigns a free port AND we bind it atomically.
+        # The previous pattern (_free_port → close → HTTPServer rebinds the same
+        # port number) had a TOCTOU window where the OS could give that port
+        # to a different process before HTTPServer claimed it.
+        self._srv = http.server.HTTPServer(("127.0.0.1", 0), _build_handler(self.events))
+        self._thread = threading.Thread(target=self._srv.serve_forever, daemon=True)
+        self._thread.start()
+        # server_address is typed ``tuple[Any, ...]`` in the stubs; we know we
+        # bound to ("127.0.0.1", <int>) so cast for the f-string.
+        host = str(self._srv.server_address[0])
+        port = int(self._srv.server_address[1])
+        self.url = f"http://{host}:{port}/notify/event/"
+
+    def close(self) -> None:
+        self._srv.shutdown()
+        self._srv.server_close()
+        # 5s is plenty for the serve_forever loop to notice ``shutdown()`` and
+        # exit; a hung worker thread is always a bug, not a transient — fail
+        # the test rather than leaking a thread that can interfere with the
+        # next test's port assignment.
+        self._thread.join(timeout=5)
+        assert not self._thread.is_alive(), "_CaptureServer worker thread did not exit"
+
+
+def _build_handler(sink: list[dict[str, Any]]) -> type[http.server.BaseHTTPRequestHandler]:
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length) if length else b""
+            try:
+                sink.append(json.loads(raw.decode("utf-8")))
+            except json.JSONDecodeError:
+                sink.append({"_raw": raw.decode("utf-8", errors="replace")})
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"success":true}')
+
+        def log_message(self, fmt: str, *args: object) -> None:  # silence pytest noise
+            return
+
+    return _Handler
+
+
+@pytest.fixture()
+def capture() -> Iterator[_CaptureServer]:
+    srv = _CaptureServer()
+    try:
+        yield srv
+    finally:
+        srv.close()
+
+
+def _run_opik_mcp(
+    extra_env: dict[str, str], timeout: float = 15.0
+) -> subprocess.CompletedProcess[bytes]:
+    """Run ``python -m opik_mcp`` as a fresh process and return the result.
+
+    The env is built from a clean baseline (no inheriting of the dev's
+    OPIK_API_KEY or COMET_WORKSPACE) so failures are deterministic.
+    """
+    base_env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        # Stamp every event payload so receiver-side filters can drop the
+        # test traffic if these somehow leak to a real receiver.
+        "OPIK_MCP_ANALYTICS_SOURCE": "opik-mcp-test",
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "opik_mcp"],
+        env={**base_env, **extra_env},
+        cwd=REPO_ROOT,
+        timeout=timeout,
+        capture_output=True,
+    )
+
+
+def test_invalid_config_emits_in_real_subprocess(capture: _CaptureServer) -> None:
+    """Bad ``COMET_WORKSPACE_ID`` must POST ``opik_mcp_startup_error`` even
+    when the ``ValidationError`` originates at module-import time.
+
+    Without the ``__init__.py`` fix this assertion fails — the subprocess
+    raises before ``main()`` runs, the fallback emit never fires, and BI
+    sees zero signal for the most common install-failure mode.
+    """
+    result = _run_opik_mcp(
+        {
+            "OPIK_MCP_ANALYTICS_URL": capture.url,
+            "COMET_WORKSPACE_ID": "not-a-uuid",
+            "OPIK_API_KEY": "test-key",
+            "OPIK_MCP_TRANSPORT": "stdio",
+        }
+    )
+
+    # Non-zero exit: ValidationError propagated out of main(); that's expected.
+    assert result.returncode != 0, "expected ValidationError to terminate the subprocess"
+
+    # The actual contract: at least one POST landed, and it's the startup_error.
+    errors = [e for e in capture.events if e.get("event_type") == "opik_mcp_startup_error"]
+    assert errors, (
+        "fallback client must POST opik_mcp_startup_error before the subprocess unwinds; "
+        f"captured events = {capture.events!r}"
+    )
+    props = errors[0]["event_properties"]
+    assert props["phase"] == "config"
+    assert props["error_kind"] == "invalid_config"
+    assert props["exception_type"] == "ValidationError"
+    # ``server_started`` MUST NOT fire — we never reached a usable Settings.
+    assert not any(e.get("event_type") == "opik_mcp_server_started" for e in capture.events), (
+        "server_started leaked on the config-fail path"
+    )
+
+
+def test_invalid_config_subprocess_omits_pii(capture: _CaptureServer) -> None:
+    """Raw bad env value must not leak into the subprocess's POST body."""
+    canary = "PII-CANARY-subprocess-not-a-real-uuid-3c7e9d11"
+    _run_opik_mcp(
+        {
+            "OPIK_MCP_ANALYTICS_URL": capture.url,
+            "COMET_WORKSPACE_ID": canary,
+            "OPIK_API_KEY": "test-key",
+            "OPIK_MCP_TRANSPORT": "stdio",
+        }
+    )
+    body = json.dumps(capture.events)
+    assert canary not in body, f"PII leak in subprocess POST: {body!r}"
+
+
+def _ipv6_loopback_supported() -> bool:
+    """Probe whether ``::1`` is bindable on this host.
+
+    Required because CI runners frequently disable IPv6 (e.g. GitHub-hosted
+    runners depending on image generation), and the preflight test must skip
+    cleanly there rather than fail with a misleading bind error.
+    """
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        try:
+            s.bind(("::1", 0))
+        finally:
+            s.close()
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(not _ipv6_loopback_supported(), reason="IPv6 loopback unavailable on host")
+def test_preflight_handles_ipv6_loopback_via_getaddrinfo(capture: _CaptureServer) -> None:
+    """``OPIK_MCP_HOST=::1`` must NOT trigger a false-positive transport_crash.
+
+    Regression for the bug where ``_preflight_bind_check`` hardcoded
+    ``AF_INET``: any user binding to ``::1`` (or to ``localhost`` on a host
+    where it resolves to ``::1``, common on macOS 15+) would have got
+    ``OSError: Invalid argument`` from the IPv4 socket trying to bind an
+    IPv6 address — and we'd have emitted a misleading ``transport_crash``
+    for a server that would otherwise have booted fine.
+
+    Test strategy: bind ``::1:<free_port>``, run opik-mcp targeting the
+    *same* address. Pre-flight check must surface a real ``OSError`` (port
+    in use) — not the spurious "Invalid argument" from the wrong family.
+    """
+    hold = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    hold.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    hold.bind(("::1", 0))
+    held_port = hold.getsockname()[1]
+    hold.listen(1)
+    try:
+        _run_opik_mcp(
+            {
+                "OPIK_MCP_ANALYTICS_URL": capture.url,
+                "OPIK_API_KEY": "test-key",
+                "COMET_WORKSPACE": "test-ws",
+                "OPIK_MCP_TRANSPORT": "streamable-http",
+                "OPIK_MCP_HOST": "::1",
+                "OPIK_MCP_PORT": str(held_port),
+                "OPIK_MCP_DEV_TOKEN": "test-token-not-default-1234567890",
+            }
+        )
+    finally:
+        hold.close()
+
+    errors = [e for e in capture.events if e.get("event_type") == "opik_mcp_startup_error"]
+    assert errors, "preflight must surface real OSError for IPv6 bind, not silently mis-classify"
+    props = errors[0]["event_properties"]
+    # Must be transport_crash with OSError — NOT some other phase or "unknown".
+    # An "Invalid argument" leak would still be OSError, but it would fire
+    # even on a free port; the held-port setup proves we caught a real bind.
+    assert props["phase"] == "transport_start"
+    assert props["error_kind"] == "transport_crash"
+    assert props["exception_type"] == "OSError"
+
+
+def test_port_in_use_emits_transport_crash_in_subprocess(capture: _CaptureServer) -> None:
+    """Pre-flight bind check must surface ``OSError`` for an occupied port.
+
+    Without the pre-flight check, uvicorn catches the bind failure
+    internally, runs the shutdown lifespan, and returns normally — the
+    process exits 0 with no startup_error event. This regression test
+    holds a port from the test process and asserts opik-mcp's subprocess
+    POSTs ``transport_crash`` before unwinding.
+    """
+    # Bind to port 0 so the OS picks AND assigns atomically — eliminates the
+    # window where _free_port → close → re-bind could lose the port to another
+    # process under CI load.
+    hold = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    hold.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    hold.bind(("127.0.0.1", 0))
+    held_port = hold.getsockname()[1]
+    hold.listen(1)
+    try:
+        _run_opik_mcp(
+            {
+                "OPIK_MCP_ANALYTICS_URL": capture.url,
+                "OPIK_API_KEY": "test-key",
+                "COMET_WORKSPACE": "test-ws",
+                "OPIK_MCP_TRANSPORT": "streamable-http",
+                "OPIK_MCP_HOST": "127.0.0.1",
+                "OPIK_MCP_PORT": str(held_port),
+                # Bypass the http_bind_check that would otherwise short-circuit.
+                "OPIK_MCP_DEV_TOKEN": "test-token-not-default-1234567890",
+            }
+        )
+    finally:
+        hold.close()
+
+    errors = [e for e in capture.events if e.get("event_type") == "opik_mcp_startup_error"]
+    assert errors, (
+        "transport_crash must fire when uvicorn's port is already bound; "
+        f"captured events = {capture.events!r}"
+    )
+    props = errors[0]["event_properties"]
+    assert props["phase"] == "transport_start"
+    assert props["error_kind"] == "transport_crash"
+    assert props["exception_type"] == "OSError"
+    assert props["transport"] == "streamable-http"
+
+
+def test_opt_out_suppresses_emit_in_subprocess(capture: _CaptureServer) -> None:
+    """``OPIK_MCP_ANALYTICS_ENABLED=false`` must hold on the config-fail
+    subprocess path — the fallback client honours opt-out even when the
+    rest of Settings is unusable.
+    """
+    _run_opik_mcp(
+        {
+            "OPIK_MCP_ANALYTICS_URL": capture.url,
+            "OPIK_MCP_ANALYTICS_ENABLED": "false",
+            "COMET_WORKSPACE_ID": "not-a-uuid",
+            "OPIK_API_KEY": "test-key",
+            "OPIK_MCP_TRANSPORT": "stdio",
+        }
+    )
+    assert not capture.events, (
+        f"opt-out must suppress emit on config-fail subprocess path; got {capture.events!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "opik-mcp"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Real-subprocess verification of the 0.1.1 `opik_mcp_startup_error` event uncovered two production bugs that the existing respx-mocked tests couldn't catch — BI saw zero signal for the two most common install-failure modes.

### Bug 1 — `invalid_config` dropped at import time

`opik_mcp/__init__.py` re-exported `mcp` from `opik_mcp.server`, which eagerly called `get_settings()` via `render_instructions()`. A bad `COMET_WORKSPACE_ID` raised `ValidationError` out of `import opik_mcp` itself, before `main()` could catch it and emit. Fix: drop the eager re-export; consumers now `from opik_mcp.server import mcp` directly.

### Bug 2 — `transport_crash` dropped on uvicorn bind failure

uvicorn catches `OSError` internally (EADDRINUSE, permission denied), runs ASGI shutdown, and returns normally — our `except BaseException` never saw it. Fix: add `_preflight_bind_check` that binds+releases the target socket before uvicorn so the `OSError` propagates to the handler. Uses `getaddrinfo` so `::1` and `localhost` (which resolves to `::1` on macOS 15+) work without an "Invalid argument" false positive.

### Quality-of-life fix

`_bucket_transport_exception_type` now walks the MRO so `OSError` subclasses (`PermissionError` on privileged ports, `ConnectionRefusedError`, `BrokenPipeError`) bucket as `"OSError"` instead of `"unknown"` — preserves the low-cardinality BI contract as std lib evolves.

## Why respx tests didn't catch this

By the time `monkeypatch.setenv` runs in pytest, `opik_mcp` is already imported and any import-time `get_settings()` calls have succeeded with the test runner's env. The new `tests/test_analytics_subprocess.py` spawns fresh `python -m opik_mcp` processes against a local capture HTTPServer — catching the bugs by reproducing the exact real-world install path.

## Test plan

- [x] `uv run pytest` — 494 passed, 2 skipped
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [x] Manual verification with `scripts/capture_bi_listener.py`:
  - [x] Bad `COMET_WORKSPACE_ID` → POST `invalid_config` lands
  - [x] Held port 28765 → POST `transport_crash` lands with `exception_type: OSError`
  - [x] Port 80 → POST `transport_crash` lands with `exception_type: OSError` (was `unknown` before MRO fix)
  - [x] `OPIK_MCP_ANALYTICS_ENABLED=false` → no POST
  - [x] PII canary in env vars → no canary in payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)