### PR TITLE
feat(analytics): ask_ollie failure_reason taxonomy + host context on every event

### DIFF
--- a/src/opik_mcp/analytics/ask_ollie_reason.py
+++ b/src/opik_mcp/analytics/ask_ollie_reason.py
@@ -164,7 +164,7 @@ def derive_failure_reason(
     exc: BaseException,
     phase: AskOlliePhase,
     *,
-    upstream_code: str | None = None,  # noqa: ARG001 (reserved for future sub-bucketing)
+    upstream_code: str | None = None,
 ) -> AskOllieFailureReason:
     """Derive a phase-aware ``failure_reason`` for an ``ask_ollie`` failure.
 
@@ -179,7 +179,7 @@ def derive_failure_reason(
     2. Match against ``_TYPED_REASONS`` (typed leaf classes pinned at their
        raise sites).
     3. Status-bearing exceptions (``httpx.HTTPStatusError`` etc.): bucket
-       by status × phase via ``_comet_http_reason`` / ``_pod_http_reason``.
+       by status x phase via ``_comet_http_reason`` / ``_pod_http_reason``.
     4. Non-status network/timeout (``httpx.TimeoutException`` etc.): bucket
        by ``_network_reason``.
     5. ``unknown`` fall-through.

--- a/src/opik_mcp/analytics/ask_ollie_reason.py
+++ b/src/opik_mcp/analytics/ask_ollie_reason.py
@@ -120,9 +120,7 @@ def _pod_http_reason(status: int | None) -> AskOllieFailureReason:
     return "unknown"
 
 
-def _network_reason(
-    real: BaseException, phase: AskOlliePhase
-) -> AskOllieFailureReason | None:
+def _network_reason(real: BaseException, phase: AskOlliePhase) -> AskOllieFailureReason | None:
     """Map non-status httpx errors to the phase-appropriate bucket."""
     if isinstance(real, httpx.TimeoutException):
         return "comet_timeout" if phase == "discover" else "pod_timeout"

--- a/src/opik_mcp/analytics/ask_ollie_reason.py
+++ b/src/opik_mcp/analytics/ask_ollie_reason.py
@@ -1,0 +1,218 @@
+"""Ask-Ollie-specific failure taxonomy.
+
+Layered on top of the coarse ``ErrorKind`` (which is shared across every
+tool). ``ask_ollie`` orchestrates four upstream services — comet-backend
+(pod discovery), the Ollie pod itself (warmup, session create, SSE
+stream, confirm POST) — and the same exception class can surface in more
+than one phase with very different operational meanings: an
+``OllieAuthError`` from ``wait_ready`` is a stale PPAUTH after discovery
+succeeded, while the same class from ``stream_events`` is a mid-stream
+auth flip. Coarse ``error_kind=auth`` collapses both; the per-phase
+``failure_reason`` separates them so a dashboard can route the right
+on-call.
+
+PRIVACY: every value here is a fixed ``Literal`` — no message text or
+upstream body is inspected. Phase is set by ask_ollie before each await
+boundary; reason is derived from ``(phase, type(exc), http_status,
+upstream_code)`` only. ``exc.args`` / ``str(exc)`` are never read.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+
+from opik_mcp.analytics.errors import (
+    derive_http_status,
+    unwrap_to_real_cause,
+)
+from opik_mcp.comet_client import (
+    CometAuthError,
+    CometPermissionError,
+    CometProtocolError,
+    OllieNotAvailableError,
+    OllieNotEnabledError,
+)
+from opik_mcp.config import MissingConfigError
+from opik_mcp.ollie_client import (
+    ConfirmDeclinedError,
+    ConfirmPostError,
+    OllieAuthError,
+    OllieStreamError,
+    PodErrorEventError,
+    PodNotReadyError,
+    PodSessionCreateError,
+    PodSessionLostError,
+    PodStreamIdleError,
+)
+
+AskOlliePhase = Literal[
+    "config",
+    "discover",
+    "warmup",
+    "create_session",
+    "stream",
+    "confirm",
+]
+
+AskOllieFailureReason = Literal[
+    # Config phase
+    "missing_config",
+    # Pod discovery (comet-backend → /api/opik/ollie/compute-api-key)
+    "comet_auth",
+    "workspace_forbidden",
+    "ollie_not_available",
+    "ollie_not_enabled",
+    "comet_protocol_drift",
+    "comet_5xx",
+    "comet_4xx_other",
+    "comet_timeout",
+    "comet_network",
+    # Pod (warmup / create_session / stream)
+    "pod_warmup_timeout",
+    "pod_auth",
+    "session_create_protocol_drift",
+    "session_lost",
+    "pod_error_event",
+    "pod_stream_idle",
+    "pod_5xx",
+    "pod_4xx_other",
+    "pod_timeout",
+    "pod_network",
+    # Confirm flow
+    "confirm_declined",
+    "confirm_post_failed",
+    # Fall-through
+    "unknown",
+]
+
+
+def _is_5xx(status: int | None) -> bool:
+    return status is not None and 500 <= status < 600
+
+
+def _is_4xx(status: int | None) -> bool:
+    return status is not None and 400 <= status < 500
+
+
+def _comet_http_reason(status: int | None) -> AskOllieFailureReason:
+    if status == 401:
+        return "comet_auth"
+    if status == 403:
+        return "workspace_forbidden"
+    if status == 404:
+        return "ollie_not_available"
+    if _is_5xx(status):
+        return "comet_5xx"
+    if _is_4xx(status):
+        return "comet_4xx_other"
+    return "unknown"
+
+
+def _pod_http_reason(status: int | None) -> AskOllieFailureReason:
+    if status in (401, 403):
+        return "pod_auth"
+    if _is_5xx(status):
+        return "pod_5xx"
+    if _is_4xx(status):
+        return "pod_4xx_other"
+    return "unknown"
+
+
+def _network_reason(
+    real: BaseException, phase: AskOlliePhase
+) -> AskOllieFailureReason | None:
+    """Map non-status httpx errors to the phase-appropriate bucket."""
+    if isinstance(real, httpx.TimeoutException):
+        return "comet_timeout" if phase == "discover" else "pod_timeout"
+    if isinstance(real, httpx.RequestError):
+        return "comet_network" if phase == "discover" else "pod_network"
+    return None
+
+
+# Map of typed exception class → fixed failure_reason. Checked in MRO-aware
+# order via isinstance, so subclasses must precede parents in the tuple.
+# Pinned per raise site by the typed-exception design (see
+# ``ollie_client.py``); the analytics layer routes by ``isinstance`` rather
+# than sniffing message text.
+_TYPED_REASONS: tuple[tuple[type[BaseException], AskOllieFailureReason], ...] = (
+    # Config
+    (MissingConfigError, "missing_config"),
+    # Comet typed (CometPermissionError subclasses CometAuthError — list first)
+    (OllieNotAvailableError, "ollie_not_available"),
+    (OllieNotEnabledError, "ollie_not_enabled"),
+    (CometProtocolError, "comet_protocol_drift"),
+    (CometPermissionError, "workspace_forbidden"),
+    (CometAuthError, "comet_auth"),
+    # Pod typed
+    (PodNotReadyError, "pod_warmup_timeout"),
+    (OllieAuthError, "pod_auth"),
+    # OllieStreamError subclasses — list ALL before the parent so isinstance
+    # routes to the subclass bucket. Parent isn't in this table; bare
+    # OllieStreamError falls through to the http/network/unknown arms.
+    (PodSessionCreateError, "session_create_protocol_drift"),
+    (PodSessionLostError, "session_lost"),
+    (PodErrorEventError, "pod_error_event"),
+    (PodStreamIdleError, "pod_stream_idle"),
+    (ConfirmDeclinedError, "confirm_declined"),
+    (ConfirmPostError, "confirm_post_failed"),
+)
+
+
+def derive_failure_reason(
+    exc: BaseException,
+    phase: AskOlliePhase,
+    *,
+    upstream_code: str | None = None,  # noqa: ARG001 (reserved for future sub-bucketing)
+) -> AskOllieFailureReason:
+    """Derive a phase-aware ``failure_reason`` for an ``ask_ollie`` failure.
+
+    Resolution order:
+    1. Unwrap ``ToolError`` / ``OllieStreamError`` pure-envelope wrappers
+       to the real cause so we route on the leaf class. ``OllieStreamError``
+       SUBCLASSES (PodSessionCreateError, PodErrorEventError, etc.) are NOT
+       envelopes — they're leaves — and ``unwrap_to_real_cause`` stops at
+       them via ``_WRAPPER_CLASSES`` membership (only the bare parent is in
+       that tuple). The wrapper-only check + the subclass-first ordering in
+       ``_TYPED_REASONS`` are what keep this right.
+    2. Match against ``_TYPED_REASONS`` (typed leaf classes pinned at their
+       raise sites).
+    3. Status-bearing exceptions (``httpx.HTTPStatusError`` etc.): bucket
+       by status × phase via ``_comet_http_reason`` / ``_pod_http_reason``.
+    4. Non-status network/timeout (``httpx.TimeoutException`` etc.): bucket
+       by ``_network_reason``.
+    5. ``unknown`` fall-through.
+
+    PRIVACY: inspects class identity, ``derive_http_status`` (integer-only
+    instance read on ``httpx.Response``), and the caller-supplied phase.
+    Never reads ``exc.args`` / ``str(exc)`` / ``upstream_code`` body.
+    """
+    real = unwrap_to_real_cause(exc)
+
+    for klass, reason in _TYPED_REASONS:
+        if isinstance(real, klass):
+            return reason
+
+    # Status-bearing (httpx.HTTPStatusError, BackendError, ClassVar fallback).
+    # Note: bare OllieStreamError (no cause unwrapped past it) lands here
+    # with no status → falls through to "unknown". That's correct: a
+    # bare-parent raise from outside the named raise sites is a
+    # protocol-drift signal we don't have a bucket for — show up as
+    # ``unknown`` and someone investigates.
+    status = derive_http_status(exc)
+    if status is not None:
+        if phase == "discover":
+            return _comet_http_reason(status)
+        return _pod_http_reason(status)
+
+    net = _network_reason(real, phase)
+    if net is not None:
+        return net
+
+    # Suppress unused-import warning for the parent type — kept in scope so
+    # readers see at a glance that we intentionally do NOT route bare
+    # OllieStreamError through _TYPED_REASONS (only its subclasses do).
+    _ = OllieStreamError
+
+    return "unknown"

--- a/src/opik_mcp/analytics/errors.py
+++ b/src/opik_mcp/analytics/errors.py
@@ -51,23 +51,42 @@ __all__ = [
 
 # Pure-envelope exception classes — these wrap a real upstream cause via
 # ``raise X from e`` (or implicit ``__context__``) and never carry their own
-# bucketing signal beyond ``"unknown"``. ``bucket_exception`` walks past
-# them to find the real culprit; emit sites preserve the wrapper class name
-# in ``exception_type`` and the unwrapped class in ``cause_type``.
+# bucketing signal beyond their default bucket. ``bucket_exception`` walks
+# past them to find the real culprit; emit sites preserve the wrapper class
+# name in ``exception_type`` and the unwrapped class in ``cause_type``.
 #
 # Why ``ToolError``: FastMCP's contract is that tool handlers surface failures
 # to the host via ``ToolError`` (see ``read_list/``, ``writes/``). Without the
 # unwrap, every read/list/write failure showed up as ``unknown / ToolError``
 # in BI, masking auth/not_found/upstream_5xx patterns.
 #
-# Why ``OllieStreamError``: a ``RuntimeError`` subclass we raise both as a
-# leaf (e.g. protocol-drift "no session_id") AND as a wrapper around upstream
-# HTTP failures. Its own ``error_kind`` ClassVar is ``"unknown"`` so the
-# bare-leaf case still buckets correctly; the wrapper case routes by cause.
+# Why bare ``OllieStreamError``: a ``RuntimeError`` we raise as a leaf for
+# protocol-drift signals AND (historically) as a wrapper around upstream
+# HTTP failures. Its own bucket is ``"stream_protocol"`` so the bare-leaf
+# case still buckets correctly; the wrapper case routes by cause.
+#
+# NOTE: typed subclasses of ``OllieStreamError`` (``PodSessionLostError``,
+# ``PodStreamIdleError``, ``ConfirmPostError``, …) own their own bucket
+# (``session_evicted``, ``stream_idle``, ``confirm_failed``, …). They are
+# NOT wrappers — see ``_is_wrapper_exception`` below: the wrapper test is
+# type-exact, not ``isinstance``. This is what lets ``ConfirmPostError``
+# (raised ``from exc``) surface as ``confirm_failed`` rather than being
+# unwrapped to its httpx cause's bucket.
 _WRAPPER_CLASSES: tuple[type[BaseException], ...] = (
     ToolError,
     OllieStreamError,
 )
+
+
+def _is_wrapper_exception(exc: BaseException) -> bool:
+    """``True`` iff ``exc`` is one of the pure-envelope wrapper classes.
+
+    Type-exact match (``type(exc) in _WRAPPER_CLASSES``) — subclasses are
+    treated as typed leaves with their own ``error_kind`` ClassVar. Without
+    this, a ``ConfirmPostError`` raised ``from`` an httpx error would unwrap
+    to the httpx cause and lose its ``confirm_failed`` signal.
+    """
+    return type(exc) in _WRAPPER_CLASSES
 
 
 # Cap on chain depth to keep cycles / deeply-nested wrappers from turning the
@@ -100,7 +119,7 @@ def unwrap_to_real_cause(
     seen: set[int] = {id(exc)}
     current: BaseException = exc
     for _ in range(max_depth):
-        if not isinstance(current, _WRAPPER_CLASSES):
+        if not _is_wrapper_exception(current):
             return current
         nxt: BaseException | None = current.__cause__
         if nxt is None and not current.__suppress_context__:

--- a/src/opik_mcp/analytics/wrappers.py
+++ b/src/opik_mcp/analytics/wrappers.py
@@ -50,20 +50,31 @@ T = TypeVar("T")
 # dropping server-side in ``before_send``.
 _USER_SIDE_ERROR_KINDS: frozenset[str] = frozenset(
     {
+        # Cross-tool coarse buckets (read / list / write / schema)
         "auth",  # 401 — bad API key / wrong workspace
         "permission",  # 403 — workspace access denied
         "validation",  # 400/422 — payload rejected by Opik or pydantic
         "not_found",  # 404 — entity doesn't exist
+        # ask_ollie-specific user-config buckets. These are all
+        # caller-actionable (bad key, missing workspace access, ollie not
+        # turned on, user declined an elicit prompt) — Sentry would only
+        # surface noise.
+        "comet_auth",  # bad/expired OPIK_API_KEY at the Comet layer
+        "comet_permission",  # workspace access denied at the Comet layer
+        "ollie_not_enabled",  # workspace doesn't have ollie-assist enabled
+        "pod_auth",  # PPAUTH cookie rejected by the pod
+        "cancelled",  # user-initiated cancellation (ConfirmDeclinedError)
     }
 )
 
 
-# User-config problems Sentry shouldn't carry. ``OllieNotEnabledError`` buckets
-# to ``"unknown"`` (indistinguishable from real bugs like ``CometProtocolError``
-# at the kind level), so it NEEDS this class-based skip. ``MissingConfigError``
-# now buckets to ``"validation"`` and is already skipped via
-# ``_USER_SIDE_ERROR_KINDS``; it stays here as belt-and-braces so a future
-# re-classification can't silently start paging Sentry.
+# Belt-and-braces class-based Sentry skip-list. Both classes already bucket
+# into ``_USER_SIDE_ERROR_KINDS`` via their ``ClassVar[ErrorKind]``
+# (``MissingConfigError`` → ``"validation"``, ``OllieNotEnabledError`` →
+# ``"ollie_not_enabled"``), so the bucket-based filter above is the primary
+# gate. This list stays as a defensive backstop — a future re-classification
+# of either class (e.g. ``MissingConfigError`` reclassified to ``"unknown"``)
+# would silently start paging Sentry otherwise.
 _USER_SIDE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     MissingConfigError,
     OllieNotEnabledError,
@@ -370,6 +381,11 @@ def _maybe_emit_tools_listed(result: Any) -> None:
     transport_probe.mark_first_rpc()
 
     props = {"tool_count_bucket": bucket_count(len(tools))}
+    # Stamp env cohort + bucketed MCP host so tools_listed segments on the
+    # same dimensions as tool_called and ask_ollie_completed. ``session``
+    # may be None when invoked outside a host (HTTP probe, test); the
+    # helper returns empty dict in that case.
+    props.update(call_context_props(session))
     try:
         _client().track_event(EVENT_TOOLS_LISTED, props)
     except BaseException:

--- a/src/opik_mcp/ask_ollie.py
+++ b/src/opik_mcp/ask_ollie.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from collections.abc import AsyncIterator
 from typing import Any, Protocol
@@ -11,12 +12,25 @@ from pydantic import BaseModel
 
 from opik_mcp import audit
 from opik_mcp.analytics import EVENT_ASK_OLLIE_COMPLETED, bucket_count
+from opik_mcp.analytics.ask_ollie_reason import (
+    AskOlliePhase,
+    derive_failure_reason,
+)
 from opik_mcp.analytics.errors import bucket_exception, unwrap_to_real_cause
 from opik_mcp.analytics.mcp_client_info import call_context_props
 from opik_mcp.comet_client import CometClient, PodDiscovery
 from opik_mcp.config import Settings, get_settings, require_ollie_config
 from opik_mcp.elicitation import confirm_with_user
-from opik_mcp.ollie_client import OllieClient, OllieStreamError, OnTick, SSEEvent
+from opik_mcp.ollie_client import (
+    ConfirmDeclinedError,
+    ConfirmPostError,
+    OllieClient,
+    OllieStreamError,
+    OnTick,
+    PodErrorEventError,
+    PodStreamIdleError,
+    SSEEvent,
+)
 from opik_mcp.writes.registry import WRITE_OPERATIONS
 
 logger = logging.getLogger("opik_mcp.ask_ollie")
@@ -45,6 +59,28 @@ def _bucket_auto_approval_tools(details: list[tuple[str | None, str | None]]) ->
     write operations (unknown / pod-supplied names → ``"other"``)."""
     buckets = {(t if t in _KNOWN_TARGET_TOOLS else "other") for t, _ in details if t}
     return ",".join(sorted(buckets))
+
+
+# ``upstream_error_code`` on ``EVENT_ASK_OLLIE_COMPLETED`` is the optional
+# ``code`` field on the pod's SSE ``error`` frame. Pod-controlled free text →
+# CONTRACT: must look like a stable identifier (lowercase alnum, ``_`` / ``-``
+# separators, ≤ 32 chars). Anything outside the shape — a long sentence, a
+# stack trace, a UUID, a URL, an email — collapses to ``"other"`` so BI
+# cardinality can't be blown up by a future pod release shipping arbitrary
+# strings. ``None`` is preserved so the emit site can omit the field entirely.
+#
+# 32 chars is well above any legitimate code we've seen (``"rate_limited"``,
+# ``"model_unavailable"``, ``"context_too_long"``) and tight enough that a
+# misbehaving pod can't slip a PII payload through.
+_UPSTREAM_CODE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+
+def _bucket_upstream_code(code: str | None) -> str | None:
+    """Pass-through for shape-valid pod codes, ``"other"`` for anything that
+    doesn't match the identifier pattern, ``None`` for absent codes."""
+    if code is None:
+        return None
+    return code if _UPSTREAM_CODE_PATTERN.match(code) else "other"
 
 
 # Session-scoped allowlist of pod target_tool names that the user has
@@ -231,6 +267,13 @@ async def run_ask_ollie(
     error_exception_type: str = ""
     error_cause_type: str = ""
     error_upstream_code: str | None = None
+    error_failure_reason: str = "unknown"
+    # Phase tracker for ``failure_reason`` derivation. Updated immediately
+    # before each await boundary that can raise so the analytics layer can
+    # attribute typed exceptions (e.g. OllieAuthError) to the right phase
+    # (warmup vs create_session vs stream). Starts at ``"config"`` so a
+    # pre-discovery MissingConfigError still carries a phase.
+    phase: AskOlliePhase = "config"
 
     try:
         settings = settings or get_settings()
@@ -259,6 +302,7 @@ async def run_ask_ollie(
             workspace,
             settings.comet_url_override,
         )
+        phase = "discover"
         discovery = await comet.discover_pod(workspace)
 
         if ctx is not None:
@@ -284,6 +328,7 @@ async def run_ask_ollie(
             )
 
         warmup_start = time.monotonic()
+        phase = "warmup"
         await ollie.wait_ready(discovery.compute_url, discovery.ppauth, on_tick=on_tick)
         pod_warmup_ms = int((time.monotonic() - warmup_start) * 1000)
 
@@ -316,10 +361,12 @@ async def run_ask_ollie(
             # structured `context` envelope above.
             body["snapshot"] = page_context
 
+        phase = "create_session"
         session_id = await ollie.create_session(
             discovery.compute_url, discovery.ppauth, workspace, body
         )
         logger.info("ask_ollie.session_created session_id=%s", session_id)
+        phase = "stream"
 
         if ctx is not None:
             await ctx.info(f"Streaming events for session {session_id}...")
@@ -379,7 +426,7 @@ async def run_ask_ollie(
                     # cancels the SSE consumer. The BaseExceptionGroup unwrap below
                     # filters the resulting CancelledError so callers see the
                     # OllieStreamError with the diagnostic message.
-                    raise OllieStreamError(
+                    raise PodStreamIdleError(
                         f"Ollie pod stream idle for {idle_for:.0f}s "
                         f"(threshold {stream_idle_timeout:.0f}s); aborting."
                     )
@@ -525,7 +572,7 @@ async def run_ask_ollie(
                                             target_tool,
                                         )
                                 if not approved_via_elicit:
-                                    raise OllieStreamError(
+                                    raise ConfirmDeclinedError(
                                         "Auto-approval disabled "
                                         "(OPIK_MCP_AUTO_APPROVE=disabled). "
                                         f"Ollie requested: {requested}. "
@@ -545,6 +592,9 @@ async def run_ask_ollie(
                                     target_tool=target_tool,
                                     summary=summary,
                                     input=tool_input,
+                                    mcp_session=getattr(ctx, "session", None)
+                                    if ctx is not None
+                                    else None,
                                 )
                             except Exception:
                                 logger.error(
@@ -568,6 +618,7 @@ async def run_ask_ollie(
                                 await ctx.info(
                                     f"Ollie auto-approved: {summary or target_tool or tool_use_id}"
                                 )
+                            phase = "confirm"
                             try:
                                 await ollie.confirm_session(
                                     discovery.compute_url,
@@ -582,10 +633,11 @@ async def run_ask_ollie(
                                 # transient confirm POST failure leaves the pod
                                 # stalled — surface a typed error instead of bubbling
                                 # the raw httpx exception to the host LLM.
-                                raise OllieStreamError(
+                                raise ConfirmPostError(
                                     f"Ollie confirm POST failed for"
                                     f" tool_use_id={tool_use_id}: {exc}"
                                 ) from exc
+                            phase = "stream"
 
                         elif evt == "navigate":
                             url = _navigate_url(payload)
@@ -609,7 +661,7 @@ async def run_ask_ollie(
                             # upstream failures without leaking the message.
                             raw_code = payload.get("code")
                             upstream_code = raw_code if isinstance(raw_code, str) else None
-                            raise OllieStreamError(message, upstream_code=upstream_code)
+                            raise PodErrorEventError(message, upstream_code=upstream_code)
 
                         elif evt == "message_end":
                             saw_message_end = True
@@ -714,6 +766,20 @@ async def run_ask_ollie(
                 real_cause = unwrap_to_real_cause(exc)
                 if real_cause is not exc:
                     error_cause_type = type(real_cause).__name__
+                # Phase-aware ask_ollie-specific bucket. Routes typed
+                # exceptions (CometAuthError, PodSessionLostError, …) to a
+                # single failure_reason per raise site so dashboards can
+                # split "wrong env" (ollie_not_available) from "session
+                # evicted" (session_lost) — both surface as not_found in
+                # the coarse error_kind.
+                error_upstream_code_for_reason = getattr(exc, "upstream_code", None)
+                error_failure_reason = derive_failure_reason(
+                    exc,
+                    phase,
+                    upstream_code=error_upstream_code_for_reason
+                    if isinstance(error_upstream_code_for_reason, str)
+                    else None,
+                )
             else:
                 error_kind = "unknown"
             # ``getattr`` returns ``Any`` — narrow to ``str`` here so the
@@ -751,14 +817,21 @@ async def run_ask_ollie(
         if errored:
             props["error_kind"] = error_kind
             props["exception_type"] = error_exception_type
+            # ``failure_reason`` is the ask_ollie-specific phase-aware bucket;
+            # ``error_kind`` is the coarse cross-tool bucket. Always emit both
+            # so dashboards can pivot either way.
+            props["failure_reason"] = error_failure_reason
+            props["phase"] = phase
             if error_cause_type:
                 props["cause_type"] = error_cause_type
-            if error_upstream_code:
-                # Length-cap as a defense against a misbehaving pod that
-                # stamps a long string into ``code``. 64 chars is enough
-                # for every legitimate code we ship while staying well
-                # under any plausible PII leak.
-                props["upstream_error_code"] = error_upstream_code[:64]
+            bucketed_code = _bucket_upstream_code(error_upstream_code)
+            if bucketed_code is not None:
+                # Pod-controlled free text — bucket to a stable identifier
+                # shape (alnum + ``_-``, ≤ 32 chars) or ``"other"``. See
+                # ``_bucket_upstream_code`` for the privacy/cardinality
+                # rationale; raw length-capping wasn't enough to bound
+                # what a misbehaving pod could ship.
+                props["upstream_error_code"] = bucketed_code
         try:
             _analytics().track_event(EVENT_ASK_OLLIE_COMPLETED, props)
         except Exception:

--- a/src/opik_mcp/ask_ollie.py
+++ b/src/opik_mcp/ask_ollie.py
@@ -25,7 +25,6 @@ from opik_mcp.ollie_client import (
     ConfirmDeclinedError,
     ConfirmPostError,
     OllieClient,
-    OllieStreamError,
     OnTick,
     PodErrorEventError,
     PodStreamIdleError,

--- a/src/opik_mcp/audit.py
+++ b/src/opik_mcp/audit.py
@@ -15,6 +15,26 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from opik_mcp.analytics.events import EVENT_AUTO_APPROVAL
+from opik_mcp.analytics.mcp_client_info import call_context_props
+from opik_mcp.writes.registry import WRITE_OPERATIONS
+
+# Allowlist of legitimate ``target_tool`` values for the analytics emit.
+# ``target_tool`` arrives in the pod's ``confirm_required`` SSE frame as a
+# free-text ``tool_name`` and is pod-controlled — never let it reach BI raw,
+# or a future pod release shipping arbitrary strings would blow up our
+# event cardinality. Mirrors ``ask_ollie._KNOWN_TARGET_TOOLS`` so the two
+# emit sites bucket the same set. The audit ROW (logged + Phase 2 hosted
+# ingest) keeps the raw value — only the analytics emit is bucketed.
+_KNOWN_TARGET_TOOLS: frozenset[str] = frozenset(WRITE_OPERATIONS)
+
+
+def _bucket_target_tool(target_tool: str | None) -> str:
+    """Pass-through for allowlisted write ops, ``"other"`` for unknown
+    pod-supplied names, ``""`` for None. Parallel to
+    ``_bucket_auto_approval_tools`` on the ``ask_ollie_completed`` event."""
+    if target_tool is None:
+        return ""
+    return target_tool if target_tool in _KNOWN_TARGET_TOOLS else "other"
 
 
 def _analytics_for_audit() -> Any:
@@ -66,11 +86,19 @@ def write_auto_approval(
     target_tool: str | None,
     summary: str | None,
     input: dict[str, Any],
+    mcp_session: Any = None,
 ) -> AuditRow:
     """Record that `opik-mcp` auto-approved a pod ``confirm_required`` event.
 
     Returns the constructed row so callers (and tests) can introspect it
     without re-parsing the log line.
+
+    ``mcp_session`` is the host-side ServerSession (``ctx.session`` in
+    ask_ollie). Threaded through so the analytics emit stamps the same
+    env-cohort + bucketed-host block as ``tool_called`` /
+    ``ask_ollie_completed``. ``None`` is safe — ``call_context_props``
+    falls back to the ``other``/``unknown`` defaults so the schema is
+    stable.
     """
     row = AuditRow(
         event="ollie_write_auto_approved",
@@ -85,14 +113,13 @@ def write_auto_approval(
     )
     _audit_logger.info("audit %s", row.model_dump_json())
     try:
-        _analytics_for_audit().track_event(
-            EVENT_AUTO_APPROVAL,
-            {
-                "tool": "ask_ollie",
-                "target_tool": target_tool or "",
-                "had_summary": str(summary is not None).lower(),
-            },
-        )
+        props = {
+            "tool": "ask_ollie",
+            "target_tool": _bucket_target_tool(target_tool),
+            "had_summary": str(summary is not None).lower(),
+        }
+        props.update(call_context_props(mcp_session))
+        _analytics_for_audit().track_event(EVENT_AUTO_APPROVAL, props)
     except Exception:
         # Audit row is the source of truth; analytics is a secondary signal.
         # Never let analytics fail the auto-approval write.

--- a/src/opik_mcp/comet_client.py
+++ b/src/opik_mcp/comet_client.py
@@ -8,9 +8,15 @@ from opik_mcp.error_kinds import ErrorKind
 
 
 class CometAuthError(RuntimeError):
-    """Comet-backend rejected the API key (401)."""
+    """Comet-backend rejected the API key (401).
 
-    error_kind: ClassVar[ErrorKind] = "auth"
+    Bucketed as ``comet_auth`` (ask_ollie-specific): distinct from generic
+    Opik 401 (``auth``) because failure here means pod discovery couldn't
+    even start, whereas a generic 401 on a read/write tool means the API
+    key works for some endpoints but not others.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "comet_auth"
     http_status: ClassVar[int | None] = 401
 
 
@@ -19,29 +25,52 @@ class CometPermissionError(CometAuthError):
     rejects the request. Subclass of ``CometAuthError`` to preserve existing
     ``except CometAuthError`` callers; the ``error_kind`` / ``http_status``
     ClassVars shadow the parent's so analytics still distinguish the two.
+
+    Bucketed as ``comet_permission`` (ask_ollie-specific) for the same
+    reason as ``CometAuthError``: a generic 403 surfaces as ``permission``.
     """
 
-    error_kind: ClassVar[ErrorKind] = "permission"
+    error_kind: ClassVar[ErrorKind] = "comet_permission"
     http_status: ClassVar[int | None] = 403
 
 
 class OllieNotEnabledError(RuntimeError):
     """Workspace does not have ollie-assist enabled.
 
-    Bucketed as ``"unknown"`` — it's a user-config problem with no clean
-    place in the upstream-failure taxonomy. The Sentry skip-list in
-    ``analytics/wrappers.py`` covers it separately by class.
+    Bucketed as ``ollie_not_enabled`` — a user-config problem distinct from
+    "Ollie isn't deployed in this env" (``OllieNotAvailableError`` →
+    ``not_found``). The Sentry skip-list in ``analytics/wrappers.py``
+    covers user-side buckets, so this still skips Sentry capture.
     """
 
-    error_kind: ClassVar[ErrorKind] = "unknown"
+    error_kind: ClassVar[ErrorKind] = "ollie_not_enabled"
     http_status: ClassVar[int | None] = None
+
+
+class OllieNotAvailableError(RuntimeError):
+    """Comet-backend returned 404 for ``/api/opik/ollie/compute-api-key``.
+
+    Distinct from ``OllieNotEnabledError`` (workspace is known but Ollie is
+    toggled off): a 404 means the compute-api-key route doesn't exist for
+    this workspace at all — either Ollie isn't deployed in the env, the
+    comet-backend is older than the route, or the workspace identifier is
+    wrong. Surfaced separately so dashboards can tell "wrong env" from
+    "session evicted mid-stream" (also a 404, but at a different URL).
+    """
+
+    error_kind: ClassVar[ErrorKind] = "not_found"
+    http_status: ClassVar[int | None] = 404
 
 
 class CometProtocolError(RuntimeError):
     """Comet-backend response was not in the expected shape — our own
-    contract-drift signal, not an upstream HTTP failure."""
+    contract-drift signal, not an upstream HTTP failure.
 
-    error_kind: ClassVar[ErrorKind] = "unknown"
+    Bucketed as ``comet_protocol`` (ask_ollie-specific) so BI can split
+    Comet-side contract drifts from generic ``unknown`` failures.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "comet_protocol"
     http_status: ClassVar[int | None] = None
 
 
@@ -87,6 +116,14 @@ class CometClient:
             preview = resp.text[:300].replace("\n", " ")
             raise CometProtocolError(
                 f"Comet returned 400 Bad Request for workspace={workspace!r}. Body: {preview!r}"
+            )
+        if resp.status_code == 404:
+            raise OllieNotAvailableError(
+                f"Ollie is not available in this environment "
+                f"(comet-backend returned 404 for workspace={workspace!r}). "
+                "Either Ollie isn't deployed for this Comet env, the workspace "
+                "name is wrong, or the comet-backend is older than the "
+                "compute-api-key route."
             )
         resp.raise_for_status()
 

--- a/src/opik_mcp/error_kinds.py
+++ b/src/opik_mcp/error_kinds.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 from typing import Literal
 
 ErrorKind = Literal[
+    # Coarse buckets shared by every tool (read / list / write / schema /
+    # ask_ollie). HTTP-status-shaped failures from the Opik backend and the
+    # generic httpx layer route here.
     "auth",
     "validation",
     "not_found",
@@ -24,4 +27,28 @@ ErrorKind = Literal[
     "upstream_5xx",
     "cancelled",
     "unknown",
+    # Startup-only bucket emitted by ``__main__._emit_startup_error`` when
+    # ``Settings`` construction raises ``pydantic.ValidationError`` (bad
+    # COMET_WORKSPACE_ID UUID, unrecognised OPIK_MCP_AUTO_APPROVE literal,
+    # etc.). The runtime ``bucket_exception`` never returns this value —
+    # listed here so the BI receiver's allowlist covers every emit site.
+    "invalid_config",
+    # ask_ollie-specific reasons. The ask_ollie pipeline is multi-stage
+    # (discover_pod → wait_ready → create_session → stream_events →
+    # confirm_session) and each stage has its own failure modes that BI
+    # wants to split out without a separate field. Other tools never raise
+    # these — but they share the field so a single dashboard column can
+    # carry both vocabularies.
+    "comet_auth",  # CometAuthError 401 — bad/expired OPIK_API_KEY
+    "comet_permission",  # CometPermissionError 403 — workspace access denied
+    "comet_protocol",  # CometProtocolError — Comet response shape drift
+    "ollie_not_enabled",  # OllieNotEnabledError — workspace lacks ollie-assist
+    "pod_not_ready",  # PodNotReadyError — warmup timed out
+    "pod_auth",  # OllieAuthError — pod rejected PPAUTH cookie
+    "session_create_failed",  # POST /sessions returned no session_id
+    "session_evicted",  # stream_events 404 — session GC'd between create + stream
+    "confirm_failed",  # POST /sessions/.../confirm raised
+    "stream_error_frame",  # pod emitted an SSE `error` event
+    "stream_idle",  # heartbeat tripped the idle-timeout watchdog
+    "stream_protocol",  # bare OllieStreamError — our own protocol-drift signal
 ]

--- a/src/opik_mcp/ollie_client.py
+++ b/src/opik_mcp/ollie_client.py
@@ -13,19 +13,25 @@ from opik_mcp.error_kinds import ErrorKind
 class PodNotReadyError(RuntimeError):
     """Pod did not become ready within the configured timeout."""
 
-    error_kind: ClassVar[ErrorKind] = "timeout"
+    error_kind: ClassVar[ErrorKind] = "pod_not_ready"
     http_status: ClassVar[int | None] = None
 
 
 class OllieAuthError(RuntimeError):
-    """Pod rejected the PPAUTH cookie."""
+    """Pod rejected the PPAUTH cookie.
 
-    error_kind: ClassVar[ErrorKind] = "auth"
+    Distinct bucket from the Comet-layer ``CometAuthError``: a PPAUTH 401
+    on the pod typically means the cookie expired between ``discover_pod``
+    and the next pod call, while a Comet 401 means the OPIK_API_KEY itself
+    is bad. Dashboards page these differently.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "pod_auth"
     http_status: ClassVar[int | None] = None
 
 
 class OllieStreamError(RuntimeError):
-    """The Ollie pod emitted an `error` SSE event.
+    """Generic Ollie-stream failure — our own protocol-drift signal.
 
     ``upstream_code`` carries the optional structured ``code`` from the SSE
     error frame (e.g. ``"rate_limited"``, ``"model_unavailable"``) so
@@ -34,18 +40,69 @@ class OllieStreamError(RuntimeError):
     raised from an internal control-flow path (confirm-POST failure, etc.)
     rather than a server-side error frame.
 
-    Bucketed as ``"unknown"`` at the leaf — it's a wrapper class, and when
-    it carries a chained cause the analytics layer unwraps to that cause's
-    bucket via ``unwrap_to_real_cause``. A bare ``OllieStreamError`` (no
-    cause) stays ``"unknown"``: it's our own protocol-drift signal.
+    Bucketed as ``"stream_protocol"`` at the bare leaf. Subclasses below
+    pin specific raise sites to their own buckets (``session_evicted``,
+    ``stream_idle``, ``stream_error_frame``, ``confirm_failed``, …). The
+    bare class itself stays a pure wrapper: when raised ``from`` an
+    upstream cause, ``unwrap_to_real_cause`` walks past it to the cause's
+    bucket; when raised bare, it surfaces as ``stream_protocol``.
     """
 
-    error_kind: ClassVar[ErrorKind] = "unknown"
+    error_kind: ClassVar[ErrorKind] = "stream_protocol"
     http_status: ClassVar[int | None] = None
 
     def __init__(self, message: str, *, upstream_code: str | None = None) -> None:
         super().__init__(message)
         self.upstream_code = upstream_code
+
+
+class PodSessionCreateError(OllieStreamError):
+    """POST /sessions returned a body without a session_id — protocol drift
+    on the pod side. Surfaced from ``OllieClient.create_session``."""
+
+    error_kind: ClassVar[ErrorKind] = "session_create_failed"
+
+
+class PodSessionLostError(OllieStreamError):
+    """GET /sessions/{id}/stream returned 404 — session was evicted between
+    create and stream connect. Surfaced from ``OllieClient.stream_events``."""
+
+    error_kind: ClassVar[ErrorKind] = "session_evicted"
+
+
+class PodErrorEventError(OllieStreamError):
+    """Pod emitted an SSE ``error`` frame mid-stream. Carries the optional
+    ``upstream_code`` from the frame."""
+
+    error_kind: ClassVar[ErrorKind] = "stream_error_frame"
+
+
+class PodStreamIdleError(OllieStreamError):
+    """Heartbeat watchdog tripped — no SSE event for longer than the
+    configured idle threshold. Surfaced from ``ask_ollie.heartbeat_loop``."""
+
+    error_kind: ClassVar[ErrorKind] = "stream_idle"
+
+
+class ConfirmDeclinedError(OllieStreamError):
+    """User declined the elicit prompt (auto-approve disabled). Surfaced
+    from ``ask_ollie`` when the user chooses not to approve a confirm."""
+
+    error_kind: ClassVar[ErrorKind] = "cancelled"
+
+
+class ConfirmPostError(OllieStreamError):
+    """POST /sessions/{id}/confirm raised — audit row already written, but
+    the pod won't make forward progress. Wraps the underlying transport
+    error via ``__cause__``.
+
+    NOT treated as a pure wrapper by the analytics unwrap (see
+    ``analytics/errors._is_wrapper_exception``): we deliberately want the
+    ``confirm_failed`` bucket to win even when there's a chained httpx
+    cause. The cause class still surfaces via ``cause_type``.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "confirm_failed"
 
 
 @dataclass
@@ -145,7 +202,7 @@ class OllieClient:
             data = resp.json()
             sid = data.get("session_id") if isinstance(data, dict) else None
             if not isinstance(sid, str) or not sid:
-                raise OllieStreamError(f"POST /sessions returned no session_id: {data!r}")
+                raise PodSessionCreateError(f"POST /sessions returned no session_id: {data!r}")
             return sid
 
     async def stream_events(
@@ -174,7 +231,7 @@ class OllieClient:
             if status in (401, 403):
                 raise OllieAuthError(f"Pod rejected /sessions/.../stream ({status}).")
             if status == 404:
-                raise OllieStreamError(
+                raise PodSessionLostError(
                     f"Session {session_id!r} not found on pod — "
                     "likely evicted between create_session and stream_events."
                 )

--- a/tests/test_analytics_errors.py
+++ b/tests/test_analytics_errors.py
@@ -27,7 +27,17 @@ from opik_mcp.comet_client import (
     OllieNotEnabledError,
 )
 from opik_mcp.config import MissingConfigError
-from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError
+from opik_mcp.ollie_client import (
+    ConfirmDeclinedError,
+    ConfirmPostError,
+    OllieAuthError,
+    OllieStreamError,
+    PodErrorEventError,
+    PodNotReadyError,
+    PodSessionCreateError,
+    PodSessionLostError,
+    PodStreamIdleError,
+)
 from opik_mcp.opik_client import (
     OpikAuthError,
     OpikNotFoundError,
@@ -134,6 +144,18 @@ def test_derive_http_status_class_lookup(exc: BaseException, expected: int | Non
     assert derive_http_status(exc) == expected
 
 
+# --- ask_ollie-specific taxonomy ---------------------------------------- #
+#
+# The ``error_kind`` allowlist carries BOTH the coarse cross-tool buckets
+# (auth / permission / validation / …) AND the ask_ollie-specific buckets
+# (comet_auth / session_evicted / stream_idle / …). The same field is shared
+# across every tool, but ask_ollie-only typed exceptions stamp the granular
+# value so dashboards can split ``ask_ollie_completed`` failures without
+# joining to a second field. Buckets must be MUTUALLY EXCLUSIVE between
+# vocabularies — a regression that flipped CometAuthError back to "auth"
+# would conflate ``ask_ollie`` events with ``read``/``list``/``write`` events.
+
+
 def test_derive_http_status_reads_httpx_response() -> None:
     """``HTTPStatusError`` carries the wire status on its response."""
     assert derive_http_status(_http_status_error(429)) == 429
@@ -146,22 +168,29 @@ def test_derive_http_status_reads_httpx_response() -> None:
 @pytest.mark.parametrize(
     "exc, expected",
     [
-        # Permission BEFORE auth — load-bearing subclass ordering.
+        # Cross-tool coarse buckets (Opik client exceptions used by read /
+        # list / write / schema). Permission BEFORE auth — load-bearing
+        # subclass ordering.
         (OpikPermissionError("x"), "permission"),
         (OpikAuthError("x"), "auth"),
-        (CometPermissionError("x"), "permission"),
-        (CometAuthError("x"), "auth"),
-        (OllieAuthError("x"), "auth"),
-        # 404 / 400 / 500.
         (OpikNotFoundError("x"), "not_found"),
         (OpikValidationError("x"), "validation"),
         (OpikServerError("x"), "upstream_5xx"),
+        # ask_ollie-specific buckets (Comet / Ollie typed exceptions). Same
+        # ``error_kind`` field as above, but the values are scoped to the
+        # ask_ollie pipeline — these exception classes never surface from
+        # read/list/write paths.
+        (CometPermissionError("x"), "comet_permission"),
+        (CometAuthError("x"), "comet_auth"),
+        (OllieAuthError("x"), "pod_auth"),
+        (PodNotReadyError("x"), "pod_not_ready"),
+        (OllieNotEnabledError("x"), "ollie_not_enabled"),
+        (CometProtocolError("x"), "comet_protocol"),
+        (OllieStreamError("x"), "stream_protocol"),
         # Pydantic argument validation lands in the same bucket as Opik's
         # typed validation error — analytics keeps them apart via
         # ``exception_type``.
         (_pydantic_error(), "validation"),
-        # Pod warmup timeout — distinct class, same bucket as httpx timeouts.
-        (PodNotReadyError("x"), "timeout"),
         # httpx hierarchy — ``TimeoutException`` is the family base; its
         # subclasses (ReadTimeout, ConnectTimeout, etc.) must all land in
         # "timeout", NOT in the broader "network" bucket.
@@ -174,11 +203,6 @@ def test_derive_http_status_reads_httpx_response() -> None:
         (httpx.ConnectError("x"), "network"),
         (httpx.ReadError("x"), "network"),
         (httpx.WriteError("x"), "network"),
-        # Our own control-flow errors that don't map cleanly to an upstream
-        # taxonomy bucket → "unknown".
-        (OllieStreamError("x"), "unknown"),
-        (OllieNotEnabledError("x"), "unknown"),
-        (CometProtocolError("x"), "unknown"),
         # Deterministic setup failure (missing api_key/workspace) → validation.
         (MissingConfigError("x"), "validation"),
         # Catch-all.
@@ -233,13 +257,28 @@ _TYPED_EXCEPTION_CLASSES: tuple[tuple[type[BaseException], str, int | None], ...
     (OpikNotFoundError, "not_found", 404),
     (OpikValidationError, "validation", 400),
     (OpikServerError, "upstream_5xx", 500),
-    (CometAuthError, "auth", 401),
-    (CometPermissionError, "permission", 403),
-    (OllieAuthError, "auth", None),
-    (OllieStreamError, "unknown", None),
-    (OllieNotEnabledError, "unknown", None),
-    (CometProtocolError, "unknown", None),
-    (PodNotReadyError, "timeout", None),
+    # ask_ollie-specific (Comet + Ollie) classes use the granular vocabulary
+    # so dashboards can split the ask_ollie pipeline by stage without joining
+    # to a second field.
+    (CometAuthError, "comet_auth", 401),
+    (CometPermissionError, "comet_permission", 403),
+    (OllieAuthError, "pod_auth", None),
+    (OllieStreamError, "stream_protocol", None),
+    # OllieStreamError subclasses pin each ask_ollie raise site to its own
+    # bucket. They are typed leaves — NOT pure wrappers — so a
+    # ``ConfirmPostError`` raised ``from httpx.ConnectError`` surfaces as
+    # ``confirm_failed``, not ``network``. The type-exact wrapper match in
+    # ``_is_wrapper_exception`` is what makes that work; see
+    # ``test_bucket_exception_subclass_type_exact_unwrap`` below.
+    (PodSessionCreateError, "session_create_failed", None),
+    (PodSessionLostError, "session_evicted", None),
+    (PodErrorEventError, "stream_error_frame", None),
+    (PodStreamIdleError, "stream_idle", None),
+    (ConfirmDeclinedError, "cancelled", None),
+    (ConfirmPostError, "confirm_failed", None),
+    (OllieNotEnabledError, "ollie_not_enabled", None),
+    (CometProtocolError, "comet_protocol", None),
+    (PodNotReadyError, "pod_not_ready", None),
     (MissingConfigError, "validation", 400),
     # Write-tool envelope: base "unknown" since concrete code never raises bare
     # WriteError; each live subclass shadows the bucket.
@@ -309,11 +348,13 @@ def test_bucket_exception_never_reads_args_or_str() -> None:
 
 
 def test_bucket_exception_subclass_resolves_before_parent() -> None:
-    """``OpikPermissionError`` extends ``OpikAuthError``. The bucketing layer
-    must isinstance-check the specific class first so a 403 doesn't get
-    mislabeled as 401 (and the dashboards lose the distinction)."""
+    """``OpikPermissionError`` extends ``OpikAuthError`` and
+    ``CometPermissionError`` extends ``CometAuthError``. The bucketing layer
+    must surface the SUBCLASS's ClassVar (Python's normal MRO) — a regression
+    that flipped resolution order would mask every 403 as a 401."""
     assert bucket_exception(OpikPermissionError("x")) == "permission"
-    assert bucket_exception(CometPermissionError("x")) == "permission"
+    # CometPermissionError gets its ask_ollie-specific bucket, NOT the parent's.
+    assert bucket_exception(CometPermissionError("x")) == "comet_permission"
 
 
 # --- unwrap_to_real_cause ------------------------------------------------ #
@@ -485,12 +526,15 @@ _WRAPPED_BUCKET_MATRIX = [
     (OpikNotFoundError("404"), "not_found", 404),
     (OpikValidationError("400"), "validation", 400),
     (OpikServerError("500"), "upstream_5xx", 500),
-    (CometAuthError("401"), "auth", 401),
-    (CometPermissionError("403"), "permission", 403),
-    (PodNotReadyError("warmup"), "timeout", None),
+    # Comet/Pod typed exceptions carry the ask_ollie-specific ClassVar
+    # buckets through the wrapper unchanged — the unwrap surfaces the
+    # leaf, and the leaf's ClassVar wins.
+    (CometAuthError("401"), "comet_auth", 401),
+    (CometPermissionError("403"), "comet_permission", 403),
+    (PodNotReadyError("warmup"), "pod_not_ready", None),
     (httpx.ReadTimeout("slow"), "timeout", None),
     (httpx.ConnectError("refused"), "network", None),
-    (OllieAuthError("ppauth"), "auth", None),
+    (OllieAuthError("ppauth"), "pod_auth", None),
     (MissingConfigError("no key"), "validation", 400),
 ]
 
@@ -540,11 +584,13 @@ def test_bucket_exception_bare_tool_error_stays_unknown() -> None:
     assert derive_http_status(ToolError("bare")) is None
 
 
-def test_bucket_exception_bare_ollie_stream_error_stays_unknown() -> None:
-    """Parallel to the bare-ToolError case — bare ``OllieStreamError``
-    (e.g. ``ollie_client.py:132`` "POST /sessions returned no session_id")
-    has no upstream cause and stays ``unknown``."""
-    assert bucket_exception(OllieStreamError("no session_id")) == "unknown"
+def test_bucket_exception_bare_ollie_stream_error_uses_classvar() -> None:
+    """Bare ``OllieStreamError`` raised as a leaf (no chained cause) surfaces
+    its ClassVar bucket ``stream_protocol`` — the bare-leaf raise itself is
+    a protocol-drift signal. Subclasses pin their own ClassVar
+    (``session_evicted`` / ``confirm_failed`` / …) and aren't unwrapped past
+    because the wrapper match is type-exact."""
+    assert bucket_exception(OllieStreamError("no session_id")) == "stream_protocol"
     assert derive_http_status(OllieStreamError("no session_id")) is None
 
 
@@ -646,3 +692,59 @@ def test_backend_error_without_extra_status_falls_back_to_classvar() -> None:
     bare = BackendError(operation="trace.create")
     assert bucket_exception(bare) == "unknown"
     assert derive_http_status(bare) is None
+
+
+# --- OllieStreamError subclasses are typed leaves, not wrappers ---------- #
+#
+# ``_is_wrapper_exception`` uses ``type(exc) in _WRAPPER_CLASSES`` (exact
+# match, NOT ``isinstance``). The bare ``OllieStreamError`` class IS in the
+# wrapper tuple — its subclasses are NOT. This is load-bearing: a
+# ``ConfirmPostError`` raised ``from httpx.ConnectError`` MUST surface as
+# ``confirm_failed`` (the subclass's ClassVar) rather than being unwrapped
+# to the httpx cause's ``network`` bucket. If anyone ever flips the wrapper
+# check to ``isinstance(exc, _WRAPPER_CLASSES)``, every typed subclass
+# silently loses its bucket — these tests pin the contract.
+
+
+@pytest.mark.parametrize(
+    "subclass, expected_bucket",
+    [
+        (PodSessionCreateError, "session_create_failed"),
+        (PodSessionLostError, "session_evicted"),
+        (PodErrorEventError, "stream_error_frame"),
+        (PodStreamIdleError, "stream_idle"),
+        (ConfirmDeclinedError, "cancelled"),
+        (ConfirmPostError, "confirm_failed"),
+    ],
+)
+def test_bucket_exception_subclass_type_exact_unwrap(
+    subclass: type[OllieStreamError], expected_bucket: str
+) -> None:
+    """Every ``OllieStreamError`` subclass raised with a chained cause MUST
+    keep its own ClassVar bucket — the cause's bucket is intentionally
+    ignored because the subclass is a typed leaf, not a pure wrapper."""
+    chain = _raise_chain(subclass("synthetic"), httpx.ConnectError("refused"))
+    assert bucket_exception(chain) == expected_bucket
+
+
+def test_confirm_post_error_preserves_confirm_failed_over_network() -> None:
+    """The canonical regression case the type-exact match was introduced
+    for: ``ConfirmPostError`` raised ``from httpx.ConnectError`` must
+    surface as ``confirm_failed``, NOT ``network``. The cause class still
+    survives via ``cause_type`` on the emit (covered by wrapper tests)."""
+    chain = _raise_chain(ConfirmPostError("pod unreachable"), httpx.ConnectError("refused"))
+    assert bucket_exception(chain) == "confirm_failed"
+    # And the cause is still reachable for ``cause_type`` derivation —
+    # unwrap stops at the subclass leaf, which IS the chain root.
+    real = unwrap_to_real_cause(chain)
+    assert isinstance(real, ConfirmPostError)
+    assert real is not real.__cause__  # cause survives on the leaf
+
+
+def test_bare_ollie_stream_error_still_unwraps_to_cause() -> None:
+    """The bare ``OllieStreamError`` class IS in the wrapper tuple — a bare
+    ``raise OllieStreamError(...) from httpx.ConnectError(...)`` chain must
+    still unwrap to ``network``. This is the historical wrapper case the
+    type-exact match preserves while shielding the subclasses."""
+    chain = _raise_chain(OllieStreamError("wrapped"), httpx.ConnectError("refused"))
+    assert bucket_exception(chain) == "network"

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -475,7 +475,10 @@ class _CanaryOllieClient:
     message never reaches the ``ask_ollie_completed`` analytics event."""
 
     canary_message: str = "ollie-stream-error-UNIQUE-CANARY-9a8b7c6d"
-    canary_code: str = "rate_limited_canary_UNIQUE-2f3e4d5c"
+    # Shape-valid identifier: lowercase alnum + ``_-``, ≤ 32 chars. Matches
+    # ``_UPSTREAM_CODE_PATTERN`` in ask_ollie.py — passes through to BI
+    # unchanged so the test can assert the wire-up actually surfaces it.
+    canary_code: str = "rate_limited_canary"
 
     async def wait_ready(
         self, compute_url: str, ppauth: str, *, on_tick: OnTick | None = None
@@ -545,41 +548,47 @@ async def test_ask_ollie_failure_strips_stream_error_message(recorder: _Recorder
     assert completed, "ask_ollie must emit a completed event on the error path"
     props = completed[0]
     assert props["completion_state"] == "error"
-    assert props["error_kind"] == "unknown"
-    assert props["exception_type"] == "OllieStreamError"
-    # ``code`` IS allowlisted into analytics (length-capped) — it's the one
-    # field pod authors are expected to keep enum-shaped. The test passes
-    # an obviously-not-PII canary to confirm the wire-up; downstream BI is
-    # the place to enforce the actual enum.
-    assert props["upstream_error_code"] == fake.canary_code[:64]
+    # Pod error frame surfaces as ``PodErrorEventError`` (subclass of
+    # ``OllieStreamError`` raised at the SSE ``error`` event site) — its
+    # ClassVar pins ``error_kind`` to ``stream_error_frame``.
+    assert props["error_kind"] == "stream_error_frame"
+    assert props["exception_type"] == "PodErrorEventError"
+    # ``code`` IS allowlisted into analytics — it's the one field pod authors
+    # are expected to keep enum-shaped. Shape-valid codes (alnum + ``_-``,
+    # ≤ 32 chars) pass through unchanged; anything else collapses to
+    # ``"other"`` so a misbehaving pod can't smuggle text past the cap. The
+    # canary here is shape-valid by construction; the long/uppercase rejection
+    # path has its own test below.
+    assert props["upstream_error_code"] == fake.canary_code
 
 
 class _LongCodeOllieClient(_CanaryOllieClient):
     """Same canary stream as ``_CanaryOllieClient`` but with a code field
-    longer than the 64-char cap. Used to verify the length-cap actually
-    fires (the base class's canary is only 36 chars long, which would
-    pass the assertion even if the slicing were removed)."""
+    that violates the identifier shape (uppercase, > 32 chars, dashes after
+    uppercase). Used to verify the shape-check bucket fires."""
 
-    # 100 chars — comfortably over the 64-char cap. The trailing canary
-    # tail (positions 64..) must be sliced off; if it appears in props,
-    # the cap regressed.
+    # 100 chars + uppercase + sentence punctuation — comfortably outside the
+    # ``^[a-z0-9][a-z0-9_-]{0,31}$`` shape. If any character of the canary
+    # tail appears in the recorded props, the shape-check regressed.
     canary_code: str = "x" * 64 + "TAIL-MUST-BE-CHOPPED-UNIQUE-CANARY-d4e5f6a7"
 
 
 @pytest.mark.anyio
-async def test_ask_ollie_failure_caps_upstream_error_code_at_64_chars(
+async def test_ask_ollie_failure_buckets_misshaped_upstream_error_code_to_other(
     recorder: _Recorder,
 ) -> None:
-    """Production cap at ``ask_ollie.py``: ``upstream_error_code`` MUST be
-    truncated to 64 chars before emit. Pod-controlled field — without the
-    cap, a misbehaving pod could stamp arbitrary text into ``code`` and
-    smuggle it past the message-stripping privacy contract."""
+    """Pod-controlled ``code`` that doesn't match the stable-identifier shape
+    (alnum + ``_-``, ≤ 32 chars) MUST collapse to ``"other"`` on emit — the
+    earlier 64-char truncation was insufficient because uppercase, spaces,
+    and punctuation could still slip ~64 chars of pod-controlled text past
+    the message-stripping privacy contract. The shape check is the load-
+    bearing fix; this test pins it on the end-to-end emit path."""
     from opik_mcp.ask_ollie import run_ask_ollie
     from opik_mcp.config import Settings
     from opik_mcp.ollie_client import OllieStreamError
 
     fake = _LongCodeOllieClient()
-    assert len(fake.canary_code) > 64  # guard the test itself
+    assert len(fake.canary_code) > 32  # guard the test itself: must violate cap
 
     with pytest.raises(OllieStreamError):
         await run_ask_ollie(
@@ -592,11 +601,11 @@ async def test_ask_ollie_failure_caps_upstream_error_code_at_64_chars(
     completed = [props for et, props in recorder.events if et == "opik_mcp_ask_ollie_completed"]
     assert completed
     code = completed[0]["upstream_error_code"]
-    assert len(code) == 64, f"expected 64-char cap, got len={len(code)}: {code!r}"
-    assert code == fake.canary_code[:64]
-    # The truncated tail must not appear anywhere in the recorded payload —
-    # if it does, the cap fired but something else (a duplicate field,
-    # a log line, etc.) is still leaking the raw value.
+    assert code == "other", f"expected misshaped code bucketed to 'other', got: {code!r}"
+    # Belt-and-braces: NO substring of the canary may appear anywhere in
+    # the recorded payload — the bucket helper is the only path that
+    # touches the field, but if a future change adds a second emit site,
+    # this catches the leak.
     payload = json.dumps(recorder.events)
     assert "TAIL-MUST-BE-CHOPPED" not in payload
 
@@ -631,7 +640,10 @@ async def test_ask_ollie_failure_typed_exception_bucketed_correctly(
     assert completed
     props = completed[0]
     assert props["completion_state"] == "error"
-    assert props["error_kind"] == "permission"
+    # CometPermissionError's ClassVar pins ``error_kind`` to
+    # ``comet_permission`` (ask_ollie-specific bucket) — distinct from a
+    # generic write/read 403 which buckets as ``permission``.
+    assert props["error_kind"] == "comet_permission"
     assert props["exception_type"] == "CometPermissionError"
     # No SSE error frame on this path → no upstream_error_code.
     assert "upstream_error_code" not in props

--- a/tests/test_analytics_tools_listed.py
+++ b/tests/test_analytics_tools_listed.py
@@ -4,9 +4,11 @@ and the wrapper emits opik_mcp_tools_listed once per session."""
 from __future__ import annotations
 
 from collections.abc import Iterator
+from types import SimpleNamespace
 
 import pytest
 from mcp.server.fastmcp import FastMCP
+from mcp.server.lowlevel.server import request_ctx
 from mcp.types import ListToolsRequest
 
 from opik_mcp.analytics import EVENT_TOOLS_LISTED, transport_probe
@@ -115,3 +117,54 @@ async def test_tools_listed_props_shape(recorder: _Recorder) -> None:
     _et, props = next(e for e in recorder.events if e[0] == EVENT_TOOLS_LISTED)
     assert "tool_count_bucket" in props
     assert props["tool_count_bucket"] in {"0", "1-10", "11-100", "101-1000", ">1000"}
+    # Session-context block: stamped on every per-call event so BI can
+    # segment tools_listed on the same dimensions as tool_called /
+    # ask_ollie_completed without joining back to session_initialized.
+    # No session in this test path → host falls back to defaults but the
+    # env keys are always present.
+    assert props["mcp_host"] == "other"
+    assert props["host_llm_family"] == "unknown"
+    for key in ("is_ci", "is_container", "launch_method", "install_id_freshly_generated"):
+        assert key in props, f"call_context_props key {key!r} missing from tools_listed"
+
+
+@pytest.mark.anyio
+async def test_tools_listed_stamps_known_host_from_request_ctx(recorder: _Recorder) -> None:
+    """When the lowlevel ``request_ctx`` carries a real session with a known
+    ``clientInfo`` (Claude Code, Cursor, …), the wrapper must surface the
+    bucketed host on the event so dashboards can split tools_listed by host.
+
+    This is the hot path in production: every tools/list RPC runs inside a
+    request context with ``ctx.session`` populated. The no-session test
+    above exercises the defensive fallback; this one pins the contract for
+    the real shape so a regression that drops the ContextVar read would
+    silently collapse every host into ``"other"``.
+    """
+    mcp = FastMCP("test")
+
+    @mcp.tool()
+    def hello() -> str:
+        return "hi"
+
+    install_tools_listed_emitter(mcp)
+    handler = mcp._mcp_server.request_handlers[ListToolsRequest]
+
+    client_info = SimpleNamespace(name="claude-code", version="1.2.3")
+    params = SimpleNamespace(
+        clientInfo=client_info, protocolVersion="2025-06-01", capabilities=None
+    )
+    session = SimpleNamespace(client_params=params)
+    ctx = SimpleNamespace(session=session)
+
+    token = request_ctx.set(ctx)  # type: ignore[arg-type]
+    try:
+        await handler(ListToolsRequest(method="tools/list"))
+    finally:
+        request_ctx.reset(token)
+
+    _et, props = next(e for e in recorder.events if e[0] == EVENT_TOOLS_LISTED)
+    assert props["mcp_host"] == "claude-code"
+    assert props["host_llm_family"] == "anthropic"
+    # Env-cohort keys still present so the schema doesn't drift between paths.
+    for key in ("is_ci", "is_container", "launch_method", "install_id_freshly_generated"):
+        assert key in props

--- a/tests/test_analytics_wrappers.py
+++ b/tests/test_analytics_wrappers.py
@@ -31,7 +31,12 @@ from opik_mcp.comet_client import (
     OllieNotEnabledError,
 )
 from opik_mcp.config import MissingConfigError
-from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError
+from opik_mcp.ollie_client import (
+    ConfirmDeclinedError,
+    OllieAuthError,
+    OllieStreamError,
+    PodNotReadyError,
+)
 from opik_mcp.opik_client import (
     OpikAuthError,
     OpikNotFoundError,
@@ -102,20 +107,24 @@ async def test_success_emits_tool_called(recorder: _Recorder) -> None:
         (OpikValidationError("x"), "validation", 400),
         (OpikServerError("x"), "upstream_5xx", 500),
         # Comet hierarchy mirrors Opik's: permission before auth, both class-keyed.
-        (CometAuthError("x"), "auth", 401),
-        (CometPermissionError("x"), "permission", 403),
-        # Control-flow errors that don't map to an upstream status — these
-        # signal "our client gave up before we got a real HTTP response".
-        (CometProtocolError("x"), "unknown", None),
-        (OllieNotEnabledError("x"), "unknown", None),
-        (OllieStreamError("x"), "unknown", None),
+        # ``comet_auth`` and ``comet_permission`` are ask_ollie-specific
+        # ClassVar buckets — distinct from generic write/read 401/403 so BI
+        # can split pod-discovery failures from regular tool failures.
+        (CometAuthError("x"), "comet_auth", 401),
+        (CometPermissionError("x"), "comet_permission", 403),
+        # Control-flow errors that don't map to an upstream status — each
+        # carries its own ClassVar bucket so BI can distinguish the source.
+        (CometProtocolError("x"), "comet_protocol", None),
+        (OllieNotEnabledError("x"), "ollie_not_enabled", None),
+        (OllieStreamError("x"), "stream_protocol", None),
         (MissingConfigError("x"), "validation", 400),
-        # Timeouts: pod warmup timeout and httpx network timeouts both fall in
-        # the "timeout" bucket; httpx.TimeoutException is the family base.
-        (PodNotReadyError("x"), "timeout", None),
+        # Pod warmup timeout has its own ClassVar bucket so BI can split it
+        # from generic httpx timeouts; httpx.TimeoutException stays "timeout".
+        (PodNotReadyError("x"), "pod_not_ready", None),
         (httpx.ReadTimeout("read timed out"), "timeout", None),
-        # Network-level failures (no HTTP response received).
-        (OllieAuthError("x"), "auth", None),
+        # OllieAuthError = PPAUTH cookie rejected by pod (distinct ClassVar
+        # bucket so dashboards can split it from Comet API-key auth).
+        (OllieAuthError("x"), "pod_auth", None),
         (httpx.ConnectError("connect refused"), "network", None),
         (httpx.ReadError("read error"), "network", None),
         # Validation: typed Opik validation + pydantic argument validation
@@ -444,14 +453,12 @@ def sentry_recorder(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> _Se
     [
         # Server-side bugs and infrastructure failures — Sentry's bread and butter.
         (OpikServerError("x"), "upstream_5xx"),
-        # ``CometProtocolError`` / ``OllieStreamError`` are our own control-flow
-        # exceptions that the coarse ErrorKind taxonomy collapses into "unknown".
-        # They're real bugs (contract drifts / stream failures) so Sentry still
-        # captures them — only ``MissingConfigError`` and ``OllieNotEnabledError``
-        # are skipped at the class level inside that bucket.
-        (CometProtocolError("x"), "unknown"),
-        (OllieStreamError("x"), "unknown"),
-        (PodNotReadyError("x"), "timeout"),
+        # Pod/Comet protocol drifts have their own ClassVar buckets now.
+        # They're real bugs (contract drifts / stream failures) so Sentry
+        # still captures them — they're NOT in ``_USER_SIDE_ERROR_KINDS``.
+        (CometProtocolError("x"), "comet_protocol"),
+        (OllieStreamError("x"), "stream_protocol"),
+        (PodNotReadyError("x"), "pod_not_ready"),
         (httpx.ConnectError("x"), "network"),
         (ValueError("x"), "unknown"),
     ],
@@ -494,6 +501,11 @@ async def test_sentry_captures_non_user_side_failures(
         CometPermissionError("x"),
         OllieNotEnabledError("x"),
         OllieAuthError("x"),
+        # ConfirmDeclinedError is the user declining an elicit prompt — a
+        # deliberate cancellation, not a failure. Its ClassVar bucket is
+        # ``"cancelled"``, which sits in ``_USER_SIDE_ERROR_KINDS``, so the
+        # skip-list test is what pins the contract from the wrapper side.
+        ConfirmDeclinedError("user said no"),
     ],
 )
 @pytest.mark.anyio
@@ -737,12 +749,12 @@ def _wrap_with_cause(wrapper: Exception, inner: Exception) -> Exception:
         (OpikNotFoundError("x"), "not_found", 404),
         (OpikValidationError("x"), "validation", 400),
         (OpikServerError("x"), "upstream_5xx", 500),
-        (CometAuthError("x"), "auth", 401),
-        (CometPermissionError("x"), "permission", 403),
-        (PodNotReadyError("x"), "timeout", None),
+        (CometAuthError("x"), "comet_auth", 401),
+        (CometPermissionError("x"), "comet_permission", 403),
+        (PodNotReadyError("x"), "pod_not_ready", None),
         (httpx.ReadTimeout("x"), "timeout", None),
         (httpx.ConnectError("x"), "network", None),
-        (OllieAuthError("x"), "auth", None),
+        (OllieAuthError("x"), "pod_auth", None),
         # MissingConfigError buckets "validation" through the wrapper — and the
         # Sentry skip-list still has to recognize it (covered separately below).
         (MissingConfigError("x"), "validation", 400),
@@ -899,9 +911,9 @@ async def test_sentry_skips_user_side_failures_through_tool_error_wrapper(
         # Server-side bugs and infra failures — Sentry's intended payload.
         # Each one is the wrapped equivalent of the bare-cause tests above.
         (OpikServerError("x"), "upstream_5xx"),
-        (PodNotReadyError("x"), "timeout"),
+        (PodNotReadyError("x"), "pod_not_ready"),
         (httpx.ConnectError("x"), "network"),
-        (CometProtocolError("x"), "unknown"),
+        (CometProtocolError("x"), "comet_protocol"),
         # An unexpected RuntimeError carrying nothing typed — the classic
         # "real bug" shape. Even through a wrapper, must reach Sentry.
         (RuntimeError("unexpected"), "unknown"),

--- a/tests/test_ask_ollie_analytics.py
+++ b/tests/test_ask_ollie_analytics.py
@@ -1,12 +1,17 @@
 import asyncio
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 
 from opik_mcp.analytics import EVENT_ASK_OLLIE_COMPLETED
-from opik_mcp.ask_ollie import _bucket_auto_approval_tools, run_ask_ollie
+from opik_mcp.ask_ollie import (
+    _bucket_auto_approval_tools,
+    _bucket_upstream_code,
+    run_ask_ollie,
+)
 from opik_mcp.comet_client import CometAuthError, PodDiscovery
 from opik_mcp.config import Settings
 from opik_mcp.ollie_client import OllieAuthError, OllieStreamError, PodNotReadyError, SSEEvent
@@ -95,6 +100,57 @@ def test_bucket_auto_approval_tools_empty() -> None:
     assert _bucket_auto_approval_tools([]) == ""
 
 
+@pytest.mark.parametrize(
+    "code",
+    [
+        "rate_limited",
+        "model_unavailable",
+        "context_too_long",
+        "code-with-dash",
+        "a",  # single-char alphanumeric
+        "0aA",  # leading digit fine; uppercase NOT — see below
+    ],
+)
+def test_bucket_upstream_code_passes_through_identifier_shape(code: str) -> None:
+    """Pod codes that look like stable identifiers (alnum + ``_-``, ≤ 32
+    chars) pass through unchanged so dashboards can split on them."""
+    # The "uppercase" parameter actually exercises the rejection arm — we
+    # double-check below. Build the assertion off the regex itself.
+    import re as _re
+
+    valid = bool(_re.match(r"^[a-z0-9][a-z0-9_-]{0,31}$", code))
+    assert _bucket_upstream_code(code) == (code if valid else "other")
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "",  # empty string — fails the leading-char anchor
+        "RATE_LIMITED",  # uppercase rejected
+        "rate limited",  # space rejected
+        "rate.limited",  # dot rejected
+        "_leading-underscore",  # leading underscore rejected (must start alnum)
+        "-leading-dash",  # leading dash rejected
+        "a" * 33,  # over 32-char cap
+        "you are unauthorized to access this resource ID 7c4a-canary",  # long sentence
+        "rate_limited\nstack trace line 2",  # newline rejected
+        "https://evil.example/leak?u=alice",  # URL rejected
+        "alice@example.com",  # email rejected
+        "{json: like}",  # punctuation rejected
+    ],
+)
+def test_bucket_upstream_code_rejects_anything_outside_shape(code: str) -> None:
+    """Pod-controlled free text that doesn't match the identifier shape MUST
+    collapse to ``"other"`` — BI cardinality and privacy guarantee. Length
+    caps alone were insufficient; the shape check is the load-bearing fix."""
+    assert _bucket_upstream_code(code) == "other"
+
+
+def test_bucket_upstream_code_none_preserved() -> None:
+    """``None`` is preserved (the emit site uses it to skip the field)."""
+    assert _bucket_upstream_code(None) is None
+
+
 @pytest.mark.anyio
 async def test_completed_carries_session_context(recorder: _Recorder) -> None:
     """ask_ollie_completed must carry the same 6-field session-context block
@@ -124,6 +180,44 @@ async def test_completed_carries_session_context(recorder: _Recorder) -> None:
     # No ctx passed by _run_with → host fields fall back to defaults.
     assert p["mcp_host"] == "other"
     assert p["host_llm_family"] == "unknown"
+
+
+@pytest.mark.anyio
+async def test_completed_stamps_known_host_when_ctx_provided(recorder: _Recorder) -> None:
+    """Production shape: ``run_ask_ollie`` is called with a real ``ctx``
+    whose ``session.client_params.clientInfo`` identifies the host
+    (Claude Code, Cursor, …). The completed event MUST surface the
+    bucketed host so dashboards can split ask_ollie usage by host —
+    parallel to ``test_tools_listed_stamps_known_host_from_request_ctx``.
+    Without this, every event would collapse into ``"other"``."""
+    comet = AsyncMock()
+    comet.discover_pod.return_value = PodDiscovery(compute_url="http://c", ppauth="p")
+    ollie = AsyncMock()
+    ollie.create_session.return_value = "sess-1"
+
+    async def _stream(*_a: Any, **_kw: Any) -> AsyncIterator[SSEEvent]:
+        yield SSEEvent(event="message_end", data={"payload": {}})
+
+    ollie.stream_events = _stream
+
+    client_info = SimpleNamespace(name="cursor", version="0.42.0")
+    params = SimpleNamespace(
+        clientInfo=client_info, protocolVersion="2025-06-01", capabilities=None
+    )
+    session = SimpleNamespace(client_params=params)
+    # ``run_ask_ollie`` calls ``ctx.info(...)`` for progress lines — mock it
+    # so the call site doesn't blow up. The session attribute is what the
+    # analytics emit actually consumes.
+    ctx = AsyncMock()
+    ctx.session = session
+
+    await _run_with(comet, ollie, recorder, ctx=ctx)
+
+    p = next(p for et, p in recorder.events if et == EVENT_ASK_OLLIE_COMPLETED)
+    assert p["mcp_host"] == "cursor"
+    # Cursor gets its own ``host_llm_family`` bucket — see
+    # ``_HOST_LLM_FAMILY`` in mcp_client_info.
+    assert p["host_llm_family"] == "cursor"
 
 
 @pytest.mark.anyio
@@ -257,11 +351,10 @@ async def test_ollie_stream_error_wrapping_upstream_5xx_unwraps_to_cause(
 
 @pytest.mark.anyio
 async def test_bare_ollie_stream_error_emits_no_cause_type(recorder: _Recorder) -> None:
-    """A bare ``OllieStreamError`` (e.g. ``ollie_client.py:132`` raising
-    'POST /sessions returned no session_id') has no upstream cause. The
-    bucket stays ``unknown`` — same as pre-unwrap — and ``cause_type`` is
-    absent, signalling 'no recoverable upstream' to dashboards rather than
-    misleading them with a leaf class that wasn't really the failure."""
+    """A bare ``OllieStreamError`` has no upstream cause. The bucket is its
+    own ClassVar value ``stream_protocol`` — the bare-leaf raise signals a
+    protocol-drift event on the pod side. ``cause_type`` is absent,
+    signalling 'no recoverable upstream' to dashboards."""
     comet = AsyncMock()
     comet.discover_pod.side_effect = OllieStreamError("no session_id")
     ollie = AsyncMock()
@@ -271,7 +364,7 @@ async def test_bare_ollie_stream_error_emits_no_cause_type(recorder: _Recorder) 
 
     completed = [p for et, p in recorder.events if et == EVENT_ASK_OLLIE_COMPLETED]
     p = completed[0]
-    assert p["error_kind"] == "unknown"
+    assert p["error_kind"] == "stream_protocol"
     assert p["exception_type"] == "OllieStreamError"
     assert "cause_type" not in p
 

--- a/tests/test_audit_analytics.py
+++ b/tests/test_audit_analytics.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from opik_mcp.analytics import EVENT_AUTO_APPROVAL
@@ -20,7 +22,7 @@ def test_write_auto_approval_emits_event(monkeypatch: pytest.MonkeyPatch) -> Non
         workspace="ws",
         session_id="sess",
         tool_use_id="tu-1",
-        target_tool="add_score",
+        target_tool="score.create",
         summary="add a score",
         input={"value": 0.9},
     )
@@ -29,7 +31,7 @@ def test_write_auto_approval_emits_event(monkeypatch: pytest.MonkeyPatch) -> Non
     assert len(events) == 1
     _, props = events[0]
     assert props["tool"] == "ask_ollie"
-    assert props["target_tool"] == "add_score"
+    assert props["target_tool"] == "score.create"
     assert props["had_summary"] == "true"
 
 
@@ -41,9 +43,108 @@ def test_write_auto_approval_missing_summary(monkeypatch: pytest.MonkeyPatch) ->
         workspace="ws",
         session_id="sess",
         tool_use_id="tu-1",
-        target_tool="add_score",
+        target_tool="score.create",
         summary=None,
         input={},
     )
     _, props = next((et, p) for et, p in recorder.events if et == EVENT_AUTO_APPROVAL)
     assert props["had_summary"] == "false"
+
+
+def test_write_auto_approval_stamps_host_context_with_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The session-context block (mcp_host, host_llm_family, env keys)
+    must be stamped on EVENT_AUTO_APPROVAL so BI can segment auto-approval
+    rate on the same dimensions as tool_called / ask_ollie_completed."""
+    recorder = _Recorder()
+    monkeypatch.setattr("opik_mcp.audit._analytics_for_audit", lambda: recorder)
+
+    client_info = SimpleNamespace(name="claude-desktop", version="1.2.3")
+    params = SimpleNamespace(clientInfo=client_info, protocolVersion="2025-06-01", capabilities=None)
+    session = SimpleNamespace(client_params=params)
+
+    write_auto_approval(
+        workspace="ws",
+        session_id="sess",
+        tool_use_id="tu-1",
+        target_tool="score.create",
+        summary="add a score",
+        input={"value": 0.9},
+        mcp_session=session,
+    )
+
+    _, props = next((et, p) for et, p in recorder.events if et == EVENT_AUTO_APPROVAL)
+    assert props["mcp_host"] == "claude-desktop"
+    assert props["host_llm_family"] == "anthropic"
+    for key in ("is_ci", "is_container", "launch_method", "install_id_freshly_generated"):
+        assert key in props
+
+
+def test_write_auto_approval_buckets_unknown_target_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``target_tool`` is the pod-controlled ``tool_name`` from the
+    ``confirm_required`` SSE frame — a future pod release that ships
+    arbitrary strings must NOT blow up event cardinality. Anything outside
+    the WRITE_OPERATIONS allowlist collapses to ``"other"``."""
+    recorder = _Recorder()
+    monkeypatch.setattr("opik_mcp.audit._analytics_for_audit", lambda: recorder)
+
+    canary = "pod-internal-handler-name-9b2a-not-an-op"
+    write_auto_approval(
+        workspace="ws",
+        session_id="sess",
+        tool_use_id="tu-1",
+        target_tool=canary,
+        summary=None,
+        input={},
+    )
+
+    _, props = next((et, p) for et, p in recorder.events if et == EVENT_AUTO_APPROVAL)
+    assert props["target_tool"] == "other"
+    assert canary not in props.values()
+
+
+def test_write_auto_approval_passes_through_known_target_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allowlisted write operations pass through to BI unchanged so
+    dashboards can split auto-approval rate by operation."""
+    recorder = _Recorder()
+    monkeypatch.setattr("opik_mcp.audit._analytics_for_audit", lambda: recorder)
+
+    write_auto_approval(
+        workspace="ws",
+        session_id="sess",
+        tool_use_id="tu-1",
+        target_tool="score.create",
+        summary=None,
+        input={},
+    )
+
+    _, props = next((et, p) for et, p in recorder.events if et == EVENT_AUTO_APPROVAL)
+    assert props["target_tool"] == "score.create"
+
+
+def test_write_auto_approval_falls_back_when_session_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A None session must not break the emit — host fields fall back to
+    the ``other``/``unknown`` defaults so the schema stays stable."""
+    recorder = _Recorder()
+    monkeypatch.setattr("opik_mcp.audit._analytics_for_audit", lambda: recorder)
+
+    write_auto_approval(
+        workspace="ws",
+        session_id="sess",
+        tool_use_id="tu-1",
+        target_tool="score.create",
+        summary=None,
+        input={},
+        mcp_session=None,
+    )
+
+    _, props = next((et, p) for et, p in recorder.events if et == EVENT_AUTO_APPROVAL)
+    assert props["mcp_host"] == "other"
+    assert props["host_llm_family"] == "unknown"

--- a/tests/test_audit_analytics.py
+++ b/tests/test_audit_analytics.py
@@ -61,7 +61,9 @@ def test_write_auto_approval_stamps_host_context_with_session(
     monkeypatch.setattr("opik_mcp.audit._analytics_for_audit", lambda: recorder)
 
     client_info = SimpleNamespace(name="claude-desktop", version="1.2.3")
-    params = SimpleNamespace(clientInfo=client_info, protocolVersion="2025-06-01", capabilities=None)
+    params = SimpleNamespace(
+        clientInfo=client_info, protocolVersion="2025-06-01", capabilities=None
+    )
     session = SimpleNamespace(client_params=params)
 
     write_auto_approval(


### PR DESCRIPTION
## Summary

- **16-reason `ErrorKind` taxonomy**: expands the cross-tool allowlist from 4 buckets to 16 so `ask_ollie` can attribute failures to the SSE phase that actually broke (`pod_not_ready`, `pod_auth`, `session_create_failed`, `session_evicted`, `confirm_failed`, `stream_error_frame`, `stream_idle`, `stream_protocol`, `comet_auth`, `comet_permission`, `comet_protocol`, `ollie_not_enabled`) plus the startup-only `invalid_config` bucket. Existing 4 reasons (`validation`, `auth`, `not_found`, `unknown`, etc.) stay stable.
- **`AskOllieFailureReason` field with phase tracking**: a parallel ask_ollie-specific reason field stamped on every `ask_ollie_completed` event. `AskOlliePhase` (`config` / `discover` / `warmup` / `create_session` / `stream` / `confirm`) tracks which step we were in when the call failed, and `derive_failure_reason` maps the exception class + phase to a granular reason. Coarse `error_kind` stays for cross-tool BI; this is the granular tool-specific column.
- **6 typed `OllieStreamError` subclasses + type-exact unwrap**: `PodSessionCreateError`, `PodSessionLostError`, `PodErrorEventError`, `PodStreamIdleError`, `ConfirmDeclinedError`, `ConfirmPostError`. The analytics wrapper now does a type-exact (`type(exc) in _WRAPPER_CLASSES`) match instead of `isinstance`, so subclasses surface their own `ClassVar[ErrorKind]` rather than being unwrapped to `__cause__`. Bare `OllieStreamError` and `ToolError` still unwrap as before.
- **Host context on `tools_listed` and `auto_approval` events**: the FastMCP tools/list wrapper reads `request_ctx` to pick up the real session's `clientInfo`, and `write_auto_approval` now accepts an `mcp_session` parameter and stamps `call_context_props(...)`. BI can now segment those events by `mcp_host` / `host_llm_family` the same way `tool_called` and `ask_ollie_completed` are segmented.
- **Privacy/cardinality protection for pod-controlled fields**: `upstream_error_code` now passes through a shape check (regex `^[a-z0-9][a-z0-9_-]{0,31}$`) — malformed pod codes bucket to `\"other\"` rather than truncating 64-char free text into the BI column. `target_tool` on `auto_approval` events buckets against the `WRITE_OPERATIONS` allowlist for the same reason.
- **`OllieNotAvailableError` distinction**: 404 from the Comet config endpoint is its own class (`error_kind = \"not_found\"`) so it's distinguishable from \"not enabled\" (`ollie_not_enabled`) without reading response bodies.
- **Sentry skip-list grows**: `ConfirmDeclinedError` (user said no at the auto-approval prompt) is now treated as a user-side outcome rather than an error to page on.

Privacy invariant preserved across the diff: public exception classifiers never read `exc.args` / `str(exc)` / response bodies. All classification is `ClassVar[ErrorKind]` reads plus a tightly-scoped whitelist of integer-only instance fields (`httpx.Response.status_code`, `BackendError.extra[\"backend_error\"][\"status\"]`).

## Test plan

- [x] `uv run --extra dev python -m pytest` — 917 passed, 2 skipped (the 2 skipped are pre-existing)
- [x] `uv run --extra dev python -m mypy src/opik_mcp` — clean (no issues in 41 source files)
- [ ] Verify BI dashboards display the new `failure_reason` and `phase` columns on `ask_ollie_completed`
- [ ] Verify `tools_listed` and `auto_approval` events now carry `mcp_host` / `host_llm_family` segments
- [ ] Verify `upstream_error_code` either passes through identifier-shaped pod codes or shows \"other\" — never raw 64-char strings
- [ ] Confirm `ConfirmDeclinedError` no longer pages Sentry on user cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)