### PR TITLE
feat(analytics): classify WriteError hierarchy out of `unknown`

### DIFF
--- a/src/opik_mcp/analytics/wrappers.py
+++ b/src/opik_mcp/analytics/wrappers.py
@@ -37,6 +37,15 @@ from opik_mcp.opik_client import (
     OpikServerError,
     OpikValidationError,
 )
+from opik_mcp.writes.errors import (
+    AuthorizationDeniedError,
+    BackendError,
+    BatchPartialFailureError,
+    BatchTooLargeError,
+    UnknownOperationError,
+    ValidationFailedError,
+    WriteError,
+)
 
 logger = logging.getLogger("opik_mcp.analytics.wrappers")
 
@@ -74,14 +83,30 @@ _ERROR_KIND_TABLE: tuple[tuple[type[BaseException], str], ...] = (
     (PodNotReadyError, "pod_warmup_timeout"),
     (OllieAuthError, "ollie_auth_failed"),
     (OllieStreamError, "ollie_stream_error"),
-    # Pydantic validation from INSIDE the tool body — e.g.
+    # `write` tool's structured error hierarchy — listed BEFORE the generic
+    # pydantic row because the dispatcher catches ``ValidationError`` from
+    # ``op.pydantic_model.model_validate(...)`` and re-raises it as
+    # ``ValidationFailedError`` (not a pydantic subclass), so the inner
+    # pydantic error never reaches this classifier on the write path.
+    # Bucket names mirror the stable ``ErrorCode`` literals declared in
+    # ``writes/errors.py`` so BI dashboards can key off the same enum used
+    # in the tool result envelope.
+    (ValidationFailedError, "write_validation_failed"),
+    (UnknownOperationError, "write_unknown_operation"),
+    (AuthorizationDeniedError, "write_authorization_denied"),
+    (BatchTooLargeError, "write_batch_too_large"),
+    (BatchPartialFailureError, "write_batch_partial_failure"),
+    (BackendError, "write_backend_error"),
+    (WriteError, "write_error_other"),  # catch-all for future subclasses
+    # Pydantic validation from INSIDE the tool body. Active path:
     # ``RunExperimentConfig.model_validate(experiment_config)`` in
-    # ``server.run_experiment`` or ``op.pydantic_model.model_validate(data)``
-    # in the write dispatcher. NOTE: FastMCP's ``Tool.run`` validates the
-    # tool's outer signature BEFORE calling our wrapped function and converts
-    # the resulting ``ValidationError`` into a ``ToolError``, so the very
-    # outermost arg-coercion failure never hits this branch. The bucket only
-    # fires when a tool itself calls ``model_validate`` on a sub-payload.
+    # ``server.run_experiment`` — a raw pydantic error there propagates
+    # directly to us. The write dispatcher's ``model_validate`` calls are
+    # NOT covered here because dispatch wraps them in ``ValidationFailedError``
+    # (handled above). NOTE: FastMCP's ``Tool.run`` validates the tool's
+    # outer signature BEFORE calling our wrapped function and converts the
+    # resulting ``ValidationError`` into a ``ToolError``, so the outermost
+    # arg-coercion failure never hits this branch either.
     (PydanticValidationError, "tool_args_invalid"),
     # Network — httpx.RequestError is the common base for ConnectError,
     # TimeoutException (read/connect/write/pool), ReadError, etc. Catches the

--- a/tests/test_analytics_wrappers.py
+++ b/tests/test_analytics_wrappers.py
@@ -22,6 +22,15 @@ from opik_mcp.opik_client import (
     OpikServerError,
     OpikValidationError,
 )
+from opik_mcp.writes.errors import (
+    AuthorizationDeniedError,
+    BackendError,
+    BatchPartialFailureError,
+    BatchTooLargeError,
+    UnknownOperationError,
+    ValidationFailedError,
+    WriteError,
+)
 
 
 def _build_pydantic_error() -> PydanticValidationError:
@@ -99,8 +108,33 @@ async def test_success_emits_tool_called(recorder: _Recorder) -> None:
         (httpx.ConnectError("connect refused"), "network_error"),
         (httpx.ReadTimeout("read timed out"), "network_error"),
         (httpx.ReadError("read error"), "network_error"),
-        # pydantic validation on tool args.
+        # pydantic validation on tool args (raw pydantic, e.g. from
+        # ``RunExperimentConfig.model_validate(...)``).
         (_build_pydantic_error(), "tool_args_invalid"),
+        # `write` tool structured errors — dispatcher wraps inner pydantic
+        # failures in ValidationFailedError, so the bucket must surface as
+        # write_validation_failed rather than tool_args_invalid.
+        (
+            ValidationFailedError.build("score.create", [], expected_schema={}, example={}),
+            "write_validation_failed",
+        ),
+        (UnknownOperationError.build("bogus.op", ("score.create",)), "write_unknown_operation"),
+        (
+            AuthorizationDeniedError.build("score.create", "write:scores"),
+            "write_authorization_denied",
+        ),
+        (BatchTooLargeError.build("score.create", 5000, 1000), "write_batch_too_large"),
+        (
+            BatchPartialFailureError.build("score.create", [], []),
+            "write_batch_partial_failure",
+        ),
+        (
+            BackendError.build("score.create", 500, {}, method="POST", path="/v1/x"),
+            "write_backend_error",
+        ),
+        # Bare WriteError (future subclass / direct instance) falls into the
+        # catch-all bucket rather than "unknown".
+        (WriteError(error="backend_error"), "write_error_other"),
         # Genuine catch-all.
         (ValueError("x"), "unknown"),
     ],


### PR DESCRIPTION
## Summary
- **The gap**: `write` tool failures all landed in `error_kind=unknown` in BI. Every `WriteError` subclass (validation, backend, auth-denied, batch limits, unknown-op) was missing from `_ERROR_KIND_TABLE` in `analytics/wrappers.py`.
- **The reason `tool_args_invalid` didn't catch it**: `writes/dispatch.py` catches `pydantic.ValidationError` at every `op.pydantic_model.model_validate(...)` call and re-raises as `ValidationFailedError`, which extends `Exception` directly (not `pydantic.ValidationError`). So the pydantic row in the table never fired on the write path.
- **The fix**: add the 6 `WriteError` subclasses to the classifier (subclass-before-parent ordering preserved) plus a `WriteError` catch-all row. Bucket names mirror the stable `ErrorCode` literals already declared in `writes/errors.py` so BI dashboards can join the analytics event against the tool-result envelope by the same enum.

This is a direct follow-up to PR #118 — discovered while verifying that 0.1.3 actually shrinks the 44% unknown share. Triggered 6 real failure paths through live MCP tool calls; 3 of them (every write-tool path) were misrouted to `unknown`.

## Test plan
- [x] `make check` clean — 508 tests pass, ruff format clean, mypy strict clean
- [x] 8 new parametrized cases in `test_analytics_wrappers.py` cover every `WriteError` subclass + the catch-all row
- [x] Existing `tool_args_invalid` row preserved with updated comment explaining why it doesn't fire on the write path
- [ ] After merge: re-run the same 6-case verification and confirm write failures now route to `write_validation_failed` / `write_backend_error` instead of `unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)