### PR TITLE
fix(analytics): unwrap wrappers so tool_called/ask_ollie bucket the real cause

### DIFF
--- a/src/opik_mcp/analytics/errors.py
+++ b/src/opik_mcp/analytics/errors.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Literal
 
 import httpx
+from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import ValidationError as PydanticValidationError
 
 from opik_mcp.comet_client import (
@@ -50,6 +51,71 @@ ErrorKind = Literal[
 ]
 
 
+# Pure-envelope exception classes — these wrap a real upstream cause via
+# ``raise X from e`` (or implicit ``__context__``) and never carry their own
+# bucketing signal. ``bucket_exception`` walks past them to find the real
+# culprit; emit sites preserve the wrapper class name in ``exception_type``
+# and the unwrapped class in ``cause_type``.
+#
+# Why ``ToolError``: FastMCP's contract is that tool handlers surface failures
+# to the host via ``ToolError`` (see ``read_list/``, ``writes/``). Without the
+# unwrap, every read/list/write failure showed up as ``unknown / ToolError``
+# in BI, masking auth/not_found/upstream_5xx patterns.
+#
+# Why ``OllieStreamError``: a ``RuntimeError`` subclass we raise both as a
+# leaf (e.g. protocol-drift "no session_id") AND as a wrapper around upstream
+# HTTP failures (``ollie_client.py:161`` raises it from a 404; ``ask_ollie.py``
+# raises it from pod ``error`` SSE frames carrying ``upstream_code``). The
+# leaf case still falls through to ``"unknown"`` below; the wrapper case now
+# routes by its real cause.
+_WRAPPER_CLASSES: tuple[type[BaseException], ...] = (
+    ToolError,
+    OllieStreamError,
+)
+
+
+# Cap on chain depth to keep cycles / deeply-nested wrappers from turning the
+# classifier into a runtime hazard. 4 hops is well past anything our codebase
+# produces (the deepest natural chain is ToolError ← OllieStreamError ← real,
+# 3 hops) and any longer chain almost certainly indicates a protocol bug
+# rather than a meaningful bucket-by-leaf signal.
+_UNWRAP_MAX_DEPTH = 4
+
+
+def unwrap_to_real_cause(
+    exc: BaseException, *, max_depth: int = _UNWRAP_MAX_DEPTH
+) -> BaseException:
+    """Walk ``__cause__`` / ``__context__`` through pure-envelope wrapper
+    exceptions and return the innermost non-wrapper, or ``exc`` if no unwrap
+    applies.
+
+    Preference order (matches Python's traceback display):
+    1. ``__cause__`` if set — the explicit ``raise X from e`` chain.
+    2. ``__context__`` if ``__suppress_context__`` is False — the implicit
+       chain Python sets when raising inside an ``except`` block.
+    3. Stop — the wrapper has no recoverable cause; treat it as the leaf.
+
+    The walk also stops at the first non-wrapper exception (a meaningful leaf)
+    and at chain cycles (defensive — ``__cause__`` can be set to anything).
+
+    PRIVACY: inspects ``type(...)``, ``__cause__``, ``__context__``,
+    ``__suppress_context__`` only — never reads ``args`` / ``str(exc)``.
+    """
+    seen: set[int] = {id(exc)}
+    current: BaseException = exc
+    for _ in range(max_depth):
+        if not isinstance(current, _WRAPPER_CLASSES):
+            return current
+        nxt: BaseException | None = current.__cause__
+        if nxt is None and not current.__suppress_context__:
+            nxt = current.__context__
+        if nxt is None or id(nxt) in seen:
+            return current
+        seen.add(id(nxt))
+        current = nxt
+    return current
+
+
 # Canonical HTTP status for each typed Opik/Comet exception. Our client
 # layers raise these in place of carrying ``status_code`` on the exception
 # instance, so we recover the status here from the class itself. Sub-
@@ -74,14 +140,18 @@ def derive_http_status(exc: BaseException) -> int | None:
     sites: the BI receiver needs the status alongside ``error_kind`` so a
     dashboard can split, e.g., ``auth`` failures into 401 vs 403 without
     losing the coarse bucket.
+
+    Unwraps through pure-envelope wrappers (``ToolError``, ``OllieStreamError``)
+    so a ``ToolError`` carrying an ``OpikAuthError`` still resolves to 401.
     """
+    real = unwrap_to_real_cause(exc)
     # ``httpx.HTTPStatusError`` carries the real status on the response.
     # Other httpx network errors (ConnectError, TimeoutException, …) have
     # no status — they failed before getting one.
-    if isinstance(exc, httpx.HTTPStatusError):
-        return exc.response.status_code
+    if isinstance(real, httpx.HTTPStatusError):
+        return real.response.status_code
     for cls, status in _EXC_TO_HTTP_STATUS:
-        if isinstance(exc, cls):
+        if isinstance(real, cls):
             return status
     return None
 
@@ -115,30 +185,37 @@ def bucket_exception(exc: BaseException, http_status: int | None = None) -> Erro
     already inspected). When omitted, the function derives a status from
     typed Opik/Comet/Ollie exceptions via ``derive_http_status``.
 
-    PRIVACY: never reads ``exc.args`` / ``str(exc)``. Class-only.
+    Unwraps through pure-envelope wrappers (``ToolError``, ``OllieStreamError``)
+    so the bucket reflects the real upstream cause. A wrapper with no cause
+    (or whose cause chain ends in a non-meaningful class) falls through to
+    ``"unknown"`` — same as before this unwrap was added.
+
+    PRIVACY: never reads ``exc.args`` / ``str(exc)``. Class-only — the unwrap
+    inspects ``__cause__`` / ``__context__`` references, not their messages.
     """
+    real = unwrap_to_real_cause(exc)
     # 1) Permission BEFORE auth — OpikPermissionError extends OpikAuthError,
     #    so a 403 must not be miscategorized as "auth" (which means 401).
-    if isinstance(exc, (OpikPermissionError, CometPermissionError)):
+    if isinstance(real, (OpikPermissionError, CometPermissionError)):
         return "permission"
-    if isinstance(exc, (OpikAuthError, CometAuthError, OllieAuthError)):
+    if isinstance(real, (OpikAuthError, CometAuthError, OllieAuthError)):
         return "auth"
-    if isinstance(exc, OpikNotFoundError):
+    if isinstance(real, OpikNotFoundError):
         return "not_found"
-    if isinstance(exc, (OpikValidationError, PydanticValidationError)):
+    if isinstance(real, (OpikValidationError, PydanticValidationError)):
         return "validation"
-    if isinstance(exc, OpikServerError):
+    if isinstance(real, OpikServerError):
         return "upstream_5xx"
-    if isinstance(exc, PodNotReadyError):
+    if isinstance(real, PodNotReadyError):
         return "timeout"
     # ``httpx.TimeoutException`` is the base for connect/read/write/pool
     # timeouts. Keep it BEFORE the broader ``RequestError`` arm so a
     # ``ReadTimeout`` lands in ``timeout``, not ``network``.
-    if isinstance(exc, httpx.TimeoutException):
+    if isinstance(real, httpx.TimeoutException):
         return "timeout"
-    if isinstance(exc, httpx.HTTPStatusError):
-        return bucket_http_status(exc.response.status_code)
-    if isinstance(exc, httpx.RequestError):
+    if isinstance(real, httpx.HTTPStatusError):
+        return bucket_http_status(real.response.status_code)
+    if isinstance(real, httpx.RequestError):
         return "network"
     # MissingConfigError, OllieStreamError, OllieNotEnabledError, CometProtocolError
     # don't map cleanly to the receiver's taxonomy — they're our own
@@ -147,7 +224,7 @@ def bucket_exception(exc: BaseException, http_status: int | None = None) -> Erro
     if http_status is not None:
         return bucket_http_status(http_status)
     if isinstance(
-        exc, (OllieStreamError, OllieNotEnabledError, CometProtocolError, MissingConfigError)
+        real, (OllieStreamError, OllieNotEnabledError, CometProtocolError, MissingConfigError)
     ):
         return "unknown"
     return "unknown"

--- a/src/opik_mcp/analytics/errors.py
+++ b/src/opik_mcp/analytics/errors.py
@@ -1,61 +1,56 @@
 """Shared error taxonomy for analytics events.
 
 Both ``opik_mcp_tool_called`` and ``opik_mcp_ask_ollie_completed`` emit an
-``error_kind`` drawn from the ``ErrorKind`` allowlist below. The granular
-exception class is preserved as ``exception_type`` — coarse bucketing for
-"what should we fix next?" dashboards, granular class names for follow-up
-investigation.
+``error_kind`` drawn from the ``ErrorKind`` allowlist (see
+``opik_mcp.error_kinds``). The granular exception class is preserved as
+``exception_type`` — coarse bucketing for "what should we fix next?"
+dashboards, granular class names for follow-up investigation.
+
+Classification model: each of our typed exception classes carries
+``error_kind: ClassVar[ErrorKind]`` and ``http_status: ClassVar[int | None]``
+as ClassVars. The classifier reads those attributes via ``getattr`` — no
+``isinstance`` cascade. Python's MRO does the work, so subclasses like
+``OpikPermissionError`` automatically shadow the parent's bucket.
+
+We still need special-case branches for:
+- pure-envelope wrappers (``ToolError``, ``OllieStreamError`` when chained):
+  the unwrap walks past them to find the real cause first.
+- non-controllable classes we can't put attributes on:
+  ``httpx.HTTPStatusError`` (status comes from the response), other
+  ``httpx`` network errors, and ``pydantic.ValidationError``.
 
 PRIVACY: every public function in this module keys off the exception CLASS
-only — never on ``exc.args`` / ``str(exc)`` / response body. That guarantees
-no exception message ever surfaces in an analytics property. The contract is
-machine-checked by ``tests/test_analytics_privacy.py``.
+only — never on ``exc.args`` / ``str(exc)`` / response body. The contract
+is machine-checked by ``tests/test_analytics_privacy.py``.
 """
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any
 
 import httpx
 from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import ValidationError as PydanticValidationError
 
-from opik_mcp.comet_client import (
-    CometAuthError,
-    CometPermissionError,
-    CometProtocolError,
-    OllieNotEnabledError,
-)
-from opik_mcp.config import MissingConfigError
-from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError
-from opik_mcp.opik_client import (
-    OpikAuthError,
-    OpikNotFoundError,
-    OpikPermissionError,
-    OpikServerError,
-    OpikValidationError,
-)
+from opik_mcp.error_kinds import ErrorKind
+from opik_mcp.ollie_client import OllieStreamError
 
-# The receiver only ever sees one of these values. Adding a new bucket is a
-# BI schema change — extend cautiously and keep the Literal in sync.
-ErrorKind = Literal[
-    "auth",
-    "validation",
-    "not_found",
-    "permission",
-    "timeout",
-    "network",
-    "upstream_5xx",
-    "cancelled",
-    "unknown",
+# Re-export so existing call sites (and downstream readers) keep their
+# ``from opik_mcp.analytics.errors import ErrorKind`` import working.
+__all__ = [
+    "ErrorKind",
+    "bucket_exception",
+    "bucket_http_status",
+    "derive_http_status",
+    "unwrap_to_real_cause",
 ]
 
 
 # Pure-envelope exception classes — these wrap a real upstream cause via
 # ``raise X from e`` (or implicit ``__context__``) and never carry their own
-# bucketing signal. ``bucket_exception`` walks past them to find the real
-# culprit; emit sites preserve the wrapper class name in ``exception_type``
-# and the unwrapped class in ``cause_type``.
+# bucketing signal beyond ``"unknown"``. ``bucket_exception`` walks past
+# them to find the real culprit; emit sites preserve the wrapper class name
+# in ``exception_type`` and the unwrapped class in ``cause_type``.
 #
 # Why ``ToolError``: FastMCP's contract is that tool handlers surface failures
 # to the host via ``ToolError`` (see ``read_list/``, ``writes/``). Without the
@@ -64,10 +59,8 @@ ErrorKind = Literal[
 #
 # Why ``OllieStreamError``: a ``RuntimeError`` subclass we raise both as a
 # leaf (e.g. protocol-drift "no session_id") AND as a wrapper around upstream
-# HTTP failures (``ollie_client.py:161`` raises it from a 404; ``ask_ollie.py``
-# raises it from pod ``error`` SSE frames carrying ``upstream_code``). The
-# leaf case still falls through to ``"unknown"`` below; the wrapper case now
-# routes by its real cause.
+# HTTP failures. Its own ``error_kind`` ClassVar is ``"unknown"`` so the
+# bare-leaf case still buckets correctly; the wrapper case routes by cause.
 _WRAPPER_CLASSES: tuple[type[BaseException], ...] = (
     ToolError,
     OllieStreamError,
@@ -116,44 +109,34 @@ def unwrap_to_real_cause(
     return current
 
 
-# Canonical HTTP status for each typed Opik/Comet exception. Our client
-# layers raise these in place of carrying ``status_code`` on the exception
-# instance, so we recover the status here from the class itself. Sub-
-# classes are intentionally listed BEFORE their parents (``OpikPermissionError``
-# extends ``OpikAuthError``) so ``isinstance`` walks resolve to the more-
-# specific status first.
-_EXC_TO_HTTP_STATUS: tuple[tuple[type[BaseException], int], ...] = (
-    (OpikPermissionError, 403),
-    (OpikAuthError, 401),
-    (OpikNotFoundError, 404),
-    (OpikValidationError, 400),
-    (OpikServerError, 500),
-    (CometPermissionError, 403),
-    (CometAuthError, 401),
-)
+def _class_attr(exc: BaseException, name: str) -> Any:
+    """Return ``type(exc).<name>`` if defined as a class-level attribute on
+    one of our typed exception classes, else ``None``.
+
+    We deliberately do NOT read instance attributes — only class-level ones
+    set as ``ClassVar``. Avoids accidentally treating a stray instance attr
+    (potentially smuggled in from user-controlled data on some future class)
+    as a taxonomy signal.
+    """
+    value = getattr(type(exc), name, None)
+    return value
 
 
 def derive_http_status(exc: BaseException) -> int | None:
     """Return the canonical HTTP status for a typed exception, else ``None``.
 
-    Designed for ``opik_mcp_tool_called`` / ``ask_ollie_completed`` emit
-    sites: the BI receiver needs the status alongside ``error_kind`` so a
-    dashboard can split, e.g., ``auth`` failures into 401 vs 403 without
-    losing the coarse bucket.
+    Reads ``type(exc).http_status`` — the ClassVar each typed Opik/Comet/
+    Ollie exception declares. ``httpx.HTTPStatusError`` is handled
+    specially because the status lives on the response, not the class.
 
     Unwraps through pure-envelope wrappers (``ToolError``, ``OllieStreamError``)
     so a ``ToolError`` carrying an ``OpikAuthError`` still resolves to 401.
     """
     real = unwrap_to_real_cause(exc)
-    # ``httpx.HTTPStatusError`` carries the real status on the response.
-    # Other httpx network errors (ConnectError, TimeoutException, …) have
-    # no status — they failed before getting one.
     if isinstance(real, httpx.HTTPStatusError):
         return real.response.status_code
-    for cls, status in _EXC_TO_HTTP_STATUS:
-        if isinstance(real, cls):
-            return status
-    return None
+    status = _class_attr(real, "http_status")
+    return status if isinstance(status, int) else None
 
 
 def bucket_http_status(status: int) -> ErrorKind:
@@ -177,37 +160,12 @@ def bucket_http_status(status: int) -> ErrorKind:
     return "unknown"
 
 
-def bucket_exception(exc: BaseException, http_status: int | None = None) -> ErrorKind:
-    """Bucket an exception into the coarse ``ErrorKind`` allowlist.
-
-    ``http_status`` lets callers supersede the class-based mapping when they
-    have a more specific signal (e.g. an ``httpx.HTTPStatusError`` they
-    already inspected). When omitted, the function derives a status from
-    typed Opik/Comet/Ollie exceptions via ``derive_http_status``.
-
-    Unwraps through pure-envelope wrappers (``ToolError``, ``OllieStreamError``)
-    so the bucket reflects the real upstream cause. A wrapper with no cause
-    (or whose cause chain ends in a non-meaningful class) falls through to
-    ``"unknown"`` — same as before this unwrap was added.
-
-    PRIVACY: never reads ``exc.args`` / ``str(exc)``. Class-only — the unwrap
-    inspects ``__cause__`` / ``__context__`` references, not their messages.
-    """
-    real = unwrap_to_real_cause(exc)
-    # 1) Permission BEFORE auth — OpikPermissionError extends OpikAuthError,
-    #    so a 403 must not be miscategorized as "auth" (which means 401).
-    if isinstance(real, (OpikPermissionError, CometPermissionError)):
-        return "permission"
-    if isinstance(real, (OpikAuthError, CometAuthError, OllieAuthError)):
-        return "auth"
-    if isinstance(real, OpikNotFoundError):
-        return "not_found"
-    if isinstance(real, (OpikValidationError, PydanticValidationError)):
+# Buckets for non-controllable classes we can't put a ClassVar on. Ordered
+# subclass-first by virtue of how the function reads them. ``httpx`` is the
+# only third-party hierarchy we route on; pydantic gets a single match.
+def _bucket_external(real: BaseException) -> ErrorKind | None:
+    if isinstance(real, PydanticValidationError):
         return "validation"
-    if isinstance(real, OpikServerError):
-        return "upstream_5xx"
-    if isinstance(real, PodNotReadyError):
-        return "timeout"
     # ``httpx.TimeoutException`` is the base for connect/read/write/pool
     # timeouts. Keep it BEFORE the broader ``RequestError`` arm so a
     # ``ReadTimeout`` lands in ``timeout``, not ``network``.
@@ -217,14 +175,36 @@ def bucket_exception(exc: BaseException, http_status: int | None = None) -> Erro
         return bucket_http_status(real.response.status_code)
     if isinstance(real, httpx.RequestError):
         return "network"
-    # MissingConfigError, OllieStreamError, OllieNotEnabledError, CometProtocolError
-    # don't map cleanly to the receiver's taxonomy — they're our own
-    # control-flow errors, not upstream failures. Caller-supplied status
-    # takes precedence when available.
+    return None
+
+
+def bucket_exception(exc: BaseException, http_status: int | None = None) -> ErrorKind:
+    """Bucket an exception into the coarse ``ErrorKind`` allowlist.
+
+    Resolution order:
+    1. Unwrap pure-envelope wrappers (``ToolError`` / ``OllieStreamError``)
+       to the real upstream cause.
+    2. Read ``type(real).error_kind`` if our codebase declared one (every
+       typed Opik/Comet/Ollie/Pod/Config exception does).
+    3. Special-case external hierarchies we can't annotate
+       (``httpx`` / ``pydantic``).
+    4. Caller-supplied ``http_status`` (lets a future tool surface a 422-
+       style validation error via return value rather than raise).
+    5. Fall through to ``"unknown"``.
+
+    PRIVACY: never reads ``exc.args`` / ``str(exc)``. The ``getattr`` reads
+    a class-level ClassVar; the unwrap inspects ``__cause__`` / ``__context__``
+    references, not their messages.
+    """
+    real = unwrap_to_real_cause(exc)
+    kind = _class_attr(real, "error_kind")
+    # The ClassVar is bound to ``ErrorKind`` (a Literal) in every declaring
+    # class, so a string at this point IS one of the allowlist values.
+    if isinstance(kind, str):
+        return kind  # type: ignore[return-value]
+    external = _bucket_external(real)
+    if external is not None:
+        return external
     if http_status is not None:
         return bucket_http_status(http_status)
-    if isinstance(
-        real, (OllieStreamError, OllieNotEnabledError, CometProtocolError, MissingConfigError)
-    ):
-        return "unknown"
     return "unknown"

--- a/src/opik_mcp/analytics/wrappers.py
+++ b/src/opik_mcp/analytics/wrappers.py
@@ -23,7 +23,11 @@ from opik_mcp.analytics import (
     get_analytics,
     transport_probe,
 )
-from opik_mcp.analytics.errors import bucket_exception, derive_http_status
+from opik_mcp.analytics.errors import (
+    bucket_exception,
+    derive_http_status,
+    unwrap_to_real_cause,
+)
 from opik_mcp.analytics.events import EVENT_TOOLS_LISTED, bucket_count
 from opik_mcp.analytics.mcp_client_info import collect_session_props
 from opik_mcp.comet_client import OllieNotEnabledError
@@ -140,6 +144,7 @@ def _report_to_sentry(
     *,
     tool_name: str,
     error_kind: str,
+    cause_type: str | None,
     duration_ms: int,
     props_fn: PropsFn | None,
     kwargs: dict[str, Any],
@@ -155,8 +160,14 @@ def _report_to_sentry(
     MCP host fingerprint (``mcp_host`` / ``mcp_client_version``) is attached
     when available — invaluable when triaging which client (Claude Code,
     Cursor, custom) hit a given Sentry issue.
+
+    ``cause_type`` mirrors the BI prop — when the raise site wraps a real
+    upstream class via ``ToolError`` / ``OllieStreamError``, the leaf class
+    is what Sentry triage actually cares about, so we tag both.
     """
     tags: dict[str, str] = {"tool_name": tool_name, "error_kind": error_kind}
+    if cause_type:
+        tags["cause_type"] = cause_type
     extras: dict[str, Any] = {"duration_ms": duration_ms}
     if props_fn is not None:
         try:
@@ -214,6 +225,7 @@ def instrument_tool(
             t0 = time.monotonic()
             error_kind: str | None = None
             exception_type: str | None = None
+            cause_type: str | None = None
             http_status: int | None = None
             result: T | None = None
             completed = False
@@ -232,19 +244,31 @@ def instrument_tool(
                     # so dashboards can distinguish cancellations from errors.
                     error_kind = "cancelled"
                 elif isinstance(exc, Exception):
+                    # Unwrap pure-envelope wrappers (ToolError, OllieStreamError)
+                    # so the bucket reflects the real cause. ``exception_type``
+                    # keeps the wrapper class (where in our code the failure
+                    # surfaced); ``cause_type`` carries the leaf (what actually
+                    # broke upstream). Both emit only when distinct.
+                    real = unwrap_to_real_cause(exc)
+                    if real is not exc:
+                        cause_type = type(real).__name__
                     error_kind = bucket_exception(exc)
                     http_status = derive_http_status(exc)
                     # Sentry carries only the kinds worth a human stack trace.
                     # Skip the user-side buckets + the few user-config classes
                     # that collapse into ``"unknown"`` (the coarse bucket can't
                     # distinguish them from real bugs like ``CometProtocolError``).
+                    # The class-level skip-list runs against ``real`` so a
+                    # ToolError wrapping ``MissingConfigError`` is recognized
+                    # as user-side and not paged to Sentry.
                     if error_kind not in _USER_SIDE_ERROR_KINDS and not isinstance(
-                        exc, _USER_SIDE_EXCEPTIONS
+                        real, _USER_SIDE_EXCEPTIONS
                     ):
                         _report_to_sentry(
                             exc,
                             tool_name=name,
                             error_kind=error_kind,
+                            cause_type=cause_type,
                             duration_ms=int((time.monotonic() - t0) * 1000),
                             props_fn=props_fn,
                             kwargs=kwargs,
@@ -260,6 +284,8 @@ def instrument_tool(
                     props["error_kind"] = error_kind
                 if exception_type:
                     props["exception_type"] = exception_type
+                if cause_type:
+                    props["cause_type"] = cause_type
                 if http_status is not None:
                     props["http_status"] = str(http_status)
                 if props_fn is not None and completed:

--- a/src/opik_mcp/ask_ollie.py
+++ b/src/opik_mcp/ask_ollie.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 from opik_mcp import audit
 from opik_mcp.analytics import EVENT_ASK_OLLIE_COMPLETED, bucket_count
-from opik_mcp.analytics.errors import bucket_exception
+from opik_mcp.analytics.errors import bucket_exception, unwrap_to_real_cause
 from opik_mcp.comet_client import CometClient, PodDiscovery
 from opik_mcp.config import Settings, get_settings, require_ollie_config
 from opik_mcp.elicitation import confirm_with_user
@@ -212,6 +212,7 @@ async def run_ask_ollie(
     # below assigns real values when ``errored`` flips to True.
     error_kind: str = "unknown"
     error_exception_type: str = ""
+    error_cause_type: str = ""
     error_upstream_code: str | None = None
 
     try:
@@ -618,10 +619,21 @@ async def run_ask_ollie(
             # Cancellation exceptions (`anyio.get_cancelled_exc_class()`) can leak
             # from the heartbeat task when the SSE body raises — filter them out
             # so they don't mask the user-facing error or block the unwrap.
+            #
+            # Plain ``raise real[0]`` (no ``from``) preserves the inner
+            # ``__cause__`` chain — production ``OllieStreamError`` instances are
+            # raised via ``raise OllieStreamError(...) from OpikAuthError(...)``
+            # and the analytics emit relies on ``unwrap_to_real_cause`` walking
+            # that chain. An earlier ``from None`` here clobbered ``__cause__``
+            # and made every wrapped failure look like ``unknown`` in BI.
             cancelled_cls = anyio.get_cancelled_exc_class()
             real = [e for e in eg.exceptions if not isinstance(e, cancelled_cls)]
             if len(real) == 1 and isinstance(real[0], Exception):
-                raise real[0] from None
+                # ``raise real[0]`` (no ``from``) is intentional. ``from eg``
+                # would overwrite the inner ``__cause__`` with the task group;
+                # ``from None`` would drop the chain entirely. Neither is what
+                # analytics need — see the block-level comment above.
+                raise real[0]  # noqa: B904
             raise
 
         if not saw_message_end and not cancelled:
@@ -675,7 +687,18 @@ async def run_ask_ollie(
             # class-name and class-keyed bucket only — exc.args is never
             # read at any emit site.
             error_exception_type = type(exc).__name__
-            error_kind = bucket_exception(exc) if isinstance(exc, Exception) else "unknown"
+            if isinstance(exc, Exception):
+                error_kind = bucket_exception(exc)
+                # Unwrap pure-envelope wrappers (OllieStreamError, ToolError)
+                # so dashboards can split on the real upstream culprit. Only
+                # populated when the unwrap actually finds a distinct cause
+                # — a bare ``OllieStreamError`` with no chained cause leaves
+                # ``cause_type`` empty and the event carries the wrapper only.
+                real_cause = unwrap_to_real_cause(exc)
+                if real_cause is not exc:
+                    error_cause_type = type(real_cause).__name__
+            else:
+                error_kind = "unknown"
             # ``getattr`` returns ``Any`` — narrow to ``str`` here so the
             # finally block doesn't need to re-check the type and so a future
             # refactor that accidentally stores a non-string would be caught
@@ -706,6 +729,8 @@ async def run_ask_ollie(
         if errored:
             props["error_kind"] = error_kind
             props["exception_type"] = error_exception_type
+            if error_cause_type:
+                props["cause_type"] = error_cause_type
             if error_upstream_code:
                 # Length-cap as a defense against a misbehaving pod that
                 # stamps a long string into ``code``. 64 chars is enough

--- a/src/opik_mcp/comet_client.py
+++ b/src/opik_mcp/comet_client.py
@@ -1,27 +1,48 @@
 import http.cookies
 from dataclasses import dataclass
+from typing import ClassVar
 
 import httpx
+
+from opik_mcp.error_kinds import ErrorKind
 
 
 class CometAuthError(RuntimeError):
     """Comet-backend rejected the API key (401)."""
 
+    error_kind: ClassVar[ErrorKind] = "auth"
+    http_status: ClassVar[int | None] = 401
+
 
 class CometPermissionError(CometAuthError):
     """Comet-backend returned 403 — caller is authenticated but the workspace
     rejects the request. Subclass of ``CometAuthError`` to preserve existing
-    ``except CometAuthError`` callers; analytics distinguishes them via
-    table-order in the kind classifier.
+    ``except CometAuthError`` callers; the ``error_kind`` / ``http_status``
+    ClassVars shadow the parent's so analytics still distinguish the two.
     """
+
+    error_kind: ClassVar[ErrorKind] = "permission"
+    http_status: ClassVar[int | None] = 403
 
 
 class OllieNotEnabledError(RuntimeError):
-    """Workspace does not have ollie-assist enabled."""
+    """Workspace does not have ollie-assist enabled.
+
+    Bucketed as ``"unknown"`` — it's a user-config problem with no clean
+    place in the upstream-failure taxonomy. The Sentry skip-list in
+    ``analytics/wrappers.py`` covers it separately by class.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "unknown"
+    http_status: ClassVar[int | None] = None
 
 
 class CometProtocolError(RuntimeError):
-    """Comet-backend response was not in the expected shape."""
+    """Comet-backend response was not in the expected shape — our own
+    contract-drift signal, not an upstream HTTP failure."""
+
+    error_kind: ClassVar[ErrorKind] = "unknown"
+    http_status: ClassVar[int | None] = None
 
 
 @dataclass(frozen=True)

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -5,9 +5,14 @@ from uuid import UUID
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from opik_mcp.error_kinds import ErrorKind
+
 
 class MissingConfigError(RuntimeError):
     """Raised when an ask_ollie call is attempted without required env vars."""
+
+    error_kind: ClassVar[ErrorKind] = "unknown"
+    http_status: ClassVar[int | None] = None
 
 
 class Settings(BaseSettings):

--- a/src/opik_mcp/error_kinds.py
+++ b/src/opik_mcp/error_kinds.py
@@ -1,0 +1,27 @@
+"""Shared analytics taxonomy.
+
+Lives in a leaf module so any layer can import the ``ErrorKind`` Literal
+without creating cycles. The typed exception classes (``opik_client``,
+``comet_client``, ``ollie_client``, ``config``) declare their bucket as a
+``ClassVar[ErrorKind]``; ``analytics/errors.py`` reads that attribute via
+``getattr`` instead of running an ``isinstance`` cascade.
+
+Adding a new bucket is a BI schema change — extend cautiously and update
+``docs/analytics.md`` (if present) plus the privacy-test allowlist.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ErrorKind = Literal[
+    "auth",
+    "validation",
+    "not_found",
+    "permission",
+    "timeout",
+    "network",
+    "upstream_5xx",
+    "cancelled",
+    "unknown",
+]

--- a/src/opik_mcp/ollie_client.py
+++ b/src/opik_mcp/ollie_client.py
@@ -1,19 +1,27 @@
 import json
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 import anyio
 import httpx
 from httpx_sse import aconnect_sse
 
+from opik_mcp.error_kinds import ErrorKind
+
 
 class PodNotReadyError(RuntimeError):
     """Pod did not become ready within the configured timeout."""
 
+    error_kind: ClassVar[ErrorKind] = "timeout"
+    http_status: ClassVar[int | None] = None
+
 
 class OllieAuthError(RuntimeError):
     """Pod rejected the PPAUTH cookie."""
+
+    error_kind: ClassVar[ErrorKind] = "auth"
+    http_status: ClassVar[int | None] = None
 
 
 class OllieStreamError(RuntimeError):
@@ -25,7 +33,15 @@ class OllieStreamError(RuntimeError):
     message. ``None`` when the frame omitted it or when the error was
     raised from an internal control-flow path (confirm-POST failure, etc.)
     rather than a server-side error frame.
+
+    Bucketed as ``"unknown"`` at the leaf — it's a wrapper class, and when
+    it carries a chained cause the analytics layer unwraps to that cause's
+    bucket via ``unwrap_to_real_cause``. A bare ``OllieStreamError`` (no
+    cause) stays ``"unknown"``: it's our own protocol-drift signal.
     """
+
+    error_kind: ClassVar[ErrorKind] = "unknown"
+    http_status: ClassVar[int | None] = None
 
     def __init__(self, message: str, *, upstream_code: str | None = None) -> None:
         super().__init__(message)

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -16,37 +16,60 @@ import json as _json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
-from typing import Any, Final, Literal, Protocol
+from typing import Any, ClassVar, Final, Literal, Protocol
 
 import httpx
 
 from opik_mcp.config import MissingConfigError, Settings
+from opik_mcp.error_kinds import ErrorKind
 
 # --- errors --------------------------------------------------------------- #
+#
+# Each class carries its own ``error_kind`` + ``http_status`` as a
+# ``ClassVar`` so ``analytics/errors.py`` can route via ``getattr`` instead
+# of an ``isinstance`` cascade. ``OpikPermissionError`` shadows its parent's
+# values — Python's attribute resolution picks the subclass automatically,
+# so the analytics layer needs no special "permission before auth" ordering.
 
 
 class OpikAuthError(RuntimeError):
     """Opik rejected the API key (401)."""
 
+    error_kind: ClassVar[ErrorKind] = "auth"
+    http_status: ClassVar[int | None] = 401
+
 
 class OpikPermissionError(OpikAuthError):
     """Opik returned 403 — caller is authenticated but not allowed for the
     target workspace / resource. Subclass of ``OpikAuthError`` so existing
-    handlers that catch the auth case continue to catch this too; analytics
-    classification distinguishes them via table-order (specific class first).
+    handlers that catch the auth case continue to catch this too; the
+    ``error_kind`` / ``http_status`` ClassVars shadow the parent's so
+    analytics still distinguish the two.
     """
+
+    error_kind: ClassVar[ErrorKind] = "permission"
+    http_status: ClassVar[int | None] = 403
 
 
 class OpikNotFoundError(RuntimeError):
     """Target entity does not exist (404). Wraps the entity hint."""
 
+    error_kind: ClassVar[ErrorKind] = "not_found"
+    http_status: ClassVar[int | None] = 404
+
 
 class OpikValidationError(RuntimeError):
     """Opik rejected the request body (400/422)."""
 
+    error_kind: ClassVar[ErrorKind] = "validation"
+    http_status: ClassVar[int | None] = 400
+
 
 class OpikServerError(RuntimeError):
     """Opik returned a 5xx response."""
+
+    error_kind: ClassVar[ErrorKind] = "upstream_5xx"
+    http_status: ClassVar[int | None] = 500
 
 
 # --- types ---------------------------------------------------------------- #

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
@@ -17,6 +18,7 @@ from opik_mcp.analytics.errors import (
     bucket_exception,
     bucket_http_status,
     derive_http_status,
+    unwrap_to_real_cause,
 )
 from opik_mcp.comet_client import (
     CometAuthError,
@@ -226,3 +228,247 @@ def test_bucket_exception_subclass_resolves_before_parent() -> None:
     mislabeled as 401 (and the dashboards lose the distinction)."""
     assert bucket_exception(OpikPermissionError("x")) == "permission"
     assert bucket_exception(CometPermissionError("x")) == "permission"
+
+
+# --- unwrap_to_real_cause ------------------------------------------------ #
+
+
+def _raise_chain(*excs: BaseException) -> BaseException:
+    """Build a real ``raise X from Y`` chain by raising sequentially.
+
+    Returns the outermost exception with ``__cause__`` populated as Python
+    would set it on the wire. Using a real ``raise`` (vs. setting attributes
+    by hand) is the only way to also exercise ``__suppress_context__`` and
+    keeps the test honest about how chains are actually produced.
+    """
+    if not excs:
+        raise AssertionError("at least one exception required")
+    if len(excs) == 1:
+        return excs[0]
+    outer, *rest = excs
+    inner = _raise_chain(*rest)
+    try:
+        raise outer from inner
+    except BaseException as e:
+        return e
+
+
+def test_unwrap_returns_leaf_when_no_wrapper() -> None:
+    """A non-wrapper exception has nothing to unwrap — return as-is."""
+    leaf = OpikAuthError("x")
+    assert unwrap_to_real_cause(leaf) is leaf
+
+
+def test_unwrap_follows_cause_through_tool_error() -> None:
+    """The exact shape every read/list/write tool produces in prod:
+    ``raise ToolError(...) from OpikAuthError(...)``. The unwrap must
+    surface the real cause so analytics can bucket it as ``auth``."""
+    chain = _raise_chain(ToolError("user-facing"), OpikAuthError("401"))
+    real = unwrap_to_real_cause(chain)
+    assert isinstance(real, OpikAuthError)
+
+
+def test_unwrap_follows_cause_through_ollie_stream_error() -> None:
+    """``OllieStreamError`` is the wrapper at the ``ask_ollie`` boundary; an
+    underlying ``httpx.HTTPStatusError`` must be reachable through it."""
+    request = httpx.Request("GET", "https://example.invalid/")
+    response = httpx.Response(503, request=request)
+    inner = httpx.HTTPStatusError("synthetic", request=request, response=response)
+    chain = _raise_chain(OllieStreamError("stream died"), inner)
+    real = unwrap_to_real_cause(chain)
+    assert isinstance(real, httpx.HTTPStatusError)
+    assert real.response.status_code == 503
+
+
+def test_unwrap_follows_context_when_no_explicit_cause() -> None:
+    """A bare ``raise ToolError(...)`` inside an ``except OpikAuthError`` block
+    sets ``__context__`` (not ``__cause__``). Python's traceback display
+    still surfaces the implicit chain — so must we."""
+    try:
+        try:
+            raise OpikNotFoundError("404")
+        except OpikNotFoundError:
+            # Deliberately omitting ``from …`` — that's the whole point of
+            # this test: verify the unwrap still finds the cause via the
+            # implicit ``__context__`` slot Python sets.
+            raise ToolError("not found")  # noqa: B904
+    except ToolError as e:
+        real = unwrap_to_real_cause(e)
+        assert isinstance(real, OpikNotFoundError)
+
+
+def test_unwrap_respects_suppress_context() -> None:
+    """``raise X from None`` sets ``__suppress_context__`` — the user is
+    explicitly saying "don't chain me". Honor that: stop at the wrapper."""
+    try:
+        try:
+            raise OpikAuthError("401")
+        except OpikAuthError:
+            raise ToolError("opaque") from None
+    except ToolError as e:
+        real = unwrap_to_real_cause(e)
+        # Must remain the wrapper — the implicit context was suppressed.
+        assert real is e
+
+
+def test_unwrap_prefers_explicit_cause_over_implicit_context() -> None:
+    """When both ``__cause__`` and ``__context__`` are set (the explicit
+    ``raise X from Y`` inside an ``except Z`` block), ``__cause__`` wins —
+    Python's own ``__suppress_context__`` machinery establishes this contract.
+    """
+    try:
+        try:
+            raise OpikValidationError("validation")  # becomes __context__
+        except OpikValidationError:
+            raise ToolError("wrapper") from OpikAuthError("auth")  # becomes __cause__
+    except ToolError as e:
+        real = unwrap_to_real_cause(e)
+        # Cause (OpikAuthError) wins over context (OpikValidationError).
+        assert isinstance(real, OpikAuthError)
+
+
+def test_unwrap_walks_multi_layer_chain() -> None:
+    """Nested wrappers — e.g. an ``ask_ollie`` invocation surfaced as a
+    ``ToolError`` somewhere upstream. Unwrap must reach the typed leaf."""
+    chain = _raise_chain(
+        ToolError("outer"),
+        OllieStreamError("middle"),
+        OpikServerError("inner"),
+    )
+    real = unwrap_to_real_cause(chain)
+    assert isinstance(real, OpikServerError)
+
+
+def test_unwrap_stops_at_first_non_wrapper() -> None:
+    """An unfamiliar exception class is treated as a leaf, even if its own
+    ``__cause__`` would reach something typed. Conservative by design:
+    the wrapper list is small and explicit — anything else is opaque."""
+    chain = _raise_chain(
+        ToolError("outer"),
+        RuntimeError("intermediate, NOT in _WRAPPER_CLASSES"),
+        OpikAuthError("would-have-been-the-leaf"),
+    )
+    real = unwrap_to_real_cause(chain)
+    # Stops at RuntimeError; OpikAuthError underneath is intentionally ignored.
+    assert isinstance(real, RuntimeError)
+    assert not isinstance(real, OpikAuthError)
+
+
+def test_unwrap_handles_cycle_without_infinite_loop() -> None:
+    """Defensive: ``__cause__`` is a writable attribute; a pathological
+    chain that loops back must not hang the classifier."""
+    a = ToolError("a")
+    b = ToolError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    # Bound by max_depth; must terminate. We don't assert which node we
+    # land on — only that no infinite loop occurs.
+    real = unwrap_to_real_cause(a)
+    assert isinstance(real, ToolError)
+
+
+def test_unwrap_bounded_max_depth() -> None:
+    """Chain longer than ``max_depth`` returns the deepest reachable
+    exception within the bound — no further walk, no crash."""
+    chain = _raise_chain(
+        ToolError("0"),
+        ToolError("1"),
+        ToolError("2"),
+        ToolError("3"),
+        ToolError("4"),
+        OpikAuthError("leaf"),
+    )
+    # Default max_depth=4: we reach hop 4 (still a ToolError), then stop.
+    real = unwrap_to_real_cause(chain)
+    assert isinstance(real, ToolError)
+    # Explicit larger depth reaches the leaf.
+    real_deep = unwrap_to_real_cause(chain, max_depth=10)
+    assert isinstance(real_deep, OpikAuthError)
+
+
+# --- bucket_exception unwraps via wrapper classes ------------------------ #
+
+# Every entry in this matrix mirrors a real production code path:
+#   ``raise ToolError(_format_client_error(...)) from e``
+# in read_tool/list_tool/write_tool, and the parallel OllieStreamError
+# raise-sites in ollie_client.py. Pre-unwrap, all of these landed in
+# "unknown / ToolError" in BI — the gap that motivated this whole change.
+_WRAPPED_BUCKET_MATRIX = [
+    (OpikAuthError("401"), "auth", 401),
+    (OpikPermissionError("403"), "permission", 403),
+    (OpikNotFoundError("404"), "not_found", 404),
+    (OpikValidationError("400"), "validation", 400),
+    (OpikServerError("500"), "upstream_5xx", 500),
+    (CometAuthError("401"), "auth", 401),
+    (CometPermissionError("403"), "permission", 403),
+    (PodNotReadyError("warmup"), "timeout", None),
+    (httpx.ReadTimeout("slow"), "timeout", None),
+    (httpx.ConnectError("refused"), "network", None),
+    (OllieAuthError("ppauth"), "auth", None),
+    (MissingConfigError("no key"), "unknown", None),
+]
+
+
+@pytest.mark.parametrize("inner, expected_bucket, expected_status", _WRAPPED_BUCKET_MATRIX)
+def test_bucket_exception_unwraps_tool_error(
+    inner: Exception, expected_bucket: str, expected_status: int | None
+) -> None:
+    """``ToolError`` is the FastMCP-contract wrapper around every read/list/
+    write failure. The classifier must look through it to the real cause."""
+    chain = _raise_chain(ToolError("user-facing"), inner)
+    assert bucket_exception(chain) == expected_bucket
+    assert derive_http_status(chain) == expected_status
+
+
+@pytest.mark.parametrize("inner, expected_bucket, expected_status", _WRAPPED_BUCKET_MATRIX)
+def test_bucket_exception_unwraps_ollie_stream_error(
+    inner: Exception, expected_bucket: str, expected_status: int | None
+) -> None:
+    """``OllieStreamError`` is the wrapper at the ``ask_ollie`` boundary; it
+    also wraps real upstream causes (e.g. SSE error frames carrying a
+    propagated HTTP status). Same unwrap contract as ``ToolError``."""
+    chain = _raise_chain(OllieStreamError("stream died"), inner)
+    assert bucket_exception(chain) == expected_bucket
+    assert derive_http_status(chain) == expected_status
+
+
+def test_bucket_exception_unwraps_http_status_error_through_wrapper() -> None:
+    """``httpx.HTTPStatusError`` is bucketed by wire status. When wrapped
+    in a ToolError, that wire status must still be recovered."""
+    request = httpx.Request("GET", "https://example.invalid/")
+    response = httpx.Response(429, request=request)
+    inner = httpx.HTTPStatusError("rate-limited", request=request, response=response)
+    chain = _raise_chain(ToolError("rate limited"), inner)
+    # 429 → 4xx that isn't auth/permission/not-found/timeout → validation.
+    assert bucket_exception(chain) == "validation"
+    assert derive_http_status(chain) == 429
+
+
+def test_bucket_exception_bare_tool_error_stays_unknown() -> None:
+    """A ``ToolError`` raised without a cause (the few legitimate cases in
+    read_tool.py — e.g. ``raise ToolError(_format_ambiguous(...))``) has no
+    upstream to surface. Bucket stays ``unknown`` — same as before this
+    unwrap was added, so dashboards still flag these as real protocol-bug
+    candidates rather than silently routing them somewhere wrong."""
+    assert bucket_exception(ToolError("bare")) == "unknown"
+    assert derive_http_status(ToolError("bare")) is None
+
+
+def test_bucket_exception_bare_ollie_stream_error_stays_unknown() -> None:
+    """Parallel to the bare-ToolError case — bare ``OllieStreamError``
+    (e.g. ``ollie_client.py:132`` "POST /sessions returned no session_id")
+    has no upstream cause and stays ``unknown``."""
+    assert bucket_exception(OllieStreamError("no session_id")) == "unknown"
+    assert derive_http_status(OllieStreamError("no session_id")) is None
+
+
+def test_bucket_exception_unwrap_does_not_read_message() -> None:
+    """Privacy regression guard: even with the new ``__cause__`` walk, the
+    classifier must not start sniffing exception messages. Plant a wrapper
+    whose message would suggest 'auth' if anyone string-matched, and
+    confirm the bucket still comes from the (unrelated) cause class."""
+    chain = _raise_chain(
+        ToolError("401 unauthorized permission denied"),
+        ValueError("would-be-unknown"),
+    )
+    assert bucket_exception(chain) == "unknown"

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -207,6 +207,65 @@ def test_bucket_exception_caller_supplied_status_wins_for_neutral_class() -> Non
     assert bucket_exception(RuntimeError("x"), http_status=503) == "upstream_5xx"
 
 
+# --- ClassVar contract --------------------------------------------------- #
+#
+# Each typed exception class owns its ``error_kind`` / ``http_status`` as a
+# ClassVar. These tests pin the contract directly so a future class that
+# forgets the attribute (or sets the wrong type) regresses the bucketing
+# surface in a localized, easy-to-read failure rather than a downstream
+# test that just says "expected auth, got unknown".
+
+
+_TYPED_EXCEPTION_CLASSES: tuple[tuple[type[BaseException], str, int | None], ...] = (
+    (OpikAuthError, "auth", 401),
+    (OpikPermissionError, "permission", 403),
+    (OpikNotFoundError, "not_found", 404),
+    (OpikValidationError, "validation", 400),
+    (OpikServerError, "upstream_5xx", 500),
+    (CometAuthError, "auth", 401),
+    (CometPermissionError, "permission", 403),
+    (OllieAuthError, "auth", None),
+    (OllieStreamError, "unknown", None),
+    (OllieNotEnabledError, "unknown", None),
+    (CometProtocolError, "unknown", None),
+    (PodNotReadyError, "timeout", None),
+    (MissingConfigError, "unknown", None),
+)
+
+
+@pytest.mark.parametrize("cls, expected_kind, expected_status", _TYPED_EXCEPTION_CLASSES)
+def test_typed_exception_classvars_define_bucket_and_status(
+    cls: type[BaseException], expected_kind: str, expected_status: int | None
+) -> None:
+    """Every typed exception class declares its bucket + status as ClassVars.
+
+    This is what lets ``bucket_exception`` use ``getattr(type(exc), ...)``
+    instead of a cascade. A regression here (forgotten attribute, typo in
+    the bucket name) localizes the failure to the exception class itself.
+    """
+    assert cls.error_kind == expected_kind, (  # type: ignore[attr-defined]
+        f"{cls.__name__}.error_kind should be {expected_kind!r}"
+    )
+    assert cls.http_status == expected_status, (  # type: ignore[attr-defined]
+        f"{cls.__name__}.http_status should be {expected_status!r}"
+    )
+
+
+def test_subclass_classvar_shadows_parent() -> None:
+    """``OpikPermissionError`` extends ``OpikAuthError`` — the subclass's
+    ClassVar shadows the parent so analytics returns ``"permission"`` for
+    the 403 case. This pins the load-bearing inheritance behavior."""
+    # Sanity-check Python's attribute resolution does the right thing.
+    assert OpikPermissionError.error_kind == "permission"
+    assert OpikAuthError.error_kind == "auth"
+    # Same for http_status.
+    assert OpikPermissionError.http_status == 403
+    assert OpikAuthError.http_status == 401
+    # And — most importantly — the bucketing surface honors the override.
+    assert bucket_exception(OpikPermissionError("x")) == "permission"
+    assert derive_http_status(OpikPermissionError("x")) == 403
+
+
 def test_bucket_exception_never_reads_args_or_str() -> None:
     """The PRIVACY contract: ``bucket_exception`` must be class-only — the
     coarse bucket cannot depend on free-form message text. Smuggle a payload

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -419,6 +419,56 @@ async def test_tool_called_failure_unknown_class_uses_class_name_only(
     assert "http_status" not in props
 
 
+@pytest.mark.anyio
+async def test_tool_called_cause_type_is_class_only(
+    recorder: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Production raise site: ``read_tool.py`` wraps every upstream failure as
+    ``raise ToolError(...) from <typed exc>``. The new ``cause_type`` prop
+    must carry the leaf class name and NOTHING from either the wrapper's
+    user-facing message OR the cause's exception message — both are tested
+    here with distinct canaries so a regression in either path fails loudly.
+
+    This is the privacy guard for the unwrap-to-real-cause change. Without
+    this test, a future refactor that started reading ``str(real)`` /
+    ``real.args`` could silently exfiltrate exception messages into BI."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    from opik_mcp import server
+    from opik_mcp.opik_client import OpikAuthError
+
+    wrapper_canary = "tool-error-wrapper-msg-UNIQUE-CANARY-1f2e3d4c"
+    cause_canary = "opik-auth-cause-msg-UNIQUE-CANARY-5b6a7980"
+
+    async def _raise(**_kw: Any) -> str:
+        try:
+            raise OpikAuthError(cause_canary)
+        except OpikAuthError as e:
+            raise ToolError(wrapper_canary) from e
+
+    monkeypatch.setattr("opik_mcp.server.run_read", _raise)
+
+    with pytest.raises(ToolError):
+        await server.read(entity_type="project", id="00000000-0000-0000-0000-000000000001")
+
+    payload = json.dumps(recorder.events)
+    assert wrapper_canary not in payload, (
+        f"PRIVACY BREACH: ToolError message {wrapper_canary!r} leaked into analytics"
+    )
+    assert cause_canary not in payload, (
+        f"PRIVACY BREACH: cause message {cause_canary!r} leaked into analytics"
+    )
+    props = _tool_called(recorder.events)
+    # exception_type captures the wrapper (where in our code the failure
+    # surfaced); cause_type captures the leaf (what actually broke).
+    assert props["exception_type"] == "ToolError"
+    assert props["cause_type"] == "OpikAuthError"
+    # Unwrap routing kicks in — auth bucket comes from the cause, not the
+    # opaque ToolError wrapper.
+    assert props["error_kind"] == "auth"
+    assert props["http_status"] == "401"
+
+
 class _CanaryOllieClient:
     """``_OllieClientProto`` fake that fires an SSE ``error`` frame whose
     ``message`` field is a unique canary. Used to verify the pod's error

--- a/tests/test_analytics_wrappers.py
+++ b/tests/test_analytics_wrappers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 import pytest
+from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
@@ -700,3 +701,231 @@ async def test_sentry_capture_survives_props_fn_failure(
     # Wrapper-provided tags still land.
     assert tags["tool_name"] == "read"
     assert tags["error_kind"] == "upstream_5xx"
+
+
+# --- Wrapper-exception unwrap (the real production shape) ---------------- #
+#
+# Every read/list/write tool in this codebase ends a failure with:
+#     raise ToolError(_format_client_error(...)) from e
+# Until the analytics classifier learned to unwrap, every one of these
+# events showed up in BI as "unknown / ToolError" — masking auth, not_found,
+# upstream_5xx, and timeout patterns indiscriminately. These tests pin the
+# end-to-end contract through the decorator surface (not just the bucket
+# helper) so a regression that drops the unwrap fails close to production.
+
+
+def _wrap_with_cause(wrapper: Exception, inner: Exception) -> Exception:
+    """Materialize ``raise wrapper from inner`` and return the caught wrapper.
+
+    Mirrors the shape every tool's error path produces in production. Using
+    a real ``raise ... from`` (vs. setting ``__cause__`` by hand) keeps the
+    test honest about ``__suppress_context__`` and the implicit context slot.
+    """
+    try:
+        raise wrapper from inner
+    except Exception as e:
+        return e
+
+
+@pytest.mark.parametrize(
+    "inner, expected_kind, expected_status",
+    [
+        # The full Phase-1 taxonomy, repeated through a ToolError wrapper.
+        # If any cell here regresses to "unknown" the unwrap is broken.
+        (OpikAuthError("x"), "auth", 401),
+        (OpikPermissionError("x"), "permission", 403),
+        (OpikNotFoundError("x"), "not_found", 404),
+        (OpikValidationError("x"), "validation", 400),
+        (OpikServerError("x"), "upstream_5xx", 500),
+        (CometAuthError("x"), "auth", 401),
+        (CometPermissionError("x"), "permission", 403),
+        (PodNotReadyError("x"), "timeout", None),
+        (httpx.ReadTimeout("x"), "timeout", None),
+        (httpx.ConnectError("x"), "network", None),
+        (OllieAuthError("x"), "auth", None),
+        # MissingConfigError stays "unknown" — but the Sentry skip-list still
+        # has to recognize it through the wrapper (covered separately below).
+        (MissingConfigError("x"), "unknown", None),
+    ],
+)
+@pytest.mark.anyio
+async def test_tool_error_wrapper_unwraps_to_real_cause(
+    recorder: _Recorder,
+    inner: Exception,
+    expected_kind: str,
+    expected_status: int | None,
+) -> None:
+    """A ``ToolError`` carrying a real cause must surface the cause's bucket
+    + status, while ``exception_type`` keeps the wrapper class (where in our
+    code the failure surfaced) and ``cause_type`` carries the leaf class
+    (what actually broke). Both pieces are needed to split dashboards by
+    "which tool boundary" AND "which upstream"."""
+    wrapper = ToolError("user-facing error message")
+
+    @instrument_tool("read")
+    async def fn() -> str:
+        raise _wrap_with_cause(wrapper, inner)
+
+    with pytest.raises(ToolError):
+        await fn()
+
+    _, props = recorder.events[0]
+    assert props["success"] == "false"
+    assert props["error_kind"] == expected_kind
+    # Wrapper class preserved — tells dashboards "this came through a tool
+    # boundary" rather than escaping from somewhere unexpected.
+    assert props["exception_type"] == "ToolError"
+    # Cause class preserved — the actual upstream class.
+    assert props["cause_type"] == type(inner).__name__
+    if expected_status is None:
+        assert "http_status" not in props
+    else:
+        assert props["http_status"] == str(expected_status)
+
+
+@pytest.mark.anyio
+async def test_bare_tool_error_emits_no_cause_type(recorder: _Recorder) -> None:
+    """A ``ToolError`` raised standalone (e.g. ``read_tool.py`` formatting an
+    ambiguous-ID hint) has nothing to unwrap. ``error_kind`` stays
+    ``"unknown"`` — same as pre-unwrap — and ``cause_type`` is absent."""
+
+    @instrument_tool("read")
+    async def fn() -> str:
+        raise ToolError("no cause")
+
+    with pytest.raises(ToolError):
+        await fn()
+
+    _, props = recorder.events[0]
+    assert props["error_kind"] == "unknown"
+    assert props["exception_type"] == "ToolError"
+    # No cause means no cause_type — the prop is only emitted when the
+    # unwrap actually finds a distinct upstream.
+    assert "cause_type" not in props
+
+
+@pytest.mark.anyio
+async def test_tool_error_wrapping_http_status_error_routes_by_wire_status(
+    recorder: _Recorder,
+) -> None:
+    """``httpx.HTTPStatusError`` carries the wire status on its response, not
+    a typed class. Through the wrapper that lookup must still happen so a
+    422 lands in ``validation`` and not ``unknown``."""
+    request = httpx.Request("GET", "https://example.invalid/")
+    response = httpx.Response(422, request=request)
+    inner = httpx.HTTPStatusError("unprocessable", request=request, response=response)
+
+    @instrument_tool("write")
+    async def fn() -> str:
+        raise _wrap_with_cause(ToolError("payload rejected"), inner)
+
+    with pytest.raises(ToolError):
+        await fn()
+
+    _, props = recorder.events[0]
+    assert props["error_kind"] == "validation"
+    assert props["http_status"] == "422"
+    assert props["exception_type"] == "ToolError"
+    assert props["cause_type"] == "HTTPStatusError"
+
+
+@pytest.mark.anyio
+async def test_ollie_stream_error_unwraps_to_upstream_cause(recorder: _Recorder) -> None:
+    """``OllieStreamError`` is raised both as a leaf and as a wrapper around
+    upstream HTTP failures (``ollie_client.py`` raising from a 404; pod error
+    SSE frames carrying an HTTP cause). Wrapped case must route by cause."""
+
+    @instrument_tool("ask_ollie")
+    async def fn() -> str:
+        raise _wrap_with_cause(OllieStreamError("stream died"), OpikServerError("upstream 500"))
+
+    with pytest.raises(OllieStreamError):
+        await fn()
+
+    _, props = recorder.events[0]
+    assert props["error_kind"] == "upstream_5xx"
+    assert props["http_status"] == "500"
+    assert props["exception_type"] == "OllieStreamError"
+    assert props["cause_type"] == "OpikServerError"
+
+
+# --- Sentry routing follows the unwrapped cause -------------------------- #
+
+
+@pytest.mark.parametrize(
+    "inner",
+    [
+        # The full user-side allowlist — every one must skip Sentry even
+        # when transported through a ToolError envelope (which is how they
+        # actually arrive in production from read/list/write tools).
+        OpikAuthError("x"),
+        OpikPermissionError("x"),
+        OpikValidationError("x"),
+        OpikNotFoundError("x"),
+        CometAuthError("x"),
+        CometPermissionError("x"),
+        OllieAuthError("x"),
+        # Class-level user-side skip via _USER_SIDE_EXCEPTIONS. Pre-unwrap
+        # the isinstance check ran against the wrapper class and failed open
+        # — Sentry got paged for every MissingConfigError-via-ToolError.
+        MissingConfigError("x"),
+        OllieNotEnabledError("x"),
+    ],
+)
+@pytest.mark.anyio
+async def test_sentry_skips_user_side_failures_through_tool_error_wrapper(
+    sentry_recorder: _SentryRecorder, inner: Exception
+) -> None:
+    """Production read/list/write tools always wrap. The Sentry skip-list
+    used to run isinstance against the wrapper (always False) — so every
+    user-side failure paged Sentry. After the unwrap, the check runs on the
+    real cause and the skip applies as designed."""
+
+    @instrument_tool("read")
+    async def fn() -> str:
+        raise _wrap_with_cause(ToolError("user-facing"), inner)
+
+    with pytest.raises(ToolError):
+        await fn()
+
+    assert sentry_recorder.calls == [], (
+        f"user-side {type(inner).__name__}-via-ToolError must not page Sentry"
+    )
+
+
+@pytest.mark.parametrize(
+    "inner, expected_kind",
+    [
+        # Server-side bugs and infra failures — Sentry's intended payload.
+        # Each one is the wrapped equivalent of the bare-cause tests above.
+        (OpikServerError("x"), "upstream_5xx"),
+        (PodNotReadyError("x"), "timeout"),
+        (httpx.ConnectError("x"), "network"),
+        (CometProtocolError("x"), "unknown"),
+        # An unexpected RuntimeError carrying nothing typed — the classic
+        # "real bug" shape. Even through a wrapper, must reach Sentry.
+        (RuntimeError("unexpected"), "unknown"),
+    ],
+)
+@pytest.mark.anyio
+async def test_sentry_captures_non_user_side_failures_through_tool_error_wrapper(
+    sentry_recorder: _SentryRecorder, inner: Exception, expected_kind: str
+) -> None:
+    """The mirror of the skip test: causes that aren't user-side still
+    page Sentry through a wrapper. ``error_kind`` reflects the unwrapped
+    cause; the captured exception is the wrapper (so the Sentry stack trace
+    shows the chain Python rendered)."""
+
+    @instrument_tool("read")
+    async def fn() -> str:
+        raise _wrap_with_cause(ToolError("user-facing"), inner)
+
+    with pytest.raises(ToolError):
+        await fn()
+
+    assert len(sentry_recorder.calls) == 1
+    captured_exc, tags, _extras, _transaction, _fingerprint = sentry_recorder.calls[0]
+    # The wrapper goes to Sentry (its chain renders the cause in the trace).
+    assert isinstance(captured_exc, ToolError)
+    # But the bucket tag reflects the unwrapped cause.
+    assert tags["error_kind"] == expected_kind

--- a/tests/test_ask_ollie_analytics.py
+++ b/tests/test_ask_ollie_analytics.py
@@ -9,7 +9,8 @@ from opik_mcp.analytics import EVENT_ASK_OLLIE_COMPLETED
 from opik_mcp.ask_ollie import run_ask_ollie
 from opik_mcp.comet_client import CometAuthError, PodDiscovery
 from opik_mcp.config import Settings
-from opik_mcp.ollie_client import OllieAuthError, PodNotReadyError, SSEEvent
+from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError, SSEEvent
+from opik_mcp.opik_client import OpikAuthError, OpikServerError
 
 
 @pytest.fixture
@@ -158,6 +159,94 @@ async def test_create_session_auth_failure_emits_completed_error(recorder: _Reco
     assert int(p["pod_warmup_ms"]) >= 0
 
 
+def _raise_wrapper_with_cause(wrapper: Exception, cause: Exception) -> Exception:
+    """Materialize ``raise wrapper from cause`` and return the caught wrapper.
+
+    Mirrors what ``ollie_client.py`` and ``ask_ollie.py`` do at every SSE
+    error frame and HTTP error — using a real ``raise … from`` keeps the
+    ``__cause__`` / ``__suppress_context__`` slots set the way Python does.
+    """
+    try:
+        raise wrapper from cause
+    except Exception as e:
+        return e
+
+
+@pytest.mark.anyio
+async def test_ollie_stream_error_wrapping_upstream_5xx_unwraps_to_cause(
+    recorder: _Recorder,
+) -> None:
+    """Production shape: the pod surfaces an upstream 500 as an ``error`` SSE
+    frame; ``ask_ollie.py`` raises ``OllieStreamError`` with the real cause
+    chained. The analytics emit must bucket by the cause (``upstream_5xx``)
+    and stash both the wrapper class name (``OllieStreamError`` — where in our
+    code the failure surfaced) and the leaf class (``OpikServerError`` — what
+    actually broke)."""
+    chained = _raise_wrapper_with_cause(
+        OllieStreamError("pod error frame"),
+        OpikServerError("backend exploded"),
+    )
+    comet = AsyncMock()
+    comet.discover_pod.side_effect = chained
+    ollie = AsyncMock()
+
+    with pytest.raises(OllieStreamError):
+        await _run_with(comet, ollie, recorder)
+
+    completed = [p for et, p in recorder.events if et == EVENT_ASK_OLLIE_COMPLETED]
+    assert len(completed) == 1
+    p = completed[0]
+    assert p["success"] == "false"
+    assert p["error_kind"] == "upstream_5xx"
+    assert p["exception_type"] == "OllieStreamError"
+    assert p["cause_type"] == "OpikServerError"
+
+
+@pytest.mark.anyio
+async def test_bare_ollie_stream_error_emits_no_cause_type(recorder: _Recorder) -> None:
+    """A bare ``OllieStreamError`` (e.g. ``ollie_client.py:132`` raising
+    'POST /sessions returned no session_id') has no upstream cause. The
+    bucket stays ``unknown`` — same as pre-unwrap — and ``cause_type`` is
+    absent, signalling 'no recoverable upstream' to dashboards rather than
+    misleading them with a leaf class that wasn't really the failure."""
+    comet = AsyncMock()
+    comet.discover_pod.side_effect = OllieStreamError("no session_id")
+    ollie = AsyncMock()
+
+    with pytest.raises(OllieStreamError):
+        await _run_with(comet, ollie, recorder)
+
+    completed = [p for et, p in recorder.events if et == EVENT_ASK_OLLIE_COMPLETED]
+    p = completed[0]
+    assert p["error_kind"] == "unknown"
+    assert p["exception_type"] == "OllieStreamError"
+    assert "cause_type" not in p
+
+
+@pytest.mark.anyio
+async def test_ollie_stream_error_wrapping_auth_unwraps_to_cause(recorder: _Recorder) -> None:
+    """A realistic mid-stream failure: PPAUTH expires between session create
+    and stream start, surfacing as ``OllieStreamError from OpikAuthError``.
+    Must route to ``auth`` so dashboards page the user-config gauge, not the
+    server-bug gauge."""
+    chained = _raise_wrapper_with_cause(
+        OllieStreamError("stream rejected mid-flight"),
+        OpikAuthError("ppauth expired"),
+    )
+    comet = AsyncMock()
+    comet.discover_pod.side_effect = chained
+    ollie = AsyncMock()
+
+    with pytest.raises(OllieStreamError):
+        await _run_with(comet, ollie, recorder)
+
+    completed = [p for et, p in recorder.events if et == EVENT_ASK_OLLIE_COMPLETED]
+    p = completed[0]
+    assert p["error_kind"] == "auth"
+    assert p["exception_type"] == "OllieStreamError"
+    assert p["cause_type"] == "OpikAuthError"
+
+
 @pytest.mark.anyio
 async def test_host_cancellation_emits_cancelled_state(recorder: _Recorder) -> None:
     """Host-level CancelledError (injected from outside the task group) must be
@@ -176,3 +265,48 @@ async def test_host_cancellation_emits_cancelled_state(recorder: _Recorder) -> N
     p = completed[0]
     assert p["completion_state"] == "cancelled"
     assert p["success"] == "true"  # cancellation is not an error
+
+
+@pytest.mark.anyio
+async def test_stream_loop_wrapped_failure_preserves_cause_chain(
+    recorder: _Recorder,
+) -> None:
+    """Production raise site: ``ollie_client.stream_events`` raises
+    ``OllieStreamError from OpikAuthError`` from inside the anyio task group.
+    The BaseExceptionGroup unwrap at ask_ollie.py:615 used to re-raise with
+    ``from None`` which clobbered ``__cause__`` — making every wrapped
+    failure look like ``unknown / OllieStreamError`` in BI.
+
+    This pins the corrected behavior: the cause chain MUST survive the
+    task-group unwrap so analytics can route on the leaf class."""
+    comet = AsyncMock()
+    comet.discover_pod.return_value = PodDiscovery(compute_url="http://c", ppauth="p")
+    ollie = AsyncMock()
+    ollie.create_session.return_value = "sess-1"
+
+    async def _stream(*_a: Any, **_kw: Any) -> AsyncIterator[SSEEvent]:
+        # Yield once so the loop enters; then raise the production-shape
+        # chained exception. The raise happens INSIDE the task group, so
+        # anyio wraps it in a BaseExceptionGroup — that's the path we need
+        # to exercise to verify the cause-preservation fix.
+        yield SSEEvent(event="message_delta", data={"payload": {"delta": "hi"}})
+        try:
+            raise OpikAuthError("ppauth expired mid-stream")
+        except OpikAuthError as inner:
+            raise OllieStreamError("stream rejected") from inner
+
+    ollie.stream_events = _stream
+
+    with pytest.raises(OllieStreamError):
+        await _run_with(comet, ollie, recorder)
+
+    completed = [p for et, p in recorder.events if et == EVENT_ASK_OLLIE_COMPLETED]
+    assert len(completed) == 1
+    p = completed[0]
+    # The whole point of preserving __cause__: a wrapped auth failure must
+    # bucket as "auth" (so dashboards flag a user-config issue), not the
+    # opaque "unknown" the bug used to produce.
+    assert p["error_kind"] == "auth"
+    assert p["exception_type"] == "OllieStreamError"
+    assert p["cause_type"] == "OpikAuthError"
+    assert p["success"] == "false"


### PR DESCRIPTION
## Summary

BI was bucketing ~95% of tool failures and ~55% of ask_ollie errors as `unknown / ToolError` or `unknown / OllieStreamError` because the classifier only inspected the top-level exception class. Production raise sites universally wrap real upstream causes:
- `read_tool.py:179`, `list_tool.py:80`, `write_tool.py:55` — `raise ToolError(...) from <typed exc>`
- `ollie_client.py:161`, `ask_ollie.py:511/568/595` — `raise OllieStreamError(...) from <typed exc>`

The wrapper class — not the real cause — was driving the bucket, masking auth/not_found/upstream_5xx patterns in dashboards.

### Fixes

- **`analytics/errors.py`**: new `unwrap_to_real_cause` walks `__cause__` / `__context__` through a small allowlist (`ToolError`, `OllieStreamError`). Bounded depth + cycle guard. `bucket_exception` and `derive_http_status` unwrap before routing.
- **`analytics/wrappers.py`**: emits a new `cause_type` prop alongside `exception_type`. Wrapper class is where the failure surfaced; cause class is what actually broke. Sentry tags pick up `cause_type` too so issue triage can split on the leaf. User-side skip-list now runs on the unwrapped cause so `ToolError` wrapping `MissingConfigError` is recognized as user-config and not paged.
- **`ask_ollie.py`**: emits `cause_type` on the completed event. Also drops the `from None` on the BaseExceptionGroup re-raise — it was clobbering the inner `__cause__` chain, so mid-stream `OllieStreamError from OpikAuthError` was reaching the analytics emit with no cause to walk.

### Privacy

Class-only throughout — never reads `exc.args` / `str(exc)`. The unwrap inspects `__cause__` / `__context__` references, not their messages. Pinned by `test_tool_called_cause_type_is_class_only` with distinct canaries on both the wrapper and the cause messages.

## Test plan
- [x] `unwrap_to_real_cause` unit tests: cause vs context, suppress_context, cycle, max_depth, multi-layer
- [x] Parametrized `bucket_exception` matrix pumping every typed cause through `ToolError` and `OllieStreamError` wrappers (`test_bucket_exception_unwraps_tool_error`, `test_bucket_exception_unwraps_ollie_stream_error`)
- [x] Bare wrapper (no cause) still buckets as `unknown` — preserves prior behavior for legitimate leaf-wrapper cases
- [x] End-to-end through the `@instrument_tool` decorator: `cause_type` emitted, Sentry routing respects unwrapped cause
- [x] `ask_ollie` production-shape tests: chained `OllieStreamError from OpikAuthError`, bare `OllieStreamError`, `ToolError` wrappers
- [x] **SSE-loop test** exercising the `BaseExceptionGroup` unwrap path (the raise site the `from None` regression actually affected): asserts `error_kind=auth`, `cause_type=OpikAuthError`
- [x] Privacy guard: distinct canaries on wrapper + cause messages, neither leaks into recorded analytics
- [x] `820 tests pass, 2 skipped`; `ruff check` clean; `ruff format --check` clean; `mypy` clean across 91 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)