### PR TITLE
chore(release): bump version to 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opik-mcp"
-version = "0.1.7"
+version = "0.1.8"
 description = "Model Context Protocol server for Opik (Comet's LLM observability platform)."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "opik-mcp"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bumps `opik-mcp` to **0.1.8** following the merge of #133 (ask_ollie failure_reason taxonomy + per-call host context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)