### PR TITLE
chore(release): bump version to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opik-mcp"
-version = "0.1.5"
+version = "0.1.6"
 description = "Model Context Protocol server for Opik (Comet's LLM observability platform)."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "opik-mcp"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Release PR for v0.1.6. Bundles one feature landed since 0.1.5:

### #130 — close error-bucketing gaps across write/read/list/URI surfaces

Every exception that crosses the analytics wrapper now buckets into the correct ``ErrorKind`` and emits the correct ``http_status``. The only events that still bucket as ``"unknown"`` are real bugs (CometProtocolError, OllieStreamError, MissingConfigError, ValueError/RuntimeError leaks), never user-input mistakes or backend HTTP failures.

- Five ``WriteError`` subclasses (``UnknownOperationError``, ``ValidationFailedError``, ``AuthorizationDeniedError``, ``BackendError``, ``BatchTooLargeError``) and the new ``EntityArgValidationError`` declare ``error_kind`` / ``http_status`` ``ClassVar``s; ``InvalidURI`` gets them too.
- ``BackendError`` and ``httpx.HTTPStatusError`` route through a shared ``_instance_http_status`` helper called BEFORE the ClassVar lookup, so per-instance HTTP status wins over class-level fallbacks.
- Six bare ``raise ToolError(...)`` sites — two in ``list_tool``, three in ``read_tool`` (including the ambiguous-name disambiguation path), and one in ``schema_tool`` — now chain through a typed cause via ``from err``, so the wrapper's unwrap surfaces the real bucket.
- BI dashboards will see write/read/list failures bucketed as ``validation`` / ``permission`` / ``upstream_5xx`` / ``not_found`` instead of the previous ``unknown / ToolError`` row; Sentry automatically skips the new user-side buckets because they're already in ``_USER_SIDE_ERROR_KINDS``.
- ``BatchPartialFailureError`` deliberately omitted — never raised in production today.

Privacy contract preserved — classifiers still inspect class + a tight whitelist of integer-only instance fields (``httpx.Response.status_code``, ``BackendError.extra["backend_error"]["status"]``). No string matching introduced.

## BI receiver impact

``tool_called`` events emitted from ``write`` / ``read`` / ``list`` / ``schema`` failures will now carry accurate ``error_kind`` and ``http_status`` properties. No new properties added; existing properties only improve in accuracy.

## Test plan

- [x] ``uv run pytest`` — 863 passed, 2 skipped
- [x] ``uv run ruff check`` + ``ruff format --check`` — clean
- [x] ``uv run mypy`` — clean
- [ ] After merge: tag ``py-v0.1.6``, push tag, trigger PyPI release

🤖 Generated with [Claude Code](https://claude.com/claude-code)