### PR TITLE
feat(analytics): close error-bucketing gaps across write/read/list/URI surfaces

### DIFF
--- a/src/opik_mcp/analytics/errors.py
+++ b/src/opik_mcp/analytics/errors.py
@@ -34,6 +34,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from opik_mcp.error_kinds import ErrorKind
 from opik_mcp.ollie_client import OllieStreamError
+from opik_mcp.writes.errors import BackendError
 
 # Re-export so existing call sites (and downstream readers) keep their
 # ``from opik_mcp.analytics.errors import ErrorKind`` import working.
@@ -122,19 +123,47 @@ def _class_attr(exc: BaseException, name: str) -> Any:
     return value
 
 
+def _instance_http_status(real: BaseException) -> int | None:
+    """Return the upstream HTTP status for classes that carry it on the
+    instance, else ``None``.
+
+    Two classes need this instance-level read:
+    - ``httpx.HTTPStatusError``: status on ``.response.status_code``. Third
+      party, can't add a ClassVar.
+    - ``BackendError`` (write tool): status on ``.extra["backend_error"]
+      ["status"]``. Ours, but each instance wraps a different upstream
+      status — a ClassVar would lock the bucket to one value.
+
+    Treating them as the same pattern lets ``bucket_exception`` route both
+    via the same arm before any ClassVar lookup.
+
+    PRIVACY: integer-only instance reads, parallel to one another. No
+    message text or response body is inspected.
+    """
+    if isinstance(real, httpx.HTTPStatusError):
+        return real.response.status_code
+    if isinstance(real, BackendError):
+        status = real.extra.get("backend_error", {}).get("status")
+        if isinstance(status, int):
+            return status
+    return None
+
+
 def derive_http_status(exc: BaseException) -> int | None:
     """Return the canonical HTTP status for a typed exception, else ``None``.
 
-    Reads ``type(exc).http_status`` — the ClassVar each typed Opik/Comet/
-    Ollie exception declares. ``httpx.HTTPStatusError`` is handled
-    specially because the status lives on the response, not the class.
-
-    Unwraps through pure-envelope wrappers (``ToolError``, ``OllieStreamError``)
-    so a ``ToolError`` carrying an ``OpikAuthError`` still resolves to 401.
+    Resolution order:
+    1. Unwrap pure-envelope wrappers (``ToolError`` / ``OllieStreamError``)
+       to the real cause.
+    2. Try the instance-level status (``_instance_http_status``) — httpx
+       responses and ``BackendError.extra`` both vary per call.
+    3. Fall back to ``type(real).http_status`` (the ClassVar each typed
+       Opik/Comet/Ollie/Write exception declares).
     """
     real = unwrap_to_real_cause(exc)
-    if isinstance(real, httpx.HTTPStatusError):
-        return real.response.status_code
+    instance_status = _instance_http_status(real)
+    if instance_status is not None:
+        return instance_status
     status = _class_attr(real, "http_status")
     return status if isinstance(status, int) else None
 
@@ -160,10 +189,13 @@ def bucket_http_status(status: int) -> ErrorKind:
     return "unknown"
 
 
-# Buckets for non-controllable classes we can't put a ClassVar on. Ordered
-# subclass-first by virtue of how the function reads them. ``httpx`` is the
-# only third-party hierarchy we route on; pydantic gets a single match.
 def _bucket_external(real: BaseException) -> ErrorKind | None:
+    """Bucket external classes we can't annotate with ClassVars.
+
+    Status-bearing classes (``httpx.HTTPStatusError``, ``BackendError``) are
+    handled earlier in ``bucket_exception`` via ``_instance_http_status``; by
+    the time control reaches here, ``real`` is a non-status external class.
+    """
     if isinstance(real, PydanticValidationError):
         return "validation"
     # ``httpx.TimeoutException`` is the base for connect/read/write/pool
@@ -171,8 +203,6 @@ def _bucket_external(real: BaseException) -> ErrorKind | None:
     # ``ReadTimeout`` lands in ``timeout``, not ``network``.
     if isinstance(real, httpx.TimeoutException):
         return "timeout"
-    if isinstance(real, httpx.HTTPStatusError):
-        return bucket_http_status(real.response.status_code)
     if isinstance(real, httpx.RequestError):
         return "network"
     return None
@@ -184,22 +214,27 @@ def bucket_exception(exc: BaseException, http_status: int | None = None) -> Erro
     Resolution order:
     1. Unwrap pure-envelope wrappers (``ToolError`` / ``OllieStreamError``)
        to the real upstream cause.
-    2. Read ``type(real).error_kind`` if our codebase declared one (every
-       typed Opik/Comet/Ollie/Pod/Config exception does).
-    3. Special-case external hierarchies we can't annotate
-       (``httpx`` / ``pydantic``).
-    4. Caller-supplied ``http_status`` (lets a future tool surface a 422-
+    2. Instance-level status (``_instance_http_status``) — httpx responses
+       and ``BackendError`` carry the status on instance state that varies
+       per call; this arm runs BEFORE the ClassVar lookup so the per-call
+       status wins over any class-level fallback.
+    3. Class-level taxonomy (``type(real).error_kind``) — every typed
+       Opik/Comet/Ollie/Write exception declares this ClassVar.
+    4. Special-case external hierarchies we can't annotate (``pydantic``,
+       non-status ``httpx`` errors).
+    5. Caller-supplied ``http_status`` (lets a future tool surface a 422-
        style validation error via return value rather than raise).
-    5. Fall through to ``"unknown"``.
+    6. Fall through to ``"unknown"``.
 
-    PRIVACY: never reads ``exc.args`` / ``str(exc)``. The ``getattr`` reads
-    a class-level ClassVar; the unwrap inspects ``__cause__`` / ``__context__``
-    references, not their messages.
+    PRIVACY: never reads ``exc.args`` / ``str(exc)``. The ClassVar read is
+    class-level; the instance-status read is integer-only and the unwrap
+    inspects ``__cause__`` / ``__context__`` references, not their messages.
     """
     real = unwrap_to_real_cause(exc)
+    instance_status = _instance_http_status(real)
+    if instance_status is not None:
+        return bucket_http_status(instance_status)
     kind = _class_attr(real, "error_kind")
-    # The ClassVar is bound to ``ErrorKind`` (a Literal) in every declaring
-    # class, so a string at this point IS one of the allowlist values.
     if isinstance(kind, str):
         return kind  # type: ignore[return-value]
     external = _bucket_external(real)

--- a/src/opik_mcp/analytics/errors.py
+++ b/src/opik_mcp/analytics/errors.py
@@ -19,9 +19,11 @@ We still need special-case branches for:
   ``httpx.HTTPStatusError`` (status comes from the response), other
   ``httpx`` network errors, and ``pydantic.ValidationError``.
 
-PRIVACY: every public function in this module keys off the exception CLASS
-only — never on ``exc.args`` / ``str(exc)`` / response body. The contract
-is machine-checked by ``tests/test_analytics_privacy.py``.
+PRIVACY: public functions never read ``exc.args`` / ``str(exc)`` / response
+body. Classification is class-level (ClassVar reads) plus a tightly-scoped
+whitelist of integer-only instance fields: ``httpx.Response.status_code``
+and ``BackendError.extra["backend_error"]["status"]``. The contract is
+machine-checked by ``tests/test_analytics_privacy.py``.
 """
 
 from __future__ import annotations
@@ -118,6 +120,7 @@ def _class_attr(exc: BaseException, name: str) -> Any:
     set as ``ClassVar``. Avoids accidentally treating a stray instance attr
     (potentially smuggled in from user-controlled data on some future class)
     as a taxonomy signal.
+    (Instance reads are handled separately by ``_instance_http_status``.)
     """
     value = getattr(type(exc), name, None)
     return value

--- a/src/opik_mcp/read_list/errors.py
+++ b/src/opik_mcp/read_list/errors.py
@@ -1,0 +1,40 @@
+"""Typed exceptions for read / list tool argument validation.
+
+The read / list tools surface user-input mistakes (unknown entity_type,
+missing parent id, list-only entity used with ``read``) as ``ToolError``
+to the MCP host. Pre-taxonomy those raises were bare — no cause chain —
+so the analytics wrapper bucketed them as ``unknown / ToolError``.
+
+``EntityArgValidationError`` is the typed cause that every such raise site
+now chains through (``raise ToolError(str(err)) from err``). It owns the
+``"validation"`` / 400 ClassVars so ``analytics/errors.bucket_exception``
+can route the bucket via ``getattr(type(real), "error_kind")``.
+
+We deliberately keep this as a single coarse class rather than per-failure-
+mode subclasses: the validation surface is small and stable, every case
+answers the same dashboard question ("the caller passed something the tool
+can't handle"), and BI's ``cause_type`` already carries the wrapper class
+for triage. Future divergence (e.g. a distinct ``entity_not_listable``
+bucket) can split the class then; YAGNI today.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from opik_mcp.error_kinds import ErrorKind
+
+
+class EntityArgValidationError(Exception):
+    """Caller passed a read/list argument that doesn't validate.
+
+    Raise this as the typed cause of the ``ToolError`` that surfaces the
+    failure to the host. The analytics wrapper unwraps the ToolError → this
+    class via ``__cause__`` and reads the ClassVars to bucket the event.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "validation"
+    http_status: ClassVar[int | None] = 400
+
+
+__all__ = ["EntityArgValidationError"]

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -26,6 +26,7 @@ from opik_mcp.opik_client import (
     OpikValidationError,
     make_opik_client,
 )
+from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, EntityHandler
 
 logger = logging.getLogger("opik_mcp.read_list.list")
@@ -50,7 +51,8 @@ async def run_list(
     handler = ENTITY_REGISTRY.get(entity_type)
     if handler is None or handler.list_fn is None:
         valid = ", ".join(sorted(LISTABLE_TYPES))
-        raise ToolError(f"Cannot list {entity_type!r}. Listable types: {valid}")
+        err = EntityArgValidationError(f"Cannot list {entity_type!r}. Listable types: {valid}")
+        raise ToolError(str(err)) from err
 
     size = max(1, min(size, _MAX_SIZE))
     page = max(1, page)
@@ -67,10 +69,11 @@ async def run_list(
 
     for required in handler.list_required_kwargs:
         if kw.get(required) is None:
-            raise ToolError(
+            err = EntityArgValidationError(
                 f"list({entity_type!r}) requires {required}. "
                 f"E.g. list({entity_type!r}, {required}='<uuid>', …)."
             )
+            raise ToolError(str(err)) from err
 
     opik = client if client is not None else make_opik_client(settings or get_settings())
 

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -174,7 +174,10 @@ async def _fetch_with_name_lookup(
         if len(candidates) == 1:
             entity_id = candidates[0]["id"]
         elif len(candidates) > 1:
-            raise ToolError(_format_ambiguous(handler.entity_type, entity_id, candidates))
+            err = EntityArgValidationError(
+                _format_ambiguous(handler.entity_type, entity_id, candidates)
+            )
+            raise ToolError(str(err)) from err
         # 0 candidates: fall through with the raw id; the fetch call below
         # will 404 with a clear message if it really doesn't exist.
 

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -29,6 +29,7 @@ from opik_mcp.opik_client import (
     make_opik_client,
 )
 from opik_mcp.read_list.compression import compact_json, estimate_tokens, size_header
+from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.registry import (
     ENTITY_REGISTRY,
     READABLE_TYPES,
@@ -124,12 +125,16 @@ async def run_read(
 
     if entity_type not in READABLE_TYPES:
         if entity_type in ENTITY_REGISTRY:
-            raise ToolError(
+            err = EntityArgValidationError(
                 f"Entity {entity_type!r} is list-only — use list({entity_type!r}, "
                 f"<parent_id>=…) to enumerate, or read the parent entity instead."
             )
+            raise ToolError(str(err)) from err
         valid = ", ".join(sorted(READABLE_TYPES))
-        raise ToolError(f"Invalid entity_type {entity_type!r}. Readable types: {valid}")
+        err = EntityArgValidationError(
+            f"Invalid entity_type {entity_type!r}. Readable types: {valid}"
+        )
+        raise ToolError(str(err)) from err
 
     handler = ENTITY_REGISTRY[entity_type]
 

--- a/src/opik_mcp/read_list/uri.py
+++ b/src/opik_mcp/read_list/uri.py
@@ -21,11 +21,19 @@ toward the ``list`` tool — ``read`` is for singletons.
 from __future__ import annotations
 
 import re
-from typing import NamedTuple
+from typing import ClassVar, NamedTuple
+
+from opik_mcp.error_kinds import ErrorKind
 
 
 class InvalidURI(ValueError):
     """The string was prefixed ``opik://`` but didn't match any known shape."""
+
+    # Read-tool callers raise this when a user-supplied identifier looks like
+    # an opik:// URI but doesn't match any known shape — squarely a payload
+    # validation failure, same bucket as a malformed UUID.
+    error_kind: ClassVar[ErrorKind] = "validation"
+    http_status: ClassVar[int | None] = 400
 
 
 class ParsedURI(NamedTuple):

--- a/src/opik_mcp/writes/errors.py
+++ b/src/opik_mcp/writes/errors.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import difflib
 import json
 from dataclasses import dataclass, field
-from typing import Any, Final, Literal
+from typing import Any, ClassVar, Final, Literal
+
+from opik_mcp.error_kinds import ErrorKind
 
 ErrorCode = Literal[
     "validation_failed",
@@ -47,6 +49,12 @@ class ValidationIssue:
 class WriteError(Exception):
     """Base for all structured write errors. Renders as the JSON body."""
 
+    # Class-level taxonomy used by analytics/errors.bucket_exception. Subclasses
+    # shadow these with their own canonical bucket; the base falls through to
+    # "unknown" since concrete code never raises bare WriteError.
+    error_kind: ClassVar[ErrorKind] = "unknown"
+    http_status: ClassVar[int | None] = None
+
     error: ErrorCode
     operation: str | None = None
     message: str = ""
@@ -71,6 +79,8 @@ class WriteError(Exception):
 
 @dataclass
 class UnknownOperationError(WriteError):
+    error_kind: ClassVar[ErrorKind] = "validation"
+    http_status: ClassVar[int | None] = 400
     error: ErrorCode = field(default=CODE_UNKNOWN_OPERATION, init=False)
 
     @classmethod
@@ -91,6 +101,8 @@ class UnknownOperationError(WriteError):
 
 @dataclass
 class ValidationFailedError(WriteError):
+    error_kind: ClassVar[ErrorKind] = "validation"
+    http_status: ClassVar[int | None] = 400
     error: ErrorCode = field(default=CODE_VALIDATION_FAILED, init=False)
 
     @classmethod
@@ -114,6 +126,8 @@ class ValidationFailedError(WriteError):
 
 @dataclass
 class AuthorizationDeniedError(WriteError):
+    error_kind: ClassVar[ErrorKind] = "permission"
+    http_status: ClassVar[int | None] = 403
     error: ErrorCode = field(default=CODE_AUTHORIZATION_DENIED, init=False)
 
     @classmethod
@@ -131,6 +145,14 @@ class AuthorizationDeniedError(WriteError):
 
 @dataclass
 class BackendError(WriteError):
+    # ClassVar defaults are intentional fallbacks — the real bucket comes from
+    # the upstream HTTP status carried on ``instance.extra["backend_error"]
+    # ["status"]``. analytics/errors._instance_http_status reads that integer
+    # BEFORE the ClassVar lookup runs. These defaults exist for defense in
+    # depth — a hand-constructed BackendError missing the extra payload
+    # collapses safely into "unknown" instead of crashing the classifier.
+    error_kind: ClassVar[ErrorKind] = "unknown"
+    http_status: ClassVar[int | None] = None
     error: ErrorCode = field(default=CODE_BACKEND_ERROR, init=False)
 
     @classmethod
@@ -159,6 +181,8 @@ class BackendError(WriteError):
 
 @dataclass
 class BatchTooLargeError(WriteError):
+    error_kind: ClassVar[ErrorKind] = "validation"
+    http_status: ClassVar[int | None] = 400
     error: ErrorCode = field(default=CODE_BATCH_TOO_LARGE, init=False)
 
     @classmethod

--- a/src/opik_mcp/writes/schema_tool.py
+++ b/src/opik_mcp/writes/schema_tool.py
@@ -42,8 +42,10 @@ def run_schema(operation: str) -> dict[str, Any]:
         # Mirror the structured envelope ``write`` raises so callers get
         # the same recovery surface (``valid_operations`` + fuzzy
         # ``did_you_mean``) on either tool — no asymmetric error shapes
-        # for the model to learn.
-        raise ToolError(UnknownOperationError.build(operation, WRITE_OPERATIONS).to_json())
+        # for the model to learn. The ``from err`` chain lets analytics
+        # unwrap to the typed cause and bucket as validation/400.
+        err = UnknownOperationError.build(operation, WRITE_OPERATIONS)
+        raise ToolError(err.to_json()) from err
     return {
         "operation": op.name,
         "schema": op.pydantic_model.model_json_schema(),

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -553,3 +553,68 @@ def test_bucket_exception_unwrap_does_not_read_message() -> None:
         ValueError("would-be-unknown"),
     )
     assert bucket_exception(chain) == "unknown"
+
+
+# --- BackendError instance-status routing -------------------------------- #
+#
+# Unlike every other typed exception, BackendError's bucket depends on the
+# upstream HTTP status it received — that status lives on instance.extra,
+# not a ClassVar. The classifier reads it via _instance_http_status, the
+# same helper that handles httpx.HTTPStatusError. Privacy contract preserved:
+# we read an integer status, never the response body or error message.
+
+
+def _backend_error(status: int) -> BackendError:
+    """Build a real BackendError instance with the given upstream status."""
+    return BackendError.build(
+        operation="trace.create",
+        status=status,
+        body={"detail": "synthetic"},
+        method="POST",
+        path="/v1/private/traces",
+    )
+
+
+@pytest.mark.parametrize(
+    "status, expected_bucket, expected_http",
+    [
+        (401, "auth", 401),
+        (403, "permission", 403),
+        (404, "not_found", 404),
+        (408, "timeout", 408),
+        (422, "validation", 422),
+        (429, "validation", 429),
+        (500, "upstream_5xx", 500),
+        (502, "upstream_5xx", 502),
+        (503, "upstream_5xx", 503),
+        (504, "timeout", 504),
+    ],
+)
+def test_backend_error_instance_status_routes_bucket(
+    status: int, expected_bucket: str, expected_http: int
+) -> None:
+    """BackendError(status=X) must bucket the same as bucket_http_status(X)
+    and derive_http_status must surface the wire status. The classifier reads
+    the instance status BEFORE the ClassVar fallback, so the "unknown"
+    ClassVar never wins for an instance with a valid extra payload."""
+    exc = _backend_error(status)
+    assert bucket_exception(exc) == expected_bucket
+    assert derive_http_status(exc) == expected_http
+
+
+def test_backend_error_through_tool_error_chain() -> None:
+    """The production raise path: write_tool wraps BackendError in ToolError
+    via ``raise ToolError(we.to_json()) from we``. The unwrap must surface
+    the BackendError, and the instance-status branch must route the bucket."""
+    chain = _raise_chain(ToolError("backend rejected"), _backend_error(503))
+    assert bucket_exception(chain) == "upstream_5xx"
+    assert derive_http_status(chain) == 503
+
+
+def test_backend_error_without_extra_status_falls_back_to_classvar() -> None:
+    """A BackendError missing the extra payload (e.g. constructed by hand in
+    a test, or a future refactor that forgets the status) falls back to the
+    ClassVar — "unknown" / None — rather than crashing the classifier."""
+    bare = BackendError(operation="trace.create")
+    assert bucket_exception(bare) == "unknown"
+    assert derive_http_status(bare) is None

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -35,6 +35,14 @@ from opik_mcp.opik_client import (
     OpikServerError,
     OpikValidationError,
 )
+from opik_mcp.writes.errors import (
+    AuthorizationDeniedError,
+    BackendError,
+    BatchTooLargeError,
+    UnknownOperationError,
+    ValidationFailedError,
+    WriteError,
+)
 
 
 def _pydantic_error() -> PydanticValidationError:
@@ -230,6 +238,20 @@ _TYPED_EXCEPTION_CLASSES: tuple[tuple[type[BaseException], str, int | None], ...
     (CometProtocolError, "unknown", None),
     (PodNotReadyError, "timeout", None),
     (MissingConfigError, "unknown", None),
+    # Write-tool envelope: base "unknown" since concrete code never raises bare
+    # WriteError; each live subclass shadows the bucket.
+    (WriteError, "unknown", None),
+    (UnknownOperationError, "validation", 400),
+    (ValidationFailedError, "validation", 400),
+    (AuthorizationDeniedError, "permission", 403),
+    # BackendError ClassVars are fallbacks; the real bucket comes from the
+    # instance.extra status — covered by a dedicated test block in Task 2.
+    (BackendError, "unknown", None),
+    (BatchTooLargeError, "validation", 400),
+    # NOTE: BatchPartialFailureError intentionally omitted — never raised in
+    # the codebase. Adding a ClassVar would expose us to a Sentry-firing edge
+    # case ("unknown" is not in _USER_SIDE_ERROR_KINDS) for a class that
+    # currently produces zero events. Revisit when the first raise site lands.
 )
 
 

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -578,6 +578,9 @@ def _backend_error(status: int) -> BackendError:
 @pytest.mark.parametrize(
     "status, expected_bucket, expected_http",
     [
+        # status=0 is malformed/absent; routed safely via bucket_http_status → "unknown".
+        # Pins the ``is not None`` guard intent so falsy-zero refactors fail loudly.
+        (0, "unknown", 0),
         (401, "auth", 401),
         (403, "permission", 403),
         (404, "not_found", 404),

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -35,6 +35,7 @@ from opik_mcp.opik_client import (
     OpikServerError,
     OpikValidationError,
 )
+from opik_mcp.read_list.uri import InvalidURI
 from opik_mcp.writes.errors import (
     AuthorizationDeniedError,
     BackendError,
@@ -248,6 +249,7 @@ _TYPED_EXCEPTION_CLASSES: tuple[tuple[type[BaseException], str, int | None], ...
     # instance.extra status — covered by a dedicated test block in Task 2.
     (BackendError, "unknown", None),
     (BatchTooLargeError, "validation", 400),
+    (InvalidURI, "validation", 400),
     # NOTE: BatchPartialFailureError intentionally omitted — never raised in
     # the codebase. Adding a ClassVar would expose us to a Sentry-firing edge
     # case ("unknown" is not in _USER_SIDE_ERROR_KINDS) for a class that
@@ -612,6 +614,14 @@ def test_backend_error_through_tool_error_chain() -> None:
     chain = _raise_chain(ToolError("backend rejected"), _backend_error(503))
     assert bucket_exception(chain) == "upstream_5xx"
     assert derive_http_status(chain) == 503
+
+
+def test_invalid_uri_through_tool_error_chain() -> None:
+    """read_tool.py raises ``ToolError(str(e)) from InvalidURI(...)`` — the
+    unwrap surfaces the typed cause and the ClassVars set the bucket."""
+    chain = _raise_chain(ToolError("bad uri"), InvalidURI("opik://nope/x"))
+    assert bucket_exception(chain) == "validation"
+    assert derive_http_status(chain) == 400
 
 
 def test_backend_error_without_extra_status_falls_back_to_classvar() -> None:

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -35,6 +35,7 @@ from opik_mcp.opik_client import (
     OpikServerError,
     OpikValidationError,
 )
+from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.uri import InvalidURI
 from opik_mcp.writes.errors import (
     AuthorizationDeniedError,
@@ -250,6 +251,7 @@ _TYPED_EXCEPTION_CLASSES: tuple[tuple[type[BaseException], str, int | None], ...
     (BackendError, "unknown", None),
     (BatchTooLargeError, "validation", 400),
     (InvalidURI, "validation", 400),
+    (EntityArgValidationError, "validation", 400),
     # NOTE: BatchPartialFailureError intentionally omitted — never raised in
     # the codebase. Adding a ClassVar would expose us to a Sentry-firing edge
     # case ("unknown" is not in _USER_SIDE_ERROR_KINDS) for a class that
@@ -620,6 +622,18 @@ def test_invalid_uri_through_tool_error_chain() -> None:
     """read_tool.py raises ``ToolError(str(e)) from InvalidURI(...)`` — the
     unwrap surfaces the typed cause and the ClassVars set the bucket."""
     chain = _raise_chain(ToolError("bad uri"), InvalidURI("opik://nope/x"))
+    assert bucket_exception(chain) == "validation"
+    assert derive_http_status(chain) == 400
+
+
+def test_entity_arg_validation_error_through_tool_error_chain() -> None:
+    """list_tool / read_tool wrap ``EntityArgValidationError`` in ``ToolError``
+    when the caller passes an unknown entity_type or omits a required parent
+    id — the unwrap must reach it and bucket as validation/400."""
+    chain = _raise_chain(
+        ToolError("user-facing"),
+        EntityArgValidationError("Cannot list 'wat'. Listable types: ..."),
+    )
     assert bucket_exception(chain) == "validation"
     assert derive_http_status(chain) == 400
 

--- a/tests/test_analytics_wrappers.py
+++ b/tests/test_analytics_wrappers.py
@@ -929,3 +929,42 @@ async def test_sentry_captures_non_user_side_failures_through_tool_error_wrapper
     assert isinstance(captured_exc, ToolError)
     # But the bucket tag reflects the unwrapped cause.
     assert tags["error_kind"] == expected_kind
+
+
+# --- End-to-end: BackendError instance-status routing -------------------- #
+
+
+@pytest.mark.anyio
+async def test_instrument_tool_buckets_backend_error_by_instance_status(
+    recorder: _Recorder,
+) -> None:
+    """End-to-end: a write tool failure surfaced as ``ToolError`` chained
+    from ``BackendError(status=503)`` must emit ``error_kind="upstream_5xx"``,
+    ``http_status="503"``, ``cause_type="BackendError"`` — verifying the
+    _instance_http_status helper is reachable from the wrapper layer.
+
+    The per-layer unit tests pin bucket_exception and the wrapper separately;
+    this test is the unique end-to-end seam that catches a regression where
+    the helper's call site shifts (e.g. moves below the ClassVar lookup
+    again) and the bucket silently collapses to "unknown"."""
+    from opik_mcp.writes.errors import BackendError
+
+    @instrument_tool("write")
+    async def fake_write(**kwargs: object) -> dict[str, object]:
+        cause = BackendError.build(
+            "trace.create", 503, {"detail": "down"}, method="POST", path="/v1/private/traces"
+        )
+        raise ToolError(cause.to_json()) from cause
+
+    with pytest.raises(ToolError):
+        await fake_write()
+
+    assert len(recorder.events) == 1
+    name, props = recorder.events[0]
+    assert name == EVENT_TOOL_CALLED
+    assert props["tool_name"] == "write"
+    assert props["success"] == "false"
+    assert props["error_kind"] == "upstream_5xx"
+    assert props["http_status"] == "503"
+    assert props["exception_type"] == "ToolError"
+    assert props["cause_type"] == "BackendError"

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
+from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.list_tool import run_list
 
 
@@ -170,3 +171,24 @@ async def test_list_clamps_size_to_max() -> None:
     fake = FakeOpikClient()
     await run_list("project", size=500, client=fake)
     assert fake.last_kwargs.get("size") == 100
+
+
+@pytest.mark.anyio
+async def test_list_unknown_entity_type_chains_typed_cause() -> None:
+    """``list('wat')`` raises ToolError, but the cause must be the typed
+    EntityArgValidationError so the analytics wrapper buckets it as
+    validation/400 rather than unknown."""
+    with pytest.raises(ToolError) as ei:
+        await run_list("not_a_real_type")
+
+    assert isinstance(ei.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_list_missing_required_kwarg_chains_typed_cause() -> None:
+    """``list('trace')`` without ``project_id`` raises ToolError; the cause
+    must be the typed EntityArgValidationError. Same chaining contract."""
+    with pytest.raises(ToolError) as ei:
+        await run_list("trace")
+
+    assert isinstance(ei.value.__cause__, EntityArgValidationError)

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -197,6 +197,7 @@ async def test_read_project_by_ambiguous_name_lists_candidates() -> None:
     assert "Multiple projects match" in str(exc.value)
     assert "p-1" in str(exc.value)
     assert "p-2" in str(exc.value)
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -13,6 +13,7 @@ import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
 from opik_mcp.opik_client import OpikNotFoundError
+from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.read_tool import run_read
 
 
@@ -256,3 +257,27 @@ async def test_read_respects_max_tokens() -> None:
     fake = FakeOpikClient(projects_by_id={UUID: {"id": UUID, "blob": "x" * 50_000}})
     out = await run_read("project", UUID, max_tokens=100, client=fake)
     assert "compression=MEDIUM" in out
+
+
+# --- exception chain assertions ------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_read_list_only_entity_chains_typed_cause() -> None:
+    """``read('test_suite_item', '<uuid>')`` — list-only entity surfaced as
+    ToolError chained from EntityArgValidationError so the analytics wrapper
+    buckets it as validation/400 instead of unknown."""
+    with pytest.raises(ToolError) as ei:
+        await run_read("test_suite_item", "00000000-0000-0000-0000-000000000000")
+
+    assert isinstance(ei.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_read_invalid_entity_type_chains_typed_cause() -> None:
+    """``read('not_real', '<uuid>')`` — invalid entity_type chained from
+    EntityArgValidationError so the bucket is validation/400, not unknown."""
+    with pytest.raises(ToolError) as ei:
+        await run_read("not_real", "00000000-0000-0000-0000-000000000000")
+
+    assert isinstance(ei.value.__cause__, EntityArgValidationError)

--- a/tests/test_writes/test_schema_tool.py
+++ b/tests/test_writes/test_schema_tool.py
@@ -1,0 +1,26 @@
+"""Tests for ``opik_mcp.writes.schema_tool``.
+
+The schema tool is a synchronous registry lookup — no BE call, no auth.
+The only failure path that lives here is the unknown-operation case at
+``schema_tool.py:46``: it must wrap the typed ``UnknownOperationError``
+in a ``ToolError`` while preserving the chain via ``from err`` so the
+analytics wrapper buckets the failure as validation/400 (not unknown).
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from opik_mcp.writes.errors import UnknownOperationError
+from opik_mcp.writes.schema_tool import run_schema
+
+
+def test_schema_unknown_operation_chains_typed_cause() -> None:
+    """``schema('not_a_real_op')`` raises ToolError chained from
+    UnknownOperationError so the analytics wrapper buckets it as
+    validation/400 via the typed exception's ClassVars."""
+    with pytest.raises(ToolError) as ei:
+        run_schema("not_a_real_op")
+
+    assert isinstance(ei.value.__cause__, UnknownOperationError)


### PR DESCRIPTION
## Summary

Every exception that crosses the analytics wrapper now buckets into the correct ``ErrorKind`` and emits the correct ``http_status``. After this PR, the only events bucketing as ``"unknown"`` are real bugs (CometProtocolError, OllieStreamError, MissingConfigError, ValueError/RuntimeError leaks), never user-input mistakes or backend HTTP failures.

- Five WriteError subclasses (UnknownOperationError, ValidationFailedError, AuthorizationDeniedError, BackendError, BatchTooLargeError) and the new EntityArgValidationError declare ``error_kind`` / ``http_status`` ClassVars; ``InvalidURI`` gets them too.
- ``BackendError`` and ``httpx.HTTPStatusError`` route through a shared ``_instance_http_status`` helper called BEFORE the ClassVar lookup, so per-instance HTTP status wins over class-level fallbacks. (``write_tool.py``'s existing ``raise ToolError(we.to_json()) from we`` was already correct; this PR adds the missing taxonomy + chain on five sites that were bare.)
- Six bare ``raise ToolError(...)`` sites — two in ``list_tool``, three in ``read_tool`` (including the ambiguous-name disambiguation path), and one in ``schema_tool`` — now chain through a typed cause via ``from err``, so the wrapper's unwrap surfaces the real bucket.
- BI dashboards will see write/read/list failures bucketed as ``validation`` / ``permission`` / ``upstream_5xx`` / ``not_found`` instead of the current ``unknown / ToolError`` row; Sentry automatically skips the new user-side buckets because they're already in ``_USER_SIDE_ERROR_KINDS``.

## Intentional design decisions

- ``BatchPartialFailureError`` omitted from the ClassVar additions — never raised anywhere in ``src/`` today, and ``"unknown"`` is not in ``_USER_SIDE_ERROR_KINDS``, so adding the ClassVar would expose us to a Sentry-firing edge case on a class producing zero events. We'll add it with a deliberate bucket when the first raise site lands.
- ``status=0`` (synthetic / malformed ``BackendError``) routes through ``bucket_http_status(0) → "unknown"`` and emits ``http_status="0"`` — pinned with a parametrize case so a future falsy-zero refactor fails loudly.
- Module-level PRIVACY docstring on ``analytics/errors.py`` updated to honestly describe the new behavior: class-level classification plus a tightly-scoped integer-only instance whitelist (``httpx.Response.status_code``, ``BackendError.extra[\"backend_error\"][\"status\"]``).

## Test plan

- [x] ``uv run pytest`` — 863 passed, 2 skipped (no regressions)
- [x] ``uv run mypy && uv run ruff check && uv run ruff format --check`` — clean
- [x] Per-layer unit tests: ``tests/test_analytics_errors.py`` ClassVar matrix + BackendError instance-status block + chain tests for each typed cause
- [x] End-to-end integration test: ``test_instrument_tool_buckets_backend_error_by_instance_status`` asserts the full ``ToolError ← BackendError(503)`` chain through ``instrument_tool`` emits ``error_kind=upstream_5xx, http_status=503, cause_type=BackendError``
- [ ] Manual smoke against a running build:
  - [ ] ``schema('not_a_real_op')`` — verify BI ``opik_mcp_tool_called`` has ``error_kind=validation`` ``http_status=400`` ``cause_type=UnknownOperationError``
  - [ ] ``list('wat')`` — verify BI event has ``error_kind=validation`` ``cause_type=EntityArgValidationError``
  - [ ] ``read('opik://nope/x', 'x')`` — verify BI event has ``error_kind=validation`` ``cause_type=InvalidURI``
  - [ ] Drive a 503 from the Opik backend (fake base_url) → verify ``error_kind=upstream_5xx`` ``http_status=503`` ``cause_type=BackendError``

🤖 Generated with [Claude Code](https://claude.com/claude-code)