### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opik-mcp"
-version = "0.1.2"
+version = "0.1.3"
 description = "Model Context Protocol server for Opik (Comet's LLM observability platform)."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "opik-mcp"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Release PR for v0.1.3. Bundles two analytics-reliability changes since 0.1.1:

### 1. `opik_mcp_startup_error` reliability — PR #117

- **Fixed silent-drop of `invalid_config` events**: `opik_mcp/__init__.py` was eagerly calling `get_settings()` via `render_instructions()`, so `ValidationError` propagated out of `import opik_mcp` itself before `main()` could catch it.
- **Added `_preflight_bind_check`**: uvicorn swallows `OSError` (EADDRINUSE, permission denied) internally and returns normally — we now bind+release the target socket first so the error reaches our handler. Uses `getaddrinfo` so `::1` and `localhost` work without false positives.
- **MRO-walking exception bucketing**: `PermissionError`, `ConnectionRefusedError`, `BrokenPipeError` now bucket as `"OSError"` instead of expanding cardinality with each subclass.

### 2. `error_kind` taxonomy split — PR #118

Splits the noisy `opik_http_4xx` and `unknown` buckets to disambiguate user-side issues from server bugs:

| Old bucket | New buckets |
|---|---|
| `opik_http_4xx` | `opik_auth_failed` (401) · `opik_permission_denied` (403) · `opik_not_found` (404) · `opik_validation_failed` (400/422) |
| `comet_auth_failed` (mixed) | `comet_auth_failed` (401) · `comet_permission_denied` (403) |
| `unknown` (partial) | `network_error` (httpx.RequestError family) · `tool_args_invalid` (pydantic.ValidationError from inner `model_validate`) |

`OpikPermissionError(OpikAuthError)` and `CometPermissionError(CometAuthError)` are subclasses so existing `except` clauses still work.

## BI receiver impact

Dashboards keying off `opik_http_4xx` will see that bucket drop to zero and the new specific buckets appear. Receiver-side filter on `event_type=opik_mcp_tool_called` is unaffected. **Coordinate with whoever owns the receiver-side dashboards before this lands.**

## Test plan

- [x] `uv run pytest` — 501 passed (was 494 in 0.1.1)
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy` — clean
- [x] Real-subprocess verification (`tests/test_analytics_subprocess.py`) — 5 regression tests spawn fresh `python -m opik_mcp` processes against a local capture HTTP server
- [x] After merge: tag `py-v0.1.3`, push tag, trigger PyPI release, create GitHub release with combined notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)