### PR TITLE
feat(analytics): per-call session-context block + privacy/bucketing fixes

### DIFF
--- a/src/opik_mcp/analytics/environment.py
+++ b/src/opik_mcp/analytics/environment.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 import sys
 from collections.abc import Callable
+from functools import lru_cache
 
 # ``sys.platform`` is a Literal type that mypy narrows per-host, so platform-
 # dispatch branches get flagged unreachable on whichever host runs CI (Linux
@@ -187,6 +188,20 @@ def _detect_parent_process() -> str:
 _logger = logging.getLogger("opik_mcp.analytics.environment")
 
 
+def _safe(fn: Callable[[], str], default: str) -> str:
+    """Run a detector, falling back to ``default`` if it raises.
+
+    Wraps each detector individually so one failure doesn't take the whole
+    fingerprint down. Same fire-and-forget contract as ``track_event``.
+    """
+    try:
+        return fn()
+    except Exception:
+        name = getattr(fn, "__name__", repr(fn))
+        _logger.debug("environment detector %s raised", name, exc_info=True)
+        return default
+
+
 def collect_environment_fingerprint() -> dict[str, str]:
     """Bucketed environment signals to merge into ``server_started`` properties.
 
@@ -195,17 +210,6 @@ def collect_environment_fingerprint() -> dict[str, str]:
     (filesystem oddity, missing tool, …), the field falls back to
     ``"unknown"`` so the aggregator never breaks the emit path.
     """
-
-    # Wrap each detector individually so one failure doesn't take the whole
-    # fingerprint down. Same fire-and-forget contract as ``track_event``.
-    def _safe(fn: Callable[[], str], default: str) -> str:
-        try:
-            return fn()
-        except Exception:
-            name = getattr(fn, "__name__", repr(fn))
-            _logger.debug("environment detector %s raised", name, exc_info=True)
-            return default
-
     out: dict[str, str] = {
         "is_ci": _safe(_detect_ci, "false"),
         "is_container": _safe(_detect_container, "unknown"),
@@ -221,3 +225,31 @@ def collect_environment_fingerprint() -> dict[str, str]:
         out["stdin_is_pipe"] = "unknown"
         out["stdout_is_pipe"] = "unknown"
     return out
+
+
+@lru_cache(maxsize=1)
+def cached_call_context_env() -> dict[str, str]:
+    """Process-stable env subset stamped on every per-call analytics event.
+
+    ``tool_called`` / ``ask_ollie_completed`` carry these so BI can segment by
+    real-user cohort (``is_ci='false' AND is_container='false'``) on a single
+    table — without joining each call back to ``server_started`` on
+    ``install_id`` (a join that drops ~35% of calls in practice).
+
+    Memoised: resolved once per process and reused on the hot path. Only the
+    cheap, stable detectors are included — ``parent_process`` (a subprocess on
+    macOS) stays startup-only on ``server_started`` and is deliberately not
+    here.
+    """
+    # Imported lazily so this module stays free of ``config`` (and its
+    # pydantic-settings machinery) at import time — ``identity`` pulls in
+    # ``config``, heavier than this hot-path module wants to load eagerly.
+    # There is no import cycle; this is purely about import cost.
+    from opik_mcp.analytics.identity import install_id_was_freshly_generated
+
+    return {
+        "is_ci": _safe(_detect_ci, "false"),
+        "is_container": _safe(_detect_container, "unknown"),
+        "launch_method": _safe(_detect_launch_method, "unknown"),
+        "install_id_freshly_generated": str(install_id_was_freshly_generated()).lower(),
+    }

--- a/src/opik_mcp/analytics/mcp_client_info.py
+++ b/src/opik_mcp/analytics/mcp_client_info.py
@@ -14,8 +14,12 @@ session-initialized emit and the Sentry capture path) in lock-step.
 
 from __future__ import annotations
 
+import contextlib
 import re
 from typing import Any
+from weakref import WeakKeyDictionary
+
+from opik_mcp.analytics.environment import cached_call_context_env
 
 # Known MCP host allowlist. Prefix match (``startswith``) on the lower-
 # cased ``clientInfo.name`` → bucket. Anything else → "other". Order
@@ -120,3 +124,60 @@ def collect_session_props(session: Any) -> dict[str, str]:
         "caps_roots": str(getattr(capabilities, "roots", None) is not None).lower(),
         "caps_tasks": str(getattr(capabilities, "tasks", None) is not None).lower(),
     }
+
+
+# Per-session cache of the bucketed host block. The MCP handshake is fixed for
+# the life of a session, so ``clientInfo`` is read and bucketed once, then
+# reused on every per-call emit — keeps the privacy-sensitive classification
+# off the hot path. ``WeakKeyDictionary`` so dead sessions are reclaimed;
+# stand-ins that don't support weak references (e.g. ``SimpleNamespace`` in
+# tests) skip the cache and recompute, which is cheap and pure.
+_session_host_cache: WeakKeyDictionary[Any, dict[str, str]] = WeakKeyDictionary()
+
+
+def _host_context(session: Any) -> dict[str, str]:
+    """The two handshake-derived fields (``mcp_host`` / ``host_llm_family``),
+    cached per session.
+
+    Only these two fields are cached — NOT the full 8-key
+    ``collect_session_props`` block. A caller that needs the version / caps
+    fields too should call ``collect_session_props`` directly (the
+    ``session_initialized`` emit does); don't layer it on top of this and
+    re-extract twice.
+    """
+    try:
+        cached = _session_host_cache.get(session)
+    except TypeError:
+        cached = None
+    if cached is not None:
+        return cached
+    props = collect_session_props(session)
+    host = {"mcp_host": props["mcp_host"], "host_llm_family": props["host_llm_family"]}
+    with contextlib.suppress(TypeError):
+        _session_host_cache[session] = host
+    return host
+
+
+def call_context_props(session: Any) -> dict[str, str]:
+    """The session-context block stamped on every per-call analytics event.
+
+    Six fields BI uses to segment ``tool_called`` / ``ask_ollie_completed`` by
+    real-user cohort and MCP host WITHOUT joining back to ``server_started`` /
+    ``session_initialized`` on ``install_id``:
+
+    - ``is_ci`` / ``is_container`` / ``launch_method`` /
+      ``install_id_freshly_generated`` — process-stable env (cached once)
+    - ``mcp_host`` / ``host_llm_family`` — per-session handshake (cached on
+      first read)
+
+    Every value is a boolean string or an allowlisted enum — never a raw path,
+    hostname, or ``clientInfo`` string. ``session`` may be ``None`` (no
+    handshake yet); the host fields fall back to ``"other"`` / ``"unknown"``.
+    """
+    return {**cached_call_context_env(), **_host_context(session)}
+
+
+def _reset_call_context_cache_for_tests() -> None:
+    """Drop both context caches. Test-only — never call from production."""
+    _session_host_cache.clear()
+    cached_call_context_env.cache_clear()

--- a/src/opik_mcp/analytics/wrappers.py
+++ b/src/opik_mcp/analytics/wrappers.py
@@ -29,7 +29,7 @@ from opik_mcp.analytics.errors import (
     unwrap_to_real_cause,
 )
 from opik_mcp.analytics.events import EVENT_TOOLS_LISTED, bucket_count
-from opik_mcp.analytics.mcp_client_info import collect_session_props
+from opik_mcp.analytics.mcp_client_info import call_context_props, collect_session_props
 from opik_mcp.comet_client import OllieNotEnabledError
 from opik_mcp.config import MissingConfigError
 
@@ -58,10 +58,12 @@ _USER_SIDE_ERROR_KINDS: frozenset[str] = frozenset(
 )
 
 
-# A few exceptions bucket to ``"unknown"`` (alongside real bugs like
-# ``CometProtocolError`` and ``OllieStreamError``) but actually represent
-# user-config problems Sentry shouldn't carry. Class-based skip because
-# the coarse ``"unknown"`` bucket can't distinguish them from the bugs.
+# User-config problems Sentry shouldn't carry. ``OllieNotEnabledError`` buckets
+# to ``"unknown"`` (indistinguishable from real bugs like ``CometProtocolError``
+# at the kind level), so it NEEDS this class-based skip. ``MissingConfigError``
+# now buckets to ``"validation"`` and is already skipped via
+# ``_USER_SIDE_ERROR_KINDS``; it stays here as belt-and-braces so a future
+# re-classification can't silently start paging Sentry.
 _USER_SIDE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     MissingConfigError,
     OllieNotEnabledError,
@@ -280,6 +282,12 @@ def instrument_tool(
                     "success": "true" if completed else "false",
                     "duration_ms": str(int((time.monotonic() - t0) * 1000)),
                 }
+                # Stamp the bucketed session context (env cohort + MCP host) so
+                # BI can segment this event without joining to server_started /
+                # session_initialized on install_id. session may be None.
+                ctx = kwargs.get("ctx")
+                session = getattr(ctx, "session", None) if ctx is not None else None
+                props.update(call_context_props(session))
                 if error_kind:
                     props["error_kind"] = error_kind
                 if exception_type:

--- a/src/opik_mcp/ask_ollie.py
+++ b/src/opik_mcp/ask_ollie.py
@@ -12,10 +12,12 @@ from pydantic import BaseModel
 from opik_mcp import audit
 from opik_mcp.analytics import EVENT_ASK_OLLIE_COMPLETED, bucket_count
 from opik_mcp.analytics.errors import bucket_exception, unwrap_to_real_cause
+from opik_mcp.analytics.mcp_client_info import call_context_props
 from opik_mcp.comet_client import CometClient, PodDiscovery
 from opik_mcp.config import Settings, get_settings, require_ollie_config
 from opik_mcp.elicitation import confirm_with_user
 from opik_mcp.ollie_client import OllieClient, OllieStreamError, OnTick, SSEEvent
+from opik_mcp.writes.registry import WRITE_OPERATIONS
 
 logger = logging.getLogger("opik_mcp.ask_ollie")
 
@@ -28,6 +30,21 @@ def _analytics() -> Any:
 
 
 FOOTER_MAX_ENTRIES = 5
+
+
+# Allowlist for the ``auto_approval_tools`` analytics field. ``target_tool``
+# arrives in the pod's ``confirm_required`` SSE frame (``tool_name``) and is
+# host/pod-controlled free text, so it must never reach analytics verbatim —
+# the privacy contract is bucketed enums only. Names on the write-operation
+# allowlist pass through; anything else collapses to ``"other"``.
+_KNOWN_TARGET_TOOLS: frozenset[str] = frozenset(WRITE_OPERATIONS)
+
+
+def _bucket_auto_approval_tools(details: list[tuple[str | None, str | None]]) -> str:
+    """Comma-join the distinct auto-approved tool names, allowlisted to known
+    write operations (unknown / pod-supplied names → ``"other"``)."""
+    buckets = {(t if t in _KNOWN_TARGET_TOOLS else "other") for t, _ in details if t}
+    return ",".join(sorted(buckets))
 
 
 # Session-scoped allowlist of pod target_tool names that the user has
@@ -724,8 +741,13 @@ async def run_ask_ollie(
                 errored=errored,
             ),
             "auto_approvals_count": str(len(auto_approval_details)),
-            "auto_approval_tools": ",".join(sorted({t for t, _ in auto_approval_details if t})),
+            "auto_approval_tools": _bucket_auto_approval_tools(auto_approval_details),
         }
+        # Stamp the bucketed session context (env cohort + MCP host) so BI can
+        # segment ask_ollie usage on a single table — same block tool_called
+        # carries. ctx (hence session) may be None when invoked outside a host.
+        session = getattr(ctx, "session", None) if ctx is not None else None
+        props.update(call_context_props(session))
         if errored:
             props["error_kind"] = error_kind
             props["exception_type"] = error_exception_type

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -9,10 +9,15 @@ from opik_mcp.error_kinds import ErrorKind
 
 
 class MissingConfigError(RuntimeError):
-    """Raised when an ask_ollie call is attempted without required env vars."""
+    """Raised when an ask_ollie call is attempted without required env vars.
 
-    error_kind: ClassVar[ErrorKind] = "unknown"
-    http_status: ClassVar[int | None] = None
+    Deterministic and classifiable (the server is missing api_key/workspace),
+    so it buckets as ``validation`` rather than ``unknown`` — it's a malformed
+    setup the user can fix, not an unexpected fault.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "validation"
+    http_status: ClassVar[int | None] = 400
 
 
 class Settings(BaseSettings):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,19 @@
+import os
 from collections.abc import AsyncIterator, Generator
 
 import httpx
 import pytest
 from asgi_lifespan import LifespanManager
 from httpx import ASGITransport
+
+# Analytics is disabled by default for the whole test process. Tests that
+# exercise analytics opt in explicitly (monkeypatch / respx mocks); leaving it
+# on would let the process-wide singleton spawn a daemon worker that phones
+# home to stats.comet.com over the real network. Beyond being slow and flaky,
+# an in-flight POST from one test can land in a *later* test's ``@respx.mock``
+# window and corrupt ``route.calls.last`` assertions. ``setdefault`` so an
+# explicit override in the environment still wins.
+os.environ.setdefault("OPIK_MCP_ANALYTICS_ENABLED", "false")
 
 
 @pytest.fixture(autouse=True)
@@ -16,17 +26,29 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     inherit ``_tools_listed_fired_processwide=True`` from a previous file
     and silently no-op. Centralising the reset here keeps every test
     independent regardless of which globals it ends up touching.
+
+    Also drops the process-wide ``get_analytics()`` singleton between tests so
+    its emit worker (a daemon thread posting over httpx) never survives a test
+    boundary. Analytics is disabled by default for the whole test process (see
+    the ``OPIK_MCP_ANALYTICS_ENABLED`` default set at the top of this module),
+    so the singleton built here never spawns a worker or phones home — but a
+    test that explicitly enables analytics still gets a clean singleton each
+    time rather than inheriting another test's live worker, whose in-flight
+    POST could otherwise land in a *later* test's ``@respx.mock`` window and
+    break assertions keyed on ``route.calls.last``.
     """
-    from opik_mcp.analytics import transport_probe
+    from opik_mcp.analytics import reset_analytics_for_tests, transport_probe
     from opik_mcp.analytics.wrappers import (
         _reset_seen_sessions_for_tests,
         _reset_seen_tools_listed_for_tests,
     )
 
+    reset_analytics_for_tests()
     _reset_seen_sessions_for_tests()
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()
     yield
+    reset_analytics_for_tests()
     _reset_seen_sessions_for_tests()
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()

--- a/tests/test_analytics_call_context.py
+++ b/tests/test_analytics_call_context.py
@@ -1,0 +1,185 @@
+"""Per-call session-context block on tool_called / ask_ollie_completed.
+
+BI segments per-call events by real-user cohort (``is_ci`` / ``is_container``)
+and MCP host on a single table, without joining each call back to
+``server_started`` / ``session_initialized`` on ``install_id`` (a join that
+drops ~35% of calls). These tests pin the 6-field block, its caching, and the
+allowlist contract (bucketed enums / boolean strings only).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any, get_args
+
+import pytest
+
+from opik_mcp.analytics import EVENT_TOOL_CALLED
+from opik_mcp.analytics.environment import cached_call_context_env
+from opik_mcp.analytics.events import HostLlmFamily, LaunchMethod, McpHost
+from opik_mcp.analytics.mcp_client_info import (
+    _reset_call_context_cache_for_tests,
+    call_context_props,
+)
+from opik_mcp.analytics.wrappers import (
+    _reset_seen_sessions_for_tests,
+    instrument_tool,
+)
+
+CONTEXT_KEYS = {
+    "is_ci",
+    "is_container",
+    "launch_method",
+    "install_id_freshly_generated",
+    "mcp_host",
+    "host_llm_family",
+}
+
+ENV_KEYS = {"is_ci", "is_container", "launch_method", "install_id_freshly_generated"}
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> Iterator[None]:
+    _reset_call_context_cache_for_tests()
+    _reset_seen_sessions_for_tests()
+    yield
+    _reset_call_context_cache_for_tests()
+    _reset_seen_sessions_for_tests()
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, str]]] = []
+
+    def track_event(self, event_type: str, properties: dict[str, str]) -> None:
+        self.events.append((event_type, properties))
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    r = _Recorder()
+    monkeypatch.setattr("opik_mcp.analytics.wrappers._client", lambda: r)
+    return r
+
+
+class _Session:
+    """Weak-referenceable session stand-in (so the per-session host cache
+    actually engages — ``SimpleNamespace`` doesn't support weakref on 3.13)."""
+
+    def __init__(self, name: str = "", version: str = "") -> None:
+        client_info = SimpleNamespace(name=name, version=version)
+        self.client_params = SimpleNamespace(
+            clientInfo=client_info, protocolVersion="", capabilities=None
+        )
+
+
+# --- cached env ----------------------------------------------------------- #
+
+
+def test_cached_call_context_env_keys_and_allowlist() -> None:
+    env = cached_call_context_env()
+    assert set(env) == ENV_KEYS
+    assert env["is_ci"] in {"true", "false"}
+    assert env["is_container"] in {"true", "false", "unknown"}
+    assert env["launch_method"] in set(get_args(LaunchMethod))
+    assert env["install_id_freshly_generated"] in {"true", "false"}
+
+
+def test_cached_call_context_env_is_memoized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolved once per process: flipping an env var after the first call must
+    not change the cached answer (proves we don't re-probe per call)."""
+    first = cached_call_context_env()
+    monkeypatch.setenv("CI", "1")
+    assert cached_call_context_env() is first
+
+
+# --- call_context_props --------------------------------------------------- #
+
+
+def test_call_context_props_buckets_known_host() -> None:
+    props = call_context_props(_Session(name="claude-code", version="1.2.3"))
+    assert set(props) == CONTEXT_KEYS
+    assert props["mcp_host"] == "claude-code"
+    assert props["host_llm_family"] == "anthropic"
+
+
+def test_call_context_props_handles_none_session() -> None:
+    props = call_context_props(None)
+    assert set(props) == CONTEXT_KEYS
+    assert props["mcp_host"] == "other"
+    assert props["host_llm_family"] == "unknown"
+
+
+def test_call_context_props_unknown_host_buckets_to_other() -> None:
+    props = call_context_props(_Session(name="acme-internal-wrapper-bob"))
+    assert props["mcp_host"] == "other"
+    assert props["host_llm_family"] == "unknown"
+    # Every value is from an allowlist — nothing host-controlled survives.
+    assert props["mcp_host"] in set(get_args(McpHost))
+    assert props["host_llm_family"] in set(get_args(HostLlmFamily))
+
+
+def test_host_context_cached_per_session() -> None:
+    """clientInfo is read and bucketed once; mutating the live session after
+    the first read must not change the cached host block."""
+    sess = _Session(name="claude-code")
+    first = call_context_props(sess)
+    assert first["mcp_host"] == "claude-code"
+
+    sess.client_params.clientInfo.name = "cursor"
+    second = call_context_props(sess)
+    assert second["mcp_host"] == "claude-code"
+
+
+def test_host_context_non_weakref_session_recomputes() -> None:
+    """A session that doesn't support weakref (SimpleNamespace) must not crash
+    the cache path — it falls through and recomputes."""
+    sess = SimpleNamespace(
+        client_params=SimpleNamespace(
+            clientInfo=SimpleNamespace(name="cursor", version=""),
+            protocolVersion="",
+            capabilities=None,
+        )
+    )
+    props = call_context_props(sess)
+    assert props["mcp_host"] == "cursor"
+    assert props["host_llm_family"] == "cursor"
+
+
+# --- integration: tool_called -------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_tool_called_carries_session_context(recorder: _Recorder) -> None:
+    @instrument_tool("read")
+    async def fn(*, ctx: Any) -> str:
+        return "ok"
+
+    ctx = SimpleNamespace(session=_Session(name="cursor"))
+    await fn(ctx=ctx)
+
+    props = next(p for et, p in recorder.events if et == EVENT_TOOL_CALLED)
+    assert set(props) >= CONTEXT_KEYS
+    assert props["mcp_host"] == "cursor"
+    assert props["host_llm_family"] == "cursor"
+    assert props["is_ci"] in {"true", "false"}
+
+
+@pytest.mark.anyio
+async def test_tool_called_context_defaults_without_ctx(recorder: _Recorder) -> None:
+    @instrument_tool("hello")
+    async def fn() -> str:
+        return "x"
+
+    await fn()
+
+    props = next(p for et, p in recorder.events if et == EVENT_TOOL_CALLED)
+    assert set(props) >= CONTEXT_KEYS
+    assert props["mcp_host"] == "other"
+    assert props["host_llm_family"] == "unknown"

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -124,7 +124,7 @@ def test_bucket_http_status_boundaries(status: int, expected: str) -> None:
         (OllieNotEnabledError("x"), None),
         (CometProtocolError("x"), None),
         (PodNotReadyError("x"), None),
-        (MissingConfigError("x"), None),
+        (MissingConfigError("x"), 400),
         (httpx.ConnectError("refused"), None),
         (httpx.ReadTimeout("slow"), None),
         (ValueError("x"), None),
@@ -179,7 +179,8 @@ def test_derive_http_status_reads_httpx_response() -> None:
         (OllieStreamError("x"), "unknown"),
         (OllieNotEnabledError("x"), "unknown"),
         (CometProtocolError("x"), "unknown"),
-        (MissingConfigError("x"), "unknown"),
+        # Deterministic setup failure (missing api_key/workspace) → validation.
+        (MissingConfigError("x"), "validation"),
         # Catch-all.
         (ValueError("x"), "unknown"),
         (RuntimeError("x"), "unknown"),
@@ -239,7 +240,7 @@ _TYPED_EXCEPTION_CLASSES: tuple[tuple[type[BaseException], str, int | None], ...
     (OllieNotEnabledError, "unknown", None),
     (CometProtocolError, "unknown", None),
     (PodNotReadyError, "timeout", None),
-    (MissingConfigError, "unknown", None),
+    (MissingConfigError, "validation", 400),
     # Write-tool envelope: base "unknown" since concrete code never raises bare
     # WriteError; each live subclass shadows the bucket.
     (WriteError, "unknown", None),
@@ -490,7 +491,7 @@ _WRAPPED_BUCKET_MATRIX = [
     (httpx.ReadTimeout("slow"), "timeout", None),
     (httpx.ConnectError("refused"), "network", None),
     (OllieAuthError("ppauth"), "auth", None),
-    (MissingConfigError("no key"), "unknown", None),
+    (MissingConfigError("no key"), "validation", 400),
 ]
 
 

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -637,6 +637,85 @@ async def test_ask_ollie_failure_typed_exception_bucketed_correctly(
     assert "upstream_error_code" not in props
 
 
+# --- per-call session context: bucketed host + env, no raw strings -------- #
+
+
+def test_call_context_props_buckets_host_without_leak(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-call session-context block (stamped on tool_called /
+    ask_ollie_completed) must bucket the MCP host and env cohort — never echo
+    a raw ``clientInfo.name``, version, protocolVersion, or HOME path."""
+    from types import SimpleNamespace
+
+    from opik_mcp.analytics.mcp_client_info import (
+        _reset_call_context_cache_for_tests,
+        call_context_props,
+    )
+
+    _reset_call_context_cache_for_tests()
+    monkeypatch.setenv("HOME", "/tmp/FORBIDDEN-CANARY-home-path-5e6f7a8b")
+
+    client_info = SimpleNamespace(
+        name="FORBIDDEN-CANARY-getpass-username-7c4a2b1c",
+        version="FORBIDDEN-CANARY-uname-nodename-1b2c3d4e",
+    )
+    params = SimpleNamespace(
+        clientInfo=client_info,
+        protocolVersion="FORBIDDEN-CANARY-home-path-5e6f7a8b",
+        capabilities=None,
+    )
+    session = SimpleNamespace(client_params=params)
+
+    props = call_context_props(session)
+    # Unknown host name → "other"; nothing host-controlled survives.
+    assert props["mcp_host"] == "other"
+    assert props["host_llm_family"] == "unknown"
+    payload = json.dumps(props)
+    for canary in FORBIDDEN:
+        assert canary not in payload, f"PRIVACY BREACH: {canary!r} leaked into call context"
+    _reset_call_context_cache_for_tests()
+
+
+@pytest.mark.anyio
+async def test_tool_called_session_context_buckets_canary_host(
+    recorder: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the real ``instrument_tool`` emit path with a canary-laden
+    ``clientInfo`` and assert the recorded tool_called carries only bucketed
+    host/env signals — the raw host strings must never reach the event."""
+    from types import SimpleNamespace
+
+    from opik_mcp.analytics.mcp_client_info import _reset_call_context_cache_for_tests
+    from opik_mcp.analytics.wrappers import _reset_seen_sessions_for_tests, instrument_tool
+
+    _reset_call_context_cache_for_tests()
+    _reset_seen_sessions_for_tests()
+
+    client_info = SimpleNamespace(
+        name="FORBIDDEN-CANARY-getpass-username-7c4a2b1c",
+        version="FORBIDDEN-CANARY-uname-nodename-1b2c3d4e",
+    )
+    params = SimpleNamespace(
+        clientInfo=client_info,
+        protocolVersion="FORBIDDEN-CANARY-home-path-5e6f7a8b",
+        capabilities=None,
+    )
+    ctx = SimpleNamespace(session=SimpleNamespace(client_params=params))
+
+    @instrument_tool("read")
+    async def fn(*, ctx: Any) -> str:
+        return "ok"
+
+    await fn(ctx=ctx)
+
+    _assert_no_leak(recorder.events)
+    props = _tool_called(recorder.events)
+    assert props["mcp_host"] == "other"
+    assert props["host_llm_family"] == "unknown"
+    assert props["is_ci"] in {"true", "false"}
+    assert props["install_id_freshly_generated"] in {"true", "false"}
+    _reset_call_context_cache_for_tests()
+
+
 # --- helpers -------------------------------------------------------------- #
 
 

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -56,6 +56,9 @@ def test_main_emits_server_started_then_runs(monkeypatch: pytest.MonkeyPatch) ->
 
     monkeypatch.setattr("opik_mcp.server.mcp", _StubMcp())
     monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+    # The test process disables analytics by default (see conftest). Opt back
+    # in here so the emitted ``analytics_enabled`` flag is exercised as "true".
+    monkeypatch.setenv("OPIK_MCP_ANALYTICS_ENABLED", "true")
 
     main_mod.main()
 
@@ -384,6 +387,9 @@ def test_startup_error_emits_via_fallback_when_settings_validation_fails(
     )
     monkeypatch.setenv("COMET_WORKSPACE_ID", "not-a-uuid")
     monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+    # The test process disables analytics by default (see conftest); this test
+    # is specifically about proving the fallback client POSTs, so opt back in.
+    monkeypatch.setenv("OPIK_MCP_ANALYTICS_ENABLED", "true")
 
     with pytest.raises(ValidationError):
         main_mod.main()

--- a/tests/test_analytics_wrappers.py
+++ b/tests/test_analytics_wrappers.py
@@ -109,7 +109,7 @@ async def test_success_emits_tool_called(recorder: _Recorder) -> None:
         (CometProtocolError("x"), "unknown", None),
         (OllieNotEnabledError("x"), "unknown", None),
         (OllieStreamError("x"), "unknown", None),
-        (MissingConfigError("x"), "unknown", None),
+        (MissingConfigError("x"), "validation", 400),
         # Timeouts: pod warmup timeout and httpx network timeouts both fall in
         # the "timeout" bucket; httpx.TimeoutException is the family base.
         (PodNotReadyError("x"), "timeout", None),
@@ -743,9 +743,9 @@ def _wrap_with_cause(wrapper: Exception, inner: Exception) -> Exception:
         (httpx.ReadTimeout("x"), "timeout", None),
         (httpx.ConnectError("x"), "network", None),
         (OllieAuthError("x"), "auth", None),
-        # MissingConfigError stays "unknown" — but the Sentry skip-list still
-        # has to recognize it through the wrapper (covered separately below).
-        (MissingConfigError("x"), "unknown", None),
+        # MissingConfigError buckets "validation" through the wrapper — and the
+        # Sentry skip-list still has to recognize it (covered separately below).
+        (MissingConfigError("x"), "validation", 400),
     ],
 )
 @pytest.mark.anyio

--- a/tests/test_ask_ollie_analytics.py
+++ b/tests/test_ask_ollie_analytics.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from opik_mcp.analytics import EVENT_ASK_OLLIE_COMPLETED
-from opik_mcp.ask_ollie import run_ask_ollie
+from opik_mcp.ask_ollie import _bucket_auto_approval_tools, run_ask_ollie
 from opik_mcp.comet_client import CometAuthError, PodDiscovery
 from opik_mcp.config import Settings
 from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError, SSEEvent
@@ -71,6 +71,59 @@ async def test_message_end_emits_completed_success(recorder: _Recorder) -> None:
     assert int(p["pod_warmup_ms"]) >= 0
     assert int(p["total_duration_ms"]) >= 0
     assert int(p["event_count"]) == 2
+
+
+def test_bucket_auto_approval_tools_allowlists_pod_strings() -> None:
+    """``target_tool`` is pod-controlled free text; only known write operations
+    survive into analytics, everything else collapses to ``"other"`` so a
+    misbehaving pod can't stamp arbitrary strings into the event."""
+    details: list[tuple[str | None, str | None]] = [
+        ("comment.create", "add note"),
+        ("score.create", "score 0.9"),
+        ("delete_dataset", "DROP everything"),  # not a known op → "other"
+        ("FORBIDDEN-CANARY-username-7c4a2b1c", "leak"),  # pod free text → "other"
+        (None, "no tool"),  # None target_tool skipped entirely
+    ]
+    out = _bucket_auto_approval_tools(details)
+    assert out == "comment.create,other,score.create"
+    # Privacy: no raw pod string survives.
+    assert "delete_dataset" not in out
+    assert "FORBIDDEN-CANARY-username-7c4a2b1c" not in out
+
+
+def test_bucket_auto_approval_tools_empty() -> None:
+    assert _bucket_auto_approval_tools([]) == ""
+
+
+@pytest.mark.anyio
+async def test_completed_carries_session_context(recorder: _Recorder) -> None:
+    """ask_ollie_completed must carry the same 6-field session-context block
+    tool_called does, so BI can segment Ollie usage on a single table."""
+    comet = AsyncMock()
+    comet.discover_pod.return_value = PodDiscovery(compute_url="http://c", ppauth="p")
+    ollie = AsyncMock()
+    ollie.create_session.return_value = "sess-1"
+
+    async def _stream(*_a: Any, **_kw: Any) -> AsyncIterator[SSEEvent]:
+        yield SSEEvent(event="message_end", data={"payload": {}})
+
+    ollie.stream_events = _stream
+
+    await _run_with(comet, ollie, recorder)
+
+    p = next(p for et, p in recorder.events if et == EVENT_ASK_OLLIE_COMPLETED)
+    for key in (
+        "is_ci",
+        "is_container",
+        "launch_method",
+        "install_id_freshly_generated",
+        "mcp_host",
+        "host_llm_family",
+    ):
+        assert key in p, f"missing session-context field {key!r}"
+    # No ctx passed by _run_with → host fields fall back to defaults.
+    assert p["mcp_host"] == "other"
+    assert p["host_llm_family"] == "unknown"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Stamps a **6-field session-context block** onto every `opik_mcp_tool_called` and `opik_mcp_ask_ollie_completed` event so BI can segment per-call analytics by real-user cohort + MCP host **on a single table**, without joining each call back to `server_started` / `session_initialized` on `install_id` — a join that drops ~35% of calls in practice.

The block:

| Field | Source | Caching |
|---|---|---|
| `is_ci` | env detector | process-stable, `lru_cache` |
| `is_container` | env detector | process-stable, `lru_cache` |
| `launch_method` | env detector | process-stable, `lru_cache` |
| `install_id_freshly_generated` | identity | process-stable, `lru_cache` |
| `mcp_host` | handshake (`clientInfo.name`, bucketed) | per-session, `WeakKeyDictionary` |
| `host_llm_family` | derived from bucketed host | per-session, `WeakKeyDictionary` |

Bundled in are two privacy / bucketing fixes surfaced during review of this change.

## What changed

**Per-call session context**
- `analytics/environment.py` — new `cached_call_context_env()` (`lru_cache`, resolved once/process); `_safe` detector wrapper lifted to module scope for reuse. Heavy `config`-pulling `identity` import kept lazy to avoid eager import cost on this hot-path module (no actual cycle).
- `analytics/mcp_client_info.py` — new `call_context_props(session)` merging the cached env block with per-session host fields; `_host_context` caches the two host fields in a `WeakKeyDictionary`, gracefully recomputing for non-weakreffable sessions.
- `analytics/wrappers.py` (`tool_called`) and `ask_ollie.py` (`ask_ollie_completed`) — stamp the block in the emit path; `session` may be `None` → falls back to `other`/`unknown`.

**Privacy: `auto_approval_tools` allowlisting**
- `ask_ollie.py` — `target_tool` arrives in the pod's `confirm_required` SSE frame and is pod-controlled free text. It was previously emitted **verbatim**. Now allowlisted against `WRITE_OPERATIONS` via `_bucket_auto_approval_tools` (unknown / free-text → `"other"`).

**Error bucketing: `MissingConfigError`**
- `config.py` — now declares `error_kind="validation"` / `http_status=400` (was `unknown`/`None`). It's a deterministic, classifiable setup error (missing api_key/workspace), not an unexpected fault, so the classifier should route it to `validation` rather than the catch-all `unknown` bucket.

## Privacy contract

Every value emitted is a **boolean string or an allowlisted enum** — no raw paths, hostnames, usernames, `clientInfo` strings, or pod tool names reach an event verbatim. An unrecognized MCP host buckets to `other`; an unknown pod `target_tool` buckets to `other`. Enforced by canary tests in `test_analytics_privacy.py` (the real `instrument_tool` emit path is driven with poisoned `clientInfo` + `HOME`) and the new `auto_approval_tools` allowlist test.

## Performance

- Env fingerprint resolved **once per process** (`lru_cache`) — some detectors shell out to `subprocess`, so this stays off the per-call hot path.
- `clientInfo` read + bucketed **once per session** (`WeakKeyDictionary`), reused on every subsequent call.

## Review findings addressed

An independent code review flagged 5 items; all addressed:
1. Stale `_USER_SIDE_EXCEPTIONS` comment (claimed `MissingConfigError` → `unknown`) — corrected; entry kept as belt-and-braces.
2. `_host_context` caching scope — docstring now warns callers not to layer it on top of `collect_session_props` and double-extract.
3. `auto_approval_tools` raw pod strings — fixed (allowlist, above).
4. Misleading "import cycle" comment in `environment.py` — rewritten to reflect the real motive (import cost).
5. PR separability — moot; shipped together so there's no interim window where `MissingConfigError` could page Sentry.

## Test plan

- [x] `pytest` — 877 passed, 2 skipped
- [x] `ruff check .` — clean
- [x] `mypy src/` — clean (40 files)
- [x] New: `test_analytics_call_context.py` (env caching/memoization, host bucketing, per-session cache, integration emit)
- [x] New: `test_bucket_auto_approval_tools_*` (allowlist + canary), `test_completed_carries_session_context`
- [x] New privacy canaries in `test_analytics_privacy.py`
- [x] Updated `MissingConfigError` assertions in `test_analytics_errors.py` / `test_analytics_wrappers.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)