### PR TITLE
feat(analytics): bucket error_kind on tool_called + ask_ollie_completed

### DIFF
--- a/src/opik_mcp/analytics/errors.py
+++ b/src/opik_mcp/analytics/errors.py
@@ -1,0 +1,153 @@
+"""Shared error taxonomy for analytics events.
+
+Both ``opik_mcp_tool_called`` and ``opik_mcp_ask_ollie_completed`` emit an
+``error_kind`` drawn from the ``ErrorKind`` allowlist below. The granular
+exception class is preserved as ``exception_type`` — coarse bucketing for
+"what should we fix next?" dashboards, granular class names for follow-up
+investigation.
+
+PRIVACY: every public function in this module keys off the exception CLASS
+only — never on ``exc.args`` / ``str(exc)`` / response body. That guarantees
+no exception message ever surfaces in an analytics property. The contract is
+machine-checked by ``tests/test_analytics_privacy.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+from pydantic import ValidationError as PydanticValidationError
+
+from opik_mcp.comet_client import (
+    CometAuthError,
+    CometPermissionError,
+    CometProtocolError,
+    OllieNotEnabledError,
+)
+from opik_mcp.config import MissingConfigError
+from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError
+from opik_mcp.opik_client import (
+    OpikAuthError,
+    OpikNotFoundError,
+    OpikPermissionError,
+    OpikServerError,
+    OpikValidationError,
+)
+
+# The receiver only ever sees one of these values. Adding a new bucket is a
+# BI schema change — extend cautiously and keep the Literal in sync.
+ErrorKind = Literal[
+    "auth",
+    "validation",
+    "not_found",
+    "permission",
+    "timeout",
+    "network",
+    "upstream_5xx",
+    "cancelled",
+    "unknown",
+]
+
+
+# Canonical HTTP status for each typed Opik/Comet exception. Our client
+# layers raise these in place of carrying ``status_code`` on the exception
+# instance, so we recover the status here from the class itself. Sub-
+# classes are intentionally listed BEFORE their parents (``OpikPermissionError``
+# extends ``OpikAuthError``) so ``isinstance`` walks resolve to the more-
+# specific status first.
+_EXC_TO_HTTP_STATUS: tuple[tuple[type[BaseException], int], ...] = (
+    (OpikPermissionError, 403),
+    (OpikAuthError, 401),
+    (OpikNotFoundError, 404),
+    (OpikValidationError, 400),
+    (OpikServerError, 500),
+    (CometPermissionError, 403),
+    (CometAuthError, 401),
+)
+
+
+def derive_http_status(exc: BaseException) -> int | None:
+    """Return the canonical HTTP status for a typed exception, else ``None``.
+
+    Designed for ``opik_mcp_tool_called`` / ``ask_ollie_completed`` emit
+    sites: the BI receiver needs the status alongside ``error_kind`` so a
+    dashboard can split, e.g., ``auth`` failures into 401 vs 403 without
+    losing the coarse bucket.
+    """
+    # ``httpx.HTTPStatusError`` carries the real status on the response.
+    # Other httpx network errors (ConnectError, TimeoutException, …) have
+    # no status — they failed before getting one.
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code
+    for cls, status in _EXC_TO_HTTP_STATUS:
+        if isinstance(exc, cls):
+            return status
+    return None
+
+
+def bucket_http_status(status: int) -> ErrorKind:
+    """Map an HTTP status code to the coarse ``ErrorKind`` allowlist.
+
+    Used when an emitter has a status code but no exception (e.g. a future
+    write tool that surfaces a 422 via return value rather than raise).
+    """
+    if status == 401:
+        return "auth"
+    if status == 403:
+        return "permission"
+    if status == 404:
+        return "not_found"
+    if status in (408, 504):
+        return "timeout"
+    if 400 <= status < 500:
+        return "validation"
+    if 500 <= status < 600:
+        return "upstream_5xx"
+    return "unknown"
+
+
+def bucket_exception(exc: BaseException, http_status: int | None = None) -> ErrorKind:
+    """Bucket an exception into the coarse ``ErrorKind`` allowlist.
+
+    ``http_status`` lets callers supersede the class-based mapping when they
+    have a more specific signal (e.g. an ``httpx.HTTPStatusError`` they
+    already inspected). When omitted, the function derives a status from
+    typed Opik/Comet/Ollie exceptions via ``derive_http_status``.
+
+    PRIVACY: never reads ``exc.args`` / ``str(exc)``. Class-only.
+    """
+    # 1) Permission BEFORE auth — OpikPermissionError extends OpikAuthError,
+    #    so a 403 must not be miscategorized as "auth" (which means 401).
+    if isinstance(exc, (OpikPermissionError, CometPermissionError)):
+        return "permission"
+    if isinstance(exc, (OpikAuthError, CometAuthError, OllieAuthError)):
+        return "auth"
+    if isinstance(exc, OpikNotFoundError):
+        return "not_found"
+    if isinstance(exc, (OpikValidationError, PydanticValidationError)):
+        return "validation"
+    if isinstance(exc, OpikServerError):
+        return "upstream_5xx"
+    if isinstance(exc, PodNotReadyError):
+        return "timeout"
+    # ``httpx.TimeoutException`` is the base for connect/read/write/pool
+    # timeouts. Keep it BEFORE the broader ``RequestError`` arm so a
+    # ``ReadTimeout`` lands in ``timeout``, not ``network``.
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(exc, httpx.HTTPStatusError):
+        return bucket_http_status(exc.response.status_code)
+    if isinstance(exc, httpx.RequestError):
+        return "network"
+    # MissingConfigError, OllieStreamError, OllieNotEnabledError, CometProtocolError
+    # don't map cleanly to the receiver's taxonomy — they're our own
+    # control-flow errors, not upstream failures. Caller-supplied status
+    # takes precedence when available.
+    if http_status is not None:
+        return bucket_http_status(http_status)
+    if isinstance(
+        exc, (OllieStreamError, OllieNotEnabledError, CometProtocolError, MissingConfigError)
+    ):
+        return "unknown"
+    return "unknown"

--- a/src/opik_mcp/analytics/wrappers.py
+++ b/src/opik_mcp/analytics/wrappers.py
@@ -14,90 +14,17 @@ from typing import Any, TypeVar
 from weakref import WeakSet
 
 import anyio
-import httpx
-from pydantic import ValidationError as PydanticValidationError
 
 from opik_mcp.analytics import (
     EVENT_SESSION_INITIALIZED,
     EVENT_TOOL_CALLED,
     get_analytics,
 )
-from opik_mcp.comet_client import (
-    CometAuthError,
-    CometPermissionError,
-    CometProtocolError,
-    OllieNotEnabledError,
-)
-from opik_mcp.config import MissingConfigError
-from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError
-from opik_mcp.opik_client import (
-    OpikAuthError,
-    OpikNotFoundError,
-    OpikPermissionError,
-    OpikServerError,
-    OpikValidationError,
-)
+from opik_mcp.analytics.errors import bucket_exception, derive_http_status
 
 logger = logging.getLogger("opik_mcp.analytics.wrappers")
 
 T = TypeVar("T")
-
-# Linear walk: first matching row wins, so list subclasses BEFORE their parents
-# (OpikPermissionError before OpikAuthError, CometPermissionError before
-# CometAuthError). The httpx network errors are listed *after* the typed-API
-# errors so an authenticated 401 isn't mis-bucketed as a network failure (an
-# OpikAuthError instance is itself not an httpx exception, but ordering keeps
-# the contract explicit if anyone later adds a hybrid type).
-#
-# PRIVACY: the *classifier* (``_classify`` below) keys off exception class
-# only — never ``exc.args`` / ``exc.message`` — so adding a row here is
-# privacy-neutral. This guarantee covers ONLY the ``error_kind`` field. The
-# exception messages themselves DO carry user data (entity ids, workspace
-# names, ~200 chars of response body via ``_error_detail``); they are safe
-# *because* nothing here serializes them. Anyone adding a future field like
-# ``error_detail`` MUST bucket / hash / drop the source string — never
-# ``str(exc)``.
-_ERROR_KIND_TABLE: tuple[tuple[type[BaseException], str], ...] = (
-    (MissingConfigError, "missing_config"),
-    # Comet — subclass first
-    (CometPermissionError, "comet_permission_denied"),
-    (CometAuthError, "comet_auth_failed"),
-    (OllieNotEnabledError, "ollie_not_enabled"),
-    (CometProtocolError, "comet_protocol_error"),
-    # Opik HTTP — split by status, subclass first
-    (OpikPermissionError, "opik_permission_denied"),
-    (OpikAuthError, "opik_auth_failed"),
-    (OpikNotFoundError, "opik_not_found"),
-    (OpikValidationError, "opik_validation_failed"),
-    (OpikServerError, "opik_http_5xx"),
-    # Ollie streaming
-    (PodNotReadyError, "pod_warmup_timeout"),
-    (OllieAuthError, "ollie_auth_failed"),
-    (OllieStreamError, "ollie_stream_error"),
-    # Pydantic validation from INSIDE the tool body — e.g.
-    # ``RunExperimentConfig.model_validate(experiment_config)`` in
-    # ``server.run_experiment`` or ``op.pydantic_model.model_validate(data)``
-    # in the write dispatcher. NOTE: FastMCP's ``Tool.run`` validates the
-    # tool's outer signature BEFORE calling our wrapped function and converts
-    # the resulting ``ValidationError`` into a ``ToolError``, so the very
-    # outermost arg-coercion failure never hits this branch. The bucket only
-    # fires when a tool itself calls ``model_validate`` on a sub-payload.
-    (PydanticValidationError, "tool_args_invalid"),
-    # Network — httpx.RequestError is the common base for ConnectError,
-    # TimeoutException (read/connect/write/pool), ReadError, etc. Catches the
-    # bulk of what used to land in "unknown" on flaky networks. HTTPStatusError
-    # is intentionally NOT here: when we use it, the typed Opik/Comet wrappers
-    # have already classified the status — a raw HTTPStatusError reaching this
-    # layer is a bug, not a network failure.
-    (httpx.RequestError, "network_error"),
-)
-
-
-def _classify(exc: BaseException) -> str:
-    for cls, kind in _ERROR_KIND_TABLE:
-        if isinstance(exc, cls):
-            return kind
-    return "unknown"
 
 
 # Indirection so tests can patch the singleton.
@@ -158,6 +85,8 @@ def instrument_tool(
             _maybe_emit_session_initialized(kwargs)
             t0 = time.monotonic()
             error_kind: str | None = None
+            exception_type: str | None = None
+            http_status: int | None = None
             result: T | None = None
             completed = False
             try:
@@ -165,12 +94,18 @@ def instrument_tool(
                 completed = True
                 return result
             except BaseException as exc:
+                # Stash class + status BEFORE re-raising so the finally
+                # block can emit them. We never read ``exc.args`` / ``str(exc)``
+                # — only the class and (for typed exceptions) the canonical
+                # HTTP status — keeping the privacy contract intact.
+                exception_type = type(exc).__name__
                 if isinstance(exc, anyio.get_cancelled_exc_class()):
                     # Host-initiated cancellation: surface as a distinct kind
                     # so dashboards can distinguish cancellations from errors.
                     error_kind = "cancelled"
                 elif isinstance(exc, Exception):
-                    error_kind = _classify(exc)
+                    error_kind = bucket_exception(exc)
+                    http_status = derive_http_status(exc)
                 raise
             finally:
                 props: dict[str, str] = {
@@ -180,6 +115,10 @@ def instrument_tool(
                 }
                 if error_kind:
                     props["error_kind"] = error_kind
+                if exception_type:
+                    props["exception_type"] = exception_type
+                if http_status is not None:
+                    props["http_status"] = str(http_status)
                 if props_fn is not None and completed:
                     try:
                         props.update(props_fn(result, kwargs))

--- a/src/opik_mcp/ask_ollie.py
+++ b/src/opik_mcp/ask_ollie.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from opik_mcp import audit
 from opik_mcp.analytics import EVENT_ASK_OLLIE_COMPLETED, bucket_count
+from opik_mcp.analytics.errors import bucket_exception
 from opik_mcp.comet_client import CometClient, PodDiscovery
 from opik_mcp.config import Settings, get_settings, require_ollie_config
 from opik_mcp.elicitation import confirm_with_user
@@ -206,6 +207,12 @@ async def run_ask_ollie(
     errored = False
     saw_message_end = False
     cancelled = False
+    # Initialize the error-emit locals so the finally clause can reference
+    # them on the happy path without UnboundLocalError. The except arm
+    # below assigns real values when ``errored`` flips to True.
+    error_kind: str = "unknown"
+    error_exception_type: str = ""
+    error_upstream_code: Any = None
 
     try:
         settings = settings or get_settings()
@@ -578,7 +585,13 @@ async def run_ask_ollie(
                                 if isinstance(raw_message, str) and raw_message
                                 else "Unknown pod error"
                             )
-                            raise OllieStreamError(message)
+                            # ``code`` is an optional structured field on the SSE
+                            # error frame. Captured here (str only, length-capped
+                            # at the bucketing layer) so analytics can group
+                            # upstream failures without leaking the message.
+                            raw_code = payload.get("code")
+                            upstream_code = raw_code if isinstance(raw_code, str) else None
+                            raise OllieStreamError(message, upstream_code=upstream_code)
 
                         elif evt == "message_end":
                             saw_message_end = True
@@ -657,32 +670,44 @@ async def run_ask_ollie(
             cancelled = True
         else:
             errored = True
+            # Stash class + bucketed kind here so the finally block can
+            # emit them without needing to read sys.exc_info(). Privacy:
+            # class-name and class-keyed bucket only — exc.args is never
+            # read at any emit site.
+            error_exception_type = type(exc).__name__
+            error_kind = bucket_exception(exc) if isinstance(exc, Exception) else "unknown"
+            error_upstream_code = getattr(exc, "upstream_code", None)
         raise
     finally:
         ttfe_ms: int = int((first_event_at - t0) * 1000) if first_event_at is not None else -1
+        props: dict[str, str] = {
+            "success": "false" if errored else "true",
+            "total_duration_ms": str(int((time.monotonic() - t0) * 1000)),
+            "pod_warmup_ms": str(pod_warmup_ms),
+            "time_to_first_event_ms": str(ttfe_ms),
+            "event_count": str(events_seen),
+            "had_continuation": str(thread_id is not None).lower(),
+            "had_page_context": str(page_context is not None).lower(),
+            "had_project_name": str(project_name is not None).lower(),
+            "attach_resources_count": bucket_count(len(attach_resources or [])),
+            "completion_state": _completion_state(
+                saw_message_end=saw_message_end,
+                cancelled=cancelled,
+                errored=errored,
+            ),
+            "auto_approvals_count": str(len(auto_approval_details)),
+            "auto_approval_tools": ",".join(sorted({t for t, _ in auto_approval_details if t})),
+        }
+        if errored:
+            props["error_kind"] = error_kind
+            props["exception_type"] = error_exception_type
+            if isinstance(error_upstream_code, str) and error_upstream_code:
+                # Length-cap as a defense against a misbehaving pod that
+                # stamps a long string into ``code``. 64 chars is enough
+                # for every legitimate code we ship while staying well
+                # under any plausible PII leak.
+                props["upstream_error_code"] = error_upstream_code[:64]
         try:
-            _analytics().track_event(
-                EVENT_ASK_OLLIE_COMPLETED,
-                {
-                    "success": "false" if errored else "true",
-                    "total_duration_ms": str(int((time.monotonic() - t0) * 1000)),
-                    "pod_warmup_ms": str(pod_warmup_ms),
-                    "time_to_first_event_ms": str(ttfe_ms),
-                    "event_count": str(events_seen),
-                    "had_continuation": str(thread_id is not None).lower(),
-                    "had_page_context": str(page_context is not None).lower(),
-                    "had_project_name": str(project_name is not None).lower(),
-                    "attach_resources_count": bucket_count(len(attach_resources or [])),
-                    "completion_state": _completion_state(
-                        saw_message_end=saw_message_end,
-                        cancelled=cancelled,
-                        errored=errored,
-                    ),
-                    "auto_approvals_count": str(len(auto_approval_details)),
-                    "auto_approval_tools": ",".join(
-                        sorted({t for t, _ in auto_approval_details if t})
-                    ),
-                },
-            )
+            _analytics().track_event(EVENT_ASK_OLLIE_COMPLETED, props)
         except Exception:
             logger.debug("ask_ollie_completed emit failed", exc_info=True)

--- a/src/opik_mcp/ask_ollie.py
+++ b/src/opik_mcp/ask_ollie.py
@@ -212,7 +212,7 @@ async def run_ask_ollie(
     # below assigns real values when ``errored`` flips to True.
     error_kind: str = "unknown"
     error_exception_type: str = ""
-    error_upstream_code: Any = None
+    error_upstream_code: str | None = None
 
     try:
         settings = settings or get_settings()
@@ -676,7 +676,12 @@ async def run_ask_ollie(
             # read at any emit site.
             error_exception_type = type(exc).__name__
             error_kind = bucket_exception(exc) if isinstance(exc, Exception) else "unknown"
-            error_upstream_code = getattr(exc, "upstream_code", None)
+            # ``getattr`` returns ``Any`` — narrow to ``str`` here so the
+            # finally block doesn't need to re-check the type and so a future
+            # refactor that accidentally stores a non-string would be caught
+            # by mypy on this assignment.
+            upstream_code = getattr(exc, "upstream_code", None)
+            error_upstream_code = upstream_code if isinstance(upstream_code, str) else None
         raise
     finally:
         ttfe_ms: int = int((first_event_at - t0) * 1000) if first_event_at is not None else -1
@@ -701,7 +706,7 @@ async def run_ask_ollie(
         if errored:
             props["error_kind"] = error_kind
             props["exception_type"] = error_exception_type
-            if isinstance(error_upstream_code, str) and error_upstream_code:
+            if error_upstream_code:
                 # Length-cap as a defense against a misbehaving pod that
                 # stamps a long string into ``code``. 64 chars is enough
                 # for every legitimate code we ship while staying well

--- a/src/opik_mcp/ollie_client.py
+++ b/src/opik_mcp/ollie_client.py
@@ -17,7 +17,19 @@ class OllieAuthError(RuntimeError):
 
 
 class OllieStreamError(RuntimeError):
-    """The Ollie pod emitted an `error` SSE event."""
+    """The Ollie pod emitted an `error` SSE event.
+
+    ``upstream_code`` carries the optional structured ``code`` from the SSE
+    error frame (e.g. ``"rate_limited"``, ``"model_unavailable"``) so
+    analytics can group failures without sniffing the human-readable
+    message. ``None`` when the frame omitted it or when the error was
+    raised from an internal control-flow path (confirm-POST failure, etc.)
+    rather than a server-side error frame.
+    """
+
+    def __init__(self, message: str, *, upstream_code: str | None = None) -> None:
+        super().__init__(message)
+        self.upstream_code = upstream_code
 
 
 @dataclass

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -1,0 +1,224 @@
+"""Unit tests for :mod:`opik_mcp.analytics.errors`.
+
+The wrapper-level integration tests in ``test_analytics_wrappers.py`` exercise
+the same mapping through the decorator surface; this module pins the helper
+contract directly so a regression in ``bucket_exception`` / ``bucket_http_status``
+/ ``derive_http_status`` fails close to the root cause.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
+
+from opik_mcp.analytics.errors import (
+    bucket_exception,
+    bucket_http_status,
+    derive_http_status,
+)
+from opik_mcp.comet_client import (
+    CometAuthError,
+    CometPermissionError,
+    CometProtocolError,
+    OllieNotEnabledError,
+)
+from opik_mcp.config import MissingConfigError
+from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError
+from opik_mcp.opik_client import (
+    OpikAuthError,
+    OpikNotFoundError,
+    OpikPermissionError,
+    OpikServerError,
+    OpikValidationError,
+)
+
+
+def _pydantic_error() -> PydanticValidationError:
+    """Real ``pydantic.ValidationError`` — the class can't be instantiated directly."""
+
+    class _M(BaseModel):
+        x: int
+
+    try:
+        _M.model_validate({"x": "not-an-int"})
+    except PydanticValidationError as e:
+        return e
+    raise AssertionError("model_validate did not raise — pydantic upgraded?")
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://example.invalid/")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("synthetic", request=request, response=response)
+
+
+# --- bucket_http_status -------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        (401, "auth"),
+        (403, "permission"),
+        (404, "not_found"),
+        (408, "timeout"),
+        (504, "timeout"),
+        # 4xx that is not auth/permission/not-found/timeout → validation.
+        (400, "validation"),
+        (409, "validation"),
+        (422, "validation"),
+        (429, "validation"),
+        # 5xx → upstream_5xx (excluding 504 above, which is a timeout).
+        (500, "upstream_5xx"),
+        (502, "upstream_5xx"),
+        (503, "upstream_5xx"),
+        (599, "upstream_5xx"),
+        # 1xx/2xx/3xx and weird codes → unknown.
+        (100, "unknown"),
+        (200, "unknown"),
+        (302, "unknown"),
+        (399, "unknown"),
+        (600, "unknown"),
+        (0, "unknown"),
+        (-1, "unknown"),
+    ],
+)
+def test_bucket_http_status_boundaries(status: int, expected: str) -> None:
+    assert bucket_http_status(status) == expected
+
+
+# --- derive_http_status -------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        # Subclass MUST resolve to its own status, not the parent's.
+        # ``OpikPermissionError`` extends ``OpikAuthError`` — a regression
+        # that flipped the table order would mask every 403 as a 401.
+        (OpikPermissionError("x"), 403),
+        (OpikAuthError("x"), 401),
+        (OpikNotFoundError("x"), 404),
+        (OpikValidationError("x"), 400),
+        (OpikServerError("x"), 500),
+        (CometPermissionError("x"), 403),
+        (CometAuthError("x"), 401),
+        # Exceptions without a canonical status return None — the BI receiver
+        # is expected to treat the absent property as "no status known".
+        (OllieAuthError("x"), None),
+        (OllieStreamError("x"), None),
+        (OllieNotEnabledError("x"), None),
+        (CometProtocolError("x"), None),
+        (PodNotReadyError("x"), None),
+        (MissingConfigError("x"), None),
+        (httpx.ConnectError("refused"), None),
+        (httpx.ReadTimeout("slow"), None),
+        (ValueError("x"), None),
+    ],
+)
+def test_derive_http_status_class_lookup(exc: BaseException, expected: int | None) -> None:
+    assert derive_http_status(exc) == expected
+
+
+def test_derive_http_status_reads_httpx_response() -> None:
+    """``HTTPStatusError`` carries the wire status on its response."""
+    assert derive_http_status(_http_status_error(429)) == 429
+    assert derive_http_status(_http_status_error(503)) == 503
+
+
+# --- bucket_exception ---------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        # Permission BEFORE auth — load-bearing subclass ordering.
+        (OpikPermissionError("x"), "permission"),
+        (OpikAuthError("x"), "auth"),
+        (CometPermissionError("x"), "permission"),
+        (CometAuthError("x"), "auth"),
+        (OllieAuthError("x"), "auth"),
+        # 404 / 400 / 500.
+        (OpikNotFoundError("x"), "not_found"),
+        (OpikValidationError("x"), "validation"),
+        (OpikServerError("x"), "upstream_5xx"),
+        # Pydantic argument validation lands in the same bucket as Opik's
+        # typed validation error — analytics keeps them apart via
+        # ``exception_type``.
+        (_pydantic_error(), "validation"),
+        # Pod warmup timeout — distinct class, same bucket as httpx timeouts.
+        (PodNotReadyError("x"), "timeout"),
+        # httpx hierarchy — ``TimeoutException`` is the family base; its
+        # subclasses (ReadTimeout, ConnectTimeout, etc.) must all land in
+        # "timeout", NOT in the broader "network" bucket.
+        (httpx.TimeoutException("x"), "timeout"),
+        (httpx.ReadTimeout("x"), "timeout"),
+        (httpx.ConnectTimeout("x"), "timeout"),
+        (httpx.WriteTimeout("x"), "timeout"),
+        (httpx.PoolTimeout("x"), "timeout"),
+        # Non-timeout RequestErrors → "network".
+        (httpx.ConnectError("x"), "network"),
+        (httpx.ReadError("x"), "network"),
+        (httpx.WriteError("x"), "network"),
+        # Our own control-flow errors that don't map cleanly to an upstream
+        # taxonomy bucket → "unknown".
+        (OllieStreamError("x"), "unknown"),
+        (OllieNotEnabledError("x"), "unknown"),
+        (CometProtocolError("x"), "unknown"),
+        (MissingConfigError("x"), "unknown"),
+        # Catch-all.
+        (ValueError("x"), "unknown"),
+        (RuntimeError("x"), "unknown"),
+    ],
+)
+def test_bucket_exception_class_only(exc: Exception, expected: str) -> None:
+    assert bucket_exception(exc) == expected
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        (401, "auth"),
+        (403, "permission"),
+        (404, "not_found"),
+        (422, "validation"),
+        (500, "upstream_5xx"),
+        (504, "timeout"),
+    ],
+)
+def test_bucket_exception_routes_http_status_errors(status: int, expected: str) -> None:
+    """``HTTPStatusError`` is bucketed by its wire status, not by class alone."""
+    assert bucket_exception(_http_status_error(status)) == expected
+
+
+def test_bucket_exception_caller_supplied_status_wins_for_neutral_class() -> None:
+    """When the exception class isn't in the typed taxonomy, the caller-supplied
+    status takes precedence over the catch-all ``unknown`` bucket. Lets a
+    future write tool surface 422-style validation errors via return value."""
+    assert bucket_exception(RuntimeError("x"), http_status=422) == "validation"
+    assert bucket_exception(RuntimeError("x"), http_status=503) == "upstream_5xx"
+
+
+def test_bucket_exception_never_reads_args_or_str() -> None:
+    """The PRIVACY contract: ``bucket_exception`` must be class-only — the
+    coarse bucket cannot depend on free-form message text. Smuggle a payload
+    into ``args`` that would change the answer if anyone ever inspected it,
+    then assert the answer is still derived from the class."""
+
+    class _Sneaky(ValueError):
+        pass
+
+    sneaky = _Sneaky("status_code=403 forbidden permission denied auth failed")
+    # If anyone string-matched on the message we'd see "permission" or "auth";
+    # class-only must yield "unknown".
+    assert bucket_exception(sneaky) == "unknown"
+
+
+def test_bucket_exception_subclass_resolves_before_parent() -> None:
+    """``OpikPermissionError`` extends ``OpikAuthError``. The bucketing layer
+    must isinstance-check the specific class first so a 403 doesn't get
+    mislabeled as 401 (and the dashboards lose the distinction)."""
+    assert bucket_exception(OpikPermissionError("x")) == "permission"
+    assert bucket_exception(CometPermissionError("x")) == "permission"

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -183,9 +183,13 @@ def test_bucket_exception_class_only(exc: Exception, expected: str) -> None:
         (401, "auth"),
         (403, "permission"),
         (404, "not_found"),
+        # 408 + 504 both bypass the broad 4xx/5xx arms and land in "timeout";
+        # both branches need integration coverage so a regression that drops
+        # the explicit ``status in (408, 504)`` check fails loudly here.
+        (408, "timeout"),
+        (504, "timeout"),
         (422, "validation"),
         (500, "upstream_5xx"),
-        (504, "timeout"),
     ],
 )
 def test_bucket_exception_routes_http_status_errors(status: int, expected: str) -> None:

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -335,6 +335,205 @@ async def test_list_props_emits_had_name_filter_false_when_absent(
     assert props["had_name_filter"] == "false"
 
 
+# --- failure paths: error_kind / exception_type / http_status MUST be bucketed -- #
+#
+# When a tool raises, the wrapper emits ``error_kind`` + ``exception_type`` (+
+# optional ``http_status``). The privacy contract says NONE of those props may
+# embed the exception message — only the class-keyed bucket, the class name
+# itself, and a numeric status. These tests stuff canary substrings into the
+# exception message and assert they never surface in the analytics payload.
+
+
+class _CanaryAuthError(Exception):
+    """Stand-in for an Opik 401 carrying a PII-shaped message body."""
+
+
+@pytest.mark.anyio
+async def test_tool_called_failure_strips_exception_message(
+    recorder: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tool that raises with a PII-shaped message MUST NOT surface that
+    text in the analytics event — only the class-keyed bucket and class name.
+    Drives ``server.read`` so ``_read_props`` + the wrapper's error-emit arm
+    both execute on the real tool surface."""
+    from opik_mcp import server
+    from opik_mcp.opik_client import OpikAuthError
+
+    canary = "raw-error-message-UNIQUE-CANARY-7e1f2a3b"
+
+    async def _raise(**_kw: Any) -> str:
+        raise OpikAuthError(canary)
+
+    monkeypatch.setattr("opik_mcp.server.run_read", _raise)
+
+    with pytest.raises(OpikAuthError):
+        await server.read(entity_type="project", id="00000000-0000-0000-0000-000000000001")
+
+    # Canary must not appear anywhere in the recorded payload.
+    payload = json.dumps(recorder.events)
+    assert canary not in payload, (
+        f"PRIVACY BREACH: raw exception message {canary!r} leaked into analytics"
+    )
+    props = _tool_called(recorder.events)
+    assert props["success"] == "false"
+    assert props["error_kind"] == "auth"
+    assert props["exception_type"] == "OpikAuthError"
+    assert props["http_status"] == "401"
+    # Defense in depth: even an http_status of "401" must not be confused
+    # with a PII substring leak — the props_fn must not have populated
+    # anything that contains "raw-error-message".
+    for v in props.values():
+        assert "UNIQUE-CANARY" not in v
+
+
+@pytest.mark.anyio
+async def test_tool_called_failure_unknown_class_uses_class_name_only(
+    recorder: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A custom Exception class falls through to ``error_kind=unknown``. The
+    only granular signal is ``exception_type`` (the class name), which is
+    fixed by the class declaration — never an attacker-controlled string."""
+    from opik_mcp import server
+
+    canary = "unknown-class-message-UNIQUE-CANARY-c4d5e6f7"
+
+    async def _raise(**_kw: Any) -> str:
+        raise _CanaryAuthError(canary)
+
+    monkeypatch.setattr("opik_mcp.server.run_read", _raise)
+
+    with pytest.raises(_CanaryAuthError):
+        await server.read(entity_type="project", id="00000000-0000-0000-0000-000000000001")
+
+    payload = json.dumps(recorder.events)
+    assert canary not in payload
+    props = _tool_called(recorder.events)
+    assert props["error_kind"] == "unknown"
+    assert props["exception_type"] == "_CanaryAuthError"
+    assert "http_status" not in props
+
+
+class _CanaryOllieClient:
+    """``_OllieClientProto`` fake that fires an SSE ``error`` frame whose
+    ``message`` field is a unique canary. Used to verify the pod's error
+    message never reaches the ``ask_ollie_completed`` analytics event."""
+
+    canary_message: str = "ollie-stream-error-UNIQUE-CANARY-9a8b7c6d"
+    canary_code: str = "rate_limited_canary_UNIQUE-2f3e4d5c"
+
+    async def wait_ready(
+        self, compute_url: str, ppauth: str, *, on_tick: OnTick | None = None
+    ) -> None:
+        pass
+
+    async def create_session(
+        self, compute_url: str, ppauth: str, workspace: str, body: dict[str, Any]
+    ) -> str:
+        return "sess-canary"
+
+    def stream_events(
+        self,
+        compute_url: str,
+        ppauth: str,
+        workspace: str,
+        session_id: str,
+        *,
+        last_event_id: int | None = None,
+    ) -> AsyncIterator[SSEEvent]:
+        return self._error_iter()
+
+    async def _error_iter(self) -> AsyncIterator[SSEEvent]:
+        yield SSEEvent(
+            event="error",
+            data={"payload": {"message": self.canary_message, "code": self.canary_code}},
+        )
+
+    async def confirm_session(
+        self,
+        compute_url: str,
+        ppauth: str,
+        workspace: str,
+        session_id: str,
+        *,
+        tool_use_id: str,
+        decision: str,
+    ) -> None:
+        pass
+
+
+@pytest.mark.anyio
+async def test_ask_ollie_failure_strips_stream_error_message(recorder: _Recorder) -> None:
+    """A pod-side SSE ``error`` frame carries a free-text ``message`` plus
+    an optional structured ``code``. The completed event MUST surface only
+    the coarse bucket + class name + (length-capped) code — never the
+    message body."""
+    from opik_mcp.ask_ollie import run_ask_ollie
+    from opik_mcp.config import Settings
+    from opik_mcp.ollie_client import OllieStreamError
+
+    fake = _CanaryOllieClient()
+    with pytest.raises(OllieStreamError):
+        await run_ask_ollie(
+            query="placeholder-query",
+            settings=Settings(opik_api_key="k", comet_workspace="ws-1"),
+            comet_client=_FakeComet(),
+            ollie_client=fake,
+        )
+
+    payload = json.dumps(recorder.events)
+    assert fake.canary_message not in payload, (
+        f"PRIVACY BREACH: pod error message {fake.canary_message!r} leaked into analytics"
+    )
+
+    completed = [props for et, props in recorder.events if et == "opik_mcp_ask_ollie_completed"]
+    assert completed, "ask_ollie must emit a completed event on the error path"
+    props = completed[0]
+    assert props["completion_state"] == "error"
+    assert props["error_kind"] == "unknown"
+    assert props["exception_type"] == "OllieStreamError"
+    # ``code`` IS allowlisted into analytics (length-capped) — it's the one
+    # field pod authors are expected to keep enum-shaped. The test passes
+    # an obviously-not-PII canary to confirm the wire-up; downstream BI is
+    # the place to enforce the actual enum.
+    assert props["upstream_error_code"] == fake.canary_code[:64]
+
+
+@pytest.mark.anyio
+async def test_ask_ollie_failure_typed_exception_bucketed_correctly(
+    recorder: _Recorder,
+) -> None:
+    """A typed pod-discovery failure (``CometPermissionError``) must surface
+    as ``error_kind=permission`` even when the exception message is PII."""
+    from opik_mcp.ask_ollie import run_ask_ollie
+    from opik_mcp.comet_client import CometPermissionError
+    from opik_mcp.config import Settings
+
+    canary = "comet-permission-message-UNIQUE-CANARY-5e6f7a8b"
+
+    class _PermissionComet:
+        async def discover_pod(self, workspace: str) -> PodDiscovery:
+            raise CometPermissionError(canary)
+
+    with pytest.raises(CometPermissionError):
+        await run_ask_ollie(
+            query="placeholder-query",
+            settings=Settings(opik_api_key="k", comet_workspace="ws-1"),
+            comet_client=_PermissionComet(),
+            ollie_client=_FakeOllie(),
+        )
+
+    payload = json.dumps(recorder.events)
+    assert canary not in payload
+    completed = [props for et, props in recorder.events if et == "opik_mcp_ask_ollie_completed"]
+    assert completed
+    props = completed[0]
+    assert props["completion_state"] == "error"
+    assert props["error_kind"] == "permission"
+    assert props["exception_type"] == "CometPermissionError"
+    # No SSE error frame on this path → no upstream_error_code.
+    assert "upstream_error_code" not in props
+
+
 # --- helpers -------------------------------------------------------------- #
 
 

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -498,6 +498,53 @@ async def test_ask_ollie_failure_strips_stream_error_message(recorder: _Recorder
     assert props["upstream_error_code"] == fake.canary_code[:64]
 
 
+class _LongCodeOllieClient(_CanaryOllieClient):
+    """Same canary stream as ``_CanaryOllieClient`` but with a code field
+    longer than the 64-char cap. Used to verify the length-cap actually
+    fires (the base class's canary is only 36 chars long, which would
+    pass the assertion even if the slicing were removed)."""
+
+    # 100 chars — comfortably over the 64-char cap. The trailing canary
+    # tail (positions 64..) must be sliced off; if it appears in props,
+    # the cap regressed.
+    canary_code: str = "x" * 64 + "TAIL-MUST-BE-CHOPPED-UNIQUE-CANARY-d4e5f6a7"
+
+
+@pytest.mark.anyio
+async def test_ask_ollie_failure_caps_upstream_error_code_at_64_chars(
+    recorder: _Recorder,
+) -> None:
+    """Production cap at ``ask_ollie.py``: ``upstream_error_code`` MUST be
+    truncated to 64 chars before emit. Pod-controlled field — without the
+    cap, a misbehaving pod could stamp arbitrary text into ``code`` and
+    smuggle it past the message-stripping privacy contract."""
+    from opik_mcp.ask_ollie import run_ask_ollie
+    from opik_mcp.config import Settings
+    from opik_mcp.ollie_client import OllieStreamError
+
+    fake = _LongCodeOllieClient()
+    assert len(fake.canary_code) > 64  # guard the test itself
+
+    with pytest.raises(OllieStreamError):
+        await run_ask_ollie(
+            query="placeholder-query",
+            settings=Settings(opik_api_key="k", comet_workspace="ws-1"),
+            comet_client=_FakeComet(),
+            ollie_client=fake,
+        )
+
+    completed = [props for et, props in recorder.events if et == "opik_mcp_ask_ollie_completed"]
+    assert completed
+    code = completed[0]["upstream_error_code"]
+    assert len(code) == 64, f"expected 64-char cap, got len={len(code)}: {code!r}"
+    assert code == fake.canary_code[:64]
+    # The truncated tail must not appear anywhere in the recorded payload —
+    # if it does, the cap fired but something else (a duplicate field,
+    # a log line, etc.) is still leaking the raw value.
+    payload = json.dumps(recorder.events)
+    assert "TAIL-MUST-BE-CHOPPED" not in payload
+
+
 @pytest.mark.anyio
 async def test_ask_ollie_failure_typed_exception_bucketed_correctly(
     recorder: _Recorder,

--- a/tests/test_analytics_wrappers.py
+++ b/tests/test_analytics_wrappers.py
@@ -74,39 +74,48 @@ async def test_success_emits_tool_called(recorder: _Recorder) -> None:
 
 
 @pytest.mark.parametrize(
-    "exc, expected_kind",
+    "exc, expected_kind, expected_status",
     [
-        # Auth/permission — subclass must match its specific bucket, NOT parent.
-        # OpikPermissionError extends OpikAuthError but must surface as
-        # "opik_permission_denied" so 403 vs 401 stay distinguishable in BI.
-        (OpikAuthError("x"), "opik_auth_failed"),
-        (OpikPermissionError("x"), "opik_permission_denied"),
-        (OpikNotFoundError("x"), "opik_not_found"),
-        (OpikValidationError("x"), "opik_validation_failed"),
-        (OpikServerError("x"), "opik_http_5xx"),
-        # Comet — same subclass-first contract as Opik.
-        (CometAuthError("x"), "comet_auth_failed"),
-        (CometPermissionError("x"), "comet_permission_denied"),
-        (CometProtocolError("x"), "comet_protocol_error"),
-        # Ollie streaming.
-        (OllieNotEnabledError("x"), "ollie_not_enabled"),
-        (PodNotReadyError("x"), "pod_warmup_timeout"),
-        (OllieAuthError("x"), "ollie_auth_failed"),
-        (OllieStreamError("x"), "ollie_stream_error"),
-        # Config / network / tool-args.
-        (MissingConfigError("x"), "missing_config"),
-        # httpx network errors — common base RequestError covers the family.
-        (httpx.ConnectError("connect refused"), "network_error"),
-        (httpx.ReadTimeout("read timed out"), "network_error"),
-        (httpx.ReadError("read error"), "network_error"),
-        # pydantic validation on tool args.
-        (_build_pydantic_error(), "tool_args_invalid"),
+        # Permission vs. auth: ``OpikPermissionError`` extends ``OpikAuthError``,
+        # so the more-specific class MUST resolve first. A regression that flips
+        # this order would mask every 403 as a 401 in BI.
+        (OpikAuthError("x"), "auth", 401),
+        (OpikPermissionError("x"), "permission", 403),
+        (OpikNotFoundError("x"), "not_found", 404),
+        (OpikValidationError("x"), "validation", 400),
+        (OpikServerError("x"), "upstream_5xx", 500),
+        # Comet hierarchy mirrors Opik's: permission before auth, both class-keyed.
+        (CometAuthError("x"), "auth", 401),
+        (CometPermissionError("x"), "permission", 403),
+        # Control-flow errors that don't map to an upstream status — these
+        # signal "our client gave up before we got a real HTTP response".
+        (CometProtocolError("x"), "unknown", None),
+        (OllieNotEnabledError("x"), "unknown", None),
+        (OllieStreamError("x"), "unknown", None),
+        (MissingConfigError("x"), "unknown", None),
+        # Timeouts: pod warmup timeout and httpx network timeouts both fall in
+        # the "timeout" bucket; httpx.TimeoutException is the family base.
+        (PodNotReadyError("x"), "timeout", None),
+        (httpx.ReadTimeout("read timed out"), "timeout", None),
+        # Network-level failures (no HTTP response received).
+        (OllieAuthError("x"), "auth", None),
+        (httpx.ConnectError("connect refused"), "network", None),
+        (httpx.ReadError("read error"), "network", None),
+        # Validation: typed Opik validation + pydantic argument validation
+        # both land in the same coarse bucket — exception_type lets analytics
+        # distinguish them downstream.
+        (_build_pydantic_error(), "validation", None),
         # Genuine catch-all.
-        (ValueError("x"), "unknown"),
+        (ValueError("x"), "unknown", None),
     ],
 )
 @pytest.mark.anyio
-async def test_error_kind_mapping(recorder: _Recorder, exc: Exception, expected_kind: str) -> None:
+async def test_error_kind_mapping(
+    recorder: _Recorder,
+    exc: Exception,
+    expected_kind: str,
+    expected_status: int | None,
+) -> None:
     @instrument_tool("read")
     async def fn() -> str:
         raise exc
@@ -116,10 +125,41 @@ async def test_error_kind_mapping(recorder: _Recorder, exc: Exception, expected_
     _et, props = recorder.events[0]
     assert props["success"] == "false"
     assert props["error_kind"] == expected_kind
+    # ``exception_type`` carries the granular class name alongside the coarse
+    # bucket so dashboards can drill in without re-introducing per-class kinds.
+    assert props["exception_type"] == type(exc).__name__
+    if expected_status is None:
+        assert "http_status" not in props
+    else:
+        assert props["http_status"] == str(expected_status)
+
+
+@pytest.mark.anyio
+async def test_http_status_error_uses_response_status(recorder: _Recorder) -> None:
+    """``httpx.HTTPStatusError`` carries its status on the response object."""
+    request = httpx.Request("GET", "https://example.invalid/")
+    response = httpx.Response(422, request=request)
+    exc = httpx.HTTPStatusError("unprocessable", request=request, response=response)
+
+    @instrument_tool("read")
+    async def fn() -> str:
+        raise exc
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await fn()
+    _et, props = recorder.events[0]
+    # 422 → 4xx that isn't auth/permission/not-found/timeout → "validation".
+    assert props["error_kind"] == "validation"
+    assert props["http_status"] == "422"
+    assert props["exception_type"] == "HTTPStatusError"
 
 
 @pytest.mark.anyio
 async def test_baseexception_marks_failure_without_error_kind(recorder: _Recorder) -> None:
+    """Non-``Exception`` ``BaseException`` (KeyboardInterrupt, SystemExit) is
+    bucketing-exempt: only the class name surfaces on ``exception_type`` so the
+    cancellation/error_kind contract isn't muddied by VM-level interrupts."""
+
     @instrument_tool("hello")
     async def fn() -> str:
         raise KeyboardInterrupt
@@ -129,6 +169,8 @@ async def test_baseexception_marks_failure_without_error_kind(recorder: _Recorde
     _, props = recorder.events[0]
     assert props["success"] == "false"
     assert "error_kind" not in props
+    assert props["exception_type"] == "KeyboardInterrupt"
+    assert "http_status" not in props
 
 
 @pytest.mark.anyio
@@ -145,6 +187,8 @@ async def test_cancelled_error_sets_error_kind_cancelled(recorder: _Recorder) ->
     _, props = recorder.events[0]
     assert props["success"] == "false"
     assert props["error_kind"] == "cancelled"
+    assert props["exception_type"] == "CancelledError"
+    assert "http_status" not in props
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Replaces the per-class fine-grained `error_kind` values on `opik_mcp_tool_called` and `opik_mcp_ask_ollie_completed` with a coarse 9-bucket taxonomy (`auth`, `validation`, `not_found`, `permission`, `timeout`, `network`, `upstream_5xx`, `cancelled`, `unknown`) that dashboards can group on without per-class enumeration.
- Adds `exception_type` (class name) on both events so the granular signal is still available for drill-downs, plus `http_status` for typed Opik/Comet errors and `httpx.HTTPStatusError`. `ask_ollie_completed` also gets `upstream_error_code` (length-capped at 64 chars) sourced from the SSE `error` frame's optional `code` field.
- All bucketing lives in a new `opik_mcp/analytics/errors` module that is class-only (never reads `exc.args` / `str(exc)` / response body) so the privacy contract is preserved end-to-end.

## Why

Today `tool_called.error_kind` and `ask_ollie_completed.error_kind` each define their own per-class enum (16+ values combined). Dashboards have to maintain a hand-rolled allowlist per event and any new typed exception breaks the chart silently. The coarse taxonomy folds the noise into 9 fixed buckets while `exception_type` keeps the granular signal as a free-text class name — net more information than before, no harder-to-evolve enum on the BI side.

## Test plan

- [x] `uv run pytest tests/test_analytics_*.py -q` — green (107 tests)
- [x] `uv run pytest tests/ -q` — green (584 passed, 2 skipped)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [x] Privacy canary tests cover the failure paths on both `tool_called` (via `server.read` + `OpikAuthError` with a PII message) and `ask_ollie_completed` (via a fake pod streaming an SSE `error` frame with a PII message + structured `code`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)