### PR TITLE
chore(release): bump version to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opik-mcp"
-version = "0.1.4"
+version = "0.1.5"
 description = "Model Context Protocol server for Opik (Comet's LLM observability platform)."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "opik-mcp"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Release PR for v0.1.5. Bundles one fix landed since 0.1.4:

### #127 — `error_kind` bucketing unwraps wrappers and reads ClassVars

`tool_called` and `ask_ollie_completed` were collapsing real upstream failures into `"unknown"` whenever the cause was hidden behind an `OllieStreamError`, a FastMCP `ToolError`, or a `BaseExceptionGroup` from `asyncio.TaskGroup`. `bucket_exception` now walks `__cause__` / `__context__` (bounded depth, cycle-safe) to the root exception before classifying, and emits a `cause_type` BI property so the wrapper class stays visible.

Refactor follow-up (originally #128, squashed into the same branch): each typed exception class now owns its `error_kind` and `http_status` as `ClassVar`s, so the taxonomy lives next to the class definition instead of in a parallel `isinstance` table in `analytics/errors.py`. Adding a new typed exception is now a one-line `ClassVar` instead of editing the analytics module.

Privacy contract preserved — bucketing is still class-only, never reads `exc.args` / `str(exc)`. Sentry tag mirrors the new `cause_type` property.

## BI receiver impact

`tool_called` and `ask_ollie_completed` gain a `cause_type` property (string class name, low cardinality). Existing `error_kind` values are unchanged — only their accuracy improves (wrapped failures now land in the right bucket instead of `"unknown"`).

## Test plan

- [ ] `uv run pytest` — clean
- [ ] `uv run ruff check` + `ruff format --check` — clean
- [ ] `uv run mypy` — clean
- [ ] After merge: tag \`py-v0.1.5\`, push tag, trigger PyPI release manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)