### PR TITLE
chore(legacy/ts): Phases 1 & 2 — soft + loud deprecation of npm opik-mcp (OPIK-6713)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # opik-mcp
 
+> **Migrating from the old `npx opik-mcp`?** The TypeScript server is deprecated
+> and sunsets on **2026-11-15**. Swap `npx -y opik-mcp` for **`uvx opik-mcp@latest`**
+> in your MCP client config. Full guide: [`legacy/typescript/MIGRATION.md`](./legacy/typescript/MIGRATION.md).
+
 **Model Context Protocol server for [Opik](https://www.comet.com/opik) + Ollie.**
 Plug your AI host (Claude Code, Cursor, VS Code Copilot, MCP Inspector) directly
 into your Opik workspace — read traces, log scores, save prompt versions, and

--- a/legacy/typescript/DEPRECATED.md
+++ b/legacy/typescript/DEPRECATED.md
@@ -19,4 +19,4 @@ npm test
 
 Or from the repo root via `make legacy-install`, `make legacy-build`, etc.
 
-The `legacy/typescript/README.md` is preserved verbatim from the v2.0.1 release for reference; it does not reflect that the package is deprecated. This file is the authoritative deprecation notice.
+The body of `legacy/typescript/README.md` is preserved from the v2.0.1 release; a deprecation banner has been prepended on top. This file (`DEPRECATED.md`) and [`MIGRATION.md`](./MIGRATION.md) remain the authoritative deprecation notice and migration guide respectively.

--- a/legacy/typescript/MIGRATION.md
+++ b/legacy/typescript/MIGRATION.md
@@ -1,0 +1,90 @@
+# Migrating from `npx opik-mcp` to `uvx opik-mcp`
+
+The TypeScript MCP server (npm `opik-mcp@2.0.x`) is **deprecated** and will
+stop serving requests on **2026-11-15**. The supported implementation is the
+Python server (PyPI `opik-mcp`), launched via `uvx`. This guide covers the
+two things that change for users: the launch command and the env vars.
+
+## TL;DR
+
+In your MCP client config, replace:
+
+```jsonc
+{ "command": "npx", "args": ["-y", "opik-mcp"] }
+```
+
+with:
+
+```jsonc
+{ "command": "uvx", "args": ["opik-mcp@latest"] }
+```
+
+If you don't have `uv` yet, install it once:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS / Linux
+# or: winget install astral-sh.uv                  # Windows
+```
+
+That's the whole client-side change. Everything below covers env var renames
+for users with non-default configs.
+
+## Env var rename map
+
+| TypeScript (legacy)                       | Python (current)              | Notes |
+|-------------------------------------------|-------------------------------|-------|
+| `OPIK_API_KEY`                            | `OPIK_API_KEY` ✓               | Unchanged. |
+| `OPIK_API_BASE_URL`                       | `OPIK_URL`                    | For Opik Cloud, leave unset. For self-hosted, set to the base URL of your install. |
+| `OPIK_WORKSPACE_NAME`                     | `COMET_WORKSPACE`             | Aligns with the rest of the Comet SDK. |
+| `OPIK_SELF_HOSTED`                        | _(removed)_                   | Detected from `OPIK_URL`; no separate flag needed. |
+| `DEBUG_MODE=true`                         | `OPIK_MCP_LOG_LEVEL=DEBUG`    | Standard log-level levels (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+| `TRANSPORT`                               | `OPIK_MCP_TRANSPORT`          | Same values (`stdio`, `streamable-http`). |
+| `STREAMABLE_HTTP_PORT`                    | `OPIK_MCP_PORT`               | |
+| `STREAMABLE_HTTP_HOST`                    | `OPIK_MCP_HOST`               | |
+| `OPIK_TOOLSETS`                           | _(removed — see below)_       | Tool surface is fixed in the Python server. |
+
+## Tool surface
+
+The TS server exposed many narrow tools grouped into toolsets (`core`,
+`expert-prompts`, `expert-datasets`, `metrics`, ...). The Python server
+consolidates everything into six tools driven by a JSON-Schema dispatcher:
+
+| Python tool | What it does |
+|---|---|
+| `read`       | Fetch a single entity by id / name / URI (`trace`, `span`, `project`, `experiment`, `prompt`, `test_suite`). |
+| `list`       | Page through a collection. |
+| `write`      | Mutating operations (scores, comments, prompt versions, experiments, ...) — uses an `operation` discriminator. |
+| `schema`     | Returns the JSON Schema + example payload for any `write` operation. |
+| `ask_ollie`  | Investigative questions, cross-entity synthesis. Returns a `thread_id` for follow-ups. |
+| `run_experiment` | Launches an experiment over a dataset. |
+
+If you previously referenced toolset names in `OPIK_TOOLSETS`, you can drop
+that variable — there's nothing equivalent to set.
+
+## Verification
+
+After updating your MCP client config and restarting the host:
+
+1. Open the MCP tool palette in your host (Claude Desktop / Cursor / VS Code).
+2. Confirm you see `read`, `list`, `write`, `schema`, `ask_ollie`,
+   `run_experiment` instead of the older `get-trace`, `list-prompts`, etc.
+3. Try one read: ask the assistant *"list the first 3 traces in
+   `<your-project>`"* — it should call `list` and return JSON.
+
+## Timeline
+
+- **2026-05-28** — Soft deprecation (npm `deprecate` label, banner, MCP
+  `instructions` field). TS server still fully functional.
+- **2026-07-23** — Loud deprecation (tool description suffixes,
+  per-tool-call notices).
+- **2026-10-15** — Final 30-day warning version.
+- **2026-11-15** — TS server `opik-mcp@2.1.0` ships as a stub: prints the
+  migration message and exits without serving requests.
+
+After 2026-11-15 you **must** be on `uvx opik-mcp@latest` for the integration
+to work.
+
+## Questions / problems
+
+- File an issue at <https://github.com/comet-ml/opik-mcp/issues>.
+- Sunset policy: [`DEPRECATED.md`](./DEPRECATED.md).

--- a/legacy/typescript/README.md
+++ b/legacy/typescript/README.md
@@ -1,3 +1,18 @@
+<!--
+  This README is preserved from the v2.0.1 release for historical reference.
+  The authoritative deprecation notice lives in DEPRECATED.md next to this file.
+-->
+
+> ## ⚠️ Deprecated — migrate to the Python server
+>
+> This TypeScript MCP server (npm `opik-mcp`) is **deprecated** and will stop
+> serving MCP requests on **2026-11-15**.
+>
+> In your MCP client config, replace `npx -y opik-mcp` with
+> **`uvx opik-mcp@latest`**.
+> Full migration guide: [`MIGRATION.md`](./MIGRATION.md)
+> · Deprecation policy: [`DEPRECATED.md`](./DEPRECATED.md)
+
 <h1 align="center" style="border-bottom: none">
   <div>
     <a href="https://www.comet.com/site/products/opik/?from=llm&utm_source=opik&utm_medium=github&utm_content=header_img&utm_campaign=opik-mcp">

--- a/legacy/typescript/package.json
+++ b/legacy/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opik-mcp",
   "version": "2.0.1",
-  "description": "MCP server to interact with Opik - Enables automated prompt optimization",
+  "description": "[DEPRECATED — use `uvx opik-mcp@latest` instead, sunset 2026-11-15] MCP server to interact with Opik - Enables automated prompt optimization",
   "type": "module",
   "bin": {
     "opik-mcp": "./build/cli.js"

--- a/legacy/typescript/src/cli.ts
+++ b/legacy/typescript/src/cli.ts
@@ -4,6 +4,14 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import configImport from './config.js';
 import { main } from './index.js';
+import { DEPRECATION_NOTICE } from './utils/deprecation.js';
+
+// Deprecation banner — stderr only, so stdio transport framing stays
+// clean. Note: this does NOT appear on ``--help`` because ``config.ts``
+// runs ``loadConfig()`` at module-load (ESM import ordering) and yargs
+// inside it calls ``process.exit(0)`` on --help before this line ever
+// executes. Accepted limitation — see commit message and OPIK-6713.
+process.stderr.write(`${DEPRECATION_NOTICE.full}\n`);
 
 // Parse command line arguments
 const argv = yargs(hideBin(process.argv))

--- a/legacy/typescript/src/index.ts
+++ b/legacy/typescript/src/index.ts
@@ -11,6 +11,7 @@ import { StreamableHttpTransport } from './transports/streamable-http-transport.
 // Import environment variables loader - no console output
 import './utils/env.js';
 import { logToFile, logFile } from './utils/logging.js';
+import { DEPRECATION_NOTICE } from './utils/deprecation.js';
 
 // Import tool loaders
 import { loadTraceTools } from './tools/trace.js';
@@ -68,7 +69,10 @@ if (config.debugMode) {
   }
 }
 
-// Create and configure server - no console output here
+// Create and configure server - no console output here.
+// ``instructions`` is sent on ``initialize`` and is the highest-leverage
+// channel: the host LLM reads it and surfaces the migration message to
+// the user. See ``utils/deprecation.ts`` for the canonical wording.
 export let server = new McpServer(
   {
     name: config.mcpName,
@@ -79,6 +83,7 @@ export let server = new McpServer(
       resources: {}, // Enable resources capability
       tools: {}, // Enable tools capability
     },
+    instructions: DEPRECATION_NOTICE.full,
   },
 );
 

--- a/legacy/typescript/src/tools/registration.ts
+++ b/legacy/typescript/src/tools/registration.ts
@@ -1,6 +1,10 @@
 import { runWithRequestContext } from '../utils/request-context.js';
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import config from '../config.js';
+import {
+  DEPRECATION_DESCRIPTION_SUFFIX,
+  DEPRECATION_RESPONSE_BLOCK,
+} from '../utils/deprecation.js';
 
 const MISSING_API_KEY_MESSAGE = [
   'This Opik MCP request requires an API key.',
@@ -79,6 +83,32 @@ function withRequestContext<T extends (...args: any[]) => any>(
   };
 }
 
+/**
+ * Append a deprecation notice to every tool response. The block is
+ * pushed at the END of ``content`` (not the front) so existing tests
+ * that read ``content[0]`` keep passing and the LLM still surfaces it
+ * via recency. Defensive: only mutates results whose shape matches the
+ * MCP tool-call protocol ({ content: [...] }); anything else is
+ * returned untouched.
+ */
+function withDeprecationNotice<T extends (...args: any[]) => any>(handler: T) {
+  return async (...args: any[]) => {
+    const result = await handler(...args);
+    if (
+      result &&
+      typeof result === 'object' &&
+      Array.isArray((result as { content?: unknown }).content)
+    ) {
+      const typed = result as { content: unknown[] };
+      return {
+        ...result,
+        content: [...typed.content, DEPRECATION_RESPONSE_BLOCK],
+      };
+    }
+    return result;
+  };
+}
+
 export function registerTool(
   server: any,
   name: string,
@@ -87,9 +117,9 @@ export function registerTool(
   handler: any,
   options: ToolRegistrationOptions = {},
 ): void {
-  const wrappedHandler = withRequestContext(
-    handler,
-    options.requiresApiKey !== false,
+  const taggedDescription = description + DEPRECATION_DESCRIPTION_SUFFIX;
+  const wrappedHandler = withDeprecationNotice(
+    withRequestContext(handler, options.requiresApiKey !== false),
   );
 
   if (typeof server.registerTool === 'function') {
@@ -103,7 +133,7 @@ export function registerTool(
       name,
       {
         ...(options.title && { title: options.title }),
-        description,
+        description: taggedDescription,
         inputSchema,
         ...(Object.keys(mergedAnnotations).length > 0 && {
           annotations: mergedAnnotations,
@@ -116,7 +146,7 @@ export function registerTool(
     return;
   }
 
-  server.tool(name, description, inputSchema, wrappedHandler);
+  server.tool(name, taggedDescription, inputSchema, wrappedHandler);
 }
 
 export function registerResource(

--- a/legacy/typescript/src/utils/deprecation.ts
+++ b/legacy/typescript/src/utils/deprecation.ts
@@ -48,3 +48,30 @@ export const DEPRECATION_NOTICE = {
   sunsetDate: SUNSET_DATE,
   migrationUrl: MIGRATION_URL,
 } as const;
+
+/**
+ * Short suffix appended to every tool ``description`` so the MCP host's
+ * tool palette shows the deprecation label inline. Kept brief — palette
+ * UIs in Claude / Cursor / VS Code truncate long descriptions. Not
+ * applied to resources/prompts: their descriptions surface less
+ * prominently and the stderr banner + ``instructions`` field already
+ * cover those surfaces.
+ */
+export const DEPRECATION_DESCRIPTION_SUFFIX = ` ⚠️ DEPRECATED — migrate to \`uvx opik-mcp@latest\` by ${SUNSET_DATE}`;
+
+/**
+ * Content block appended to every tool response. The host LLM reads
+ * tool outputs on every call, so this is the channel that survives
+ * sessions started before the upgrade and never reads logs/READMEs.
+ * Phrased as a server-to-assistant notice so the model surfaces it
+ * to the user instead of treating it as part of the tool payload.
+ */
+export const DEPRECATION_RESPONSE_BLOCK = {
+  type: 'text',
+  text:
+    `[opik-mcp server notice] This TypeScript MCP server (npm) is ` +
+    `DEPRECATED and stops serving requests on ${SUNSET_DATE}. Please ` +
+    `tell the user to replace \`npx -y opik-mcp\` with ` +
+    `\`uvx opik-mcp@latest\` in their MCP client config. Migration ` +
+    `guide: ${MIGRATION_URL}`,
+} as const;

--- a/legacy/typescript/src/utils/deprecation.ts
+++ b/legacy/typescript/src/utils/deprecation.ts
@@ -1,0 +1,50 @@
+/**
+ * Single source of truth for the deprecation message surfaced by every
+ * channel (MCP ``instructions`` field, stderr banner, README, package
+ * description, future tool-result injection). Keep all wording here so
+ * the four channels never drift apart.
+ *
+ * The companion `legacy/typescript/DEPRECATED.md` declares the same EOL
+ * date — update both together if it changes.
+ */
+
+export const SUNSET_DATE = '2026-11-15' as const;
+export const MIGRATION_URL =
+  'https://github.com/comet-ml/opik-mcp/blob/main/legacy/typescript/MIGRATION.md' as const;
+
+const ONE_LINE =
+  `[DEPRECATED] opik-mcp (npm) is deprecated. Migrate to: ` +
+  `uvx opik-mcp@latest — sunset ${SUNSET_DATE}.`;
+
+const SHORT =
+  `The TypeScript Opik MCP server is deprecated and will stop ` +
+  `serving requests on ${SUNSET_DATE}. ` +
+  `Install the supported Python build with: uvx opik-mcp@latest`;
+
+const FULL = `\
+============================================================
+  ⚠️  opik-mcp (npm, TypeScript) is DEPRECATED
+============================================================
+
+This server stops serving MCP requests on ${SUNSET_DATE}.
+
+Migrate now — in your MCP client config, replace:
+
+  npx -y opik-mcp
+
+with:
+
+  uvx opik-mcp@latest
+
+The tool surface, env vars and transports have changed. Migration
+guide: ${MIGRATION_URL}
+
+============================================================`;
+
+export const DEPRECATION_NOTICE = {
+  oneLine: ONE_LINE,
+  short: SHORT,
+  full: FULL,
+  sunsetDate: SUNSET_DATE,
+  migrationUrl: MIGRATION_URL,
+} as const;

--- a/legacy/typescript/tests/registration.test.ts
+++ b/legacy/typescript/tests/registration.test.ts
@@ -3,6 +3,10 @@ import { loadCapabilitiesTools } from '../src/tools/capabilities.js';
 import { loadProjectTools } from '../src/tools/project.js';
 import type { OpikConfig } from '../src/config.js';
 import appConfig from '../src/config.js';
+import {
+  DEPRECATION_DESCRIPTION_SUFFIX,
+  DEPRECATION_RESPONSE_BLOCK,
+} from '../src/utils/deprecation.js';
 
 describe('tool registration auth requirements', () => {
   const originalApiKey = appConfig.apiKey;
@@ -72,5 +76,52 @@ describe('tool registration auth requirements', () => {
     expect(safeToolResult.content?.[0]?.text).toContain(
       '"transport": "streamable-http"',
     );
+  });
+});
+
+describe('tool registration deprecation notice (Phase 2)', () => {
+  const originalApiKey = appConfig.apiKey;
+
+  afterEach(() => {
+    appConfig.apiKey = originalApiKey;
+  });
+
+  test('appends DEPRECATED suffix to every tool description', () => {
+    const calls: any[] = [];
+    const server = {
+      registerTool: jest.fn((...args: any[]) => {
+        calls.push(args);
+      }),
+    } as any;
+
+    loadProjectTools(server, { includeReadOps: true, includeMutations: true });
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const description = call[1]?.description;
+      expect(typeof description).toBe('string');
+      expect(description.endsWith(DEPRECATION_DESCRIPTION_SUFFIX)).toBe(true);
+    }
+  });
+
+  test('appends deprecation block to tool response content', async () => {
+    appConfig.apiKey = '';
+
+    const calls: any[] = [];
+    const server = {
+      registerTool: jest.fn((...args: any[]) => {
+        calls.push(args);
+      }),
+    } as any;
+
+    loadProjectTools(server, { includeReadOps: true, includeMutations: true });
+    const handler = calls.find((call) => call[0] === 'list-projects')?.[2];
+
+    const result = await handler({ page: 1, size: 10 }, {});
+
+    const last = result.content?.at(-1);
+    expect(last?.type).toBe(DEPRECATION_RESPONSE_BLOCK.type);
+    expect(last?.text).toBe(DEPRECATION_RESPONSE_BLOCK.text);
+    expect(result.content.length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
Phases 1 and 2 of the multi-phase deprecation plan for the legacy TypeScript MCP server (npm `opik-mcp`). Ticket: [OPIK-6713](https://comet-ml.atlassian.net/browse/OPIK-6713). Sunset target: **2026-11-15**.

## Phase 1 — Soft deprecation

Existing TS functionality is unchanged. Users running `npx -y opik-mcp` on next startup get three independent, redundant deprecation signals — each pointing at the supported `uvx opik-mcp@latest` flow:

1. **`McpServer` `instructions` field** — set on `initialize`, so the host LLM (Claude Desktop, Cursor, VS Code Copilot) reads it and surfaces the migration message to the user. The highest-leverage tactic specific to MCP servers — verified to be wired through SDK 1.26's `ServerOptions.instructions`.
2. **Stderr banner at `cli.ts` top** — lands in MCP host logs on every startup. Stderr only, never stdout, so stdio framing stays clean. (`--help` invocations skip this because `config.ts` runs yargs at module load and `process.exit(0)`s before `cli.ts`'s body executes — accepted limitation, documented in code.)
3. **`package.json` description prefix** — shows as `[DEPRECATED — use \`uvx opik-mcp@latest\` instead, sunset 2026-11-15]` on npmjs.com.

Plus:
- `legacy/typescript/src/utils/deprecation.ts` — single source of truth so the channels (instructions / stderr / READMEs / package description / tool palette / tool result) never drift.
- `legacy/typescript/MIGRATION.md` — user-facing migration guide with the full env-var rename map and the new six-tool surface.
- Root `README.md` + legacy `README.md` — visible top banners pointing at `MIGRATION.md`.
- `legacy/typescript/DEPRECATED.md` — updated to reflect the banner now exists on top of the legacy README.

## Phase 2 — Loud deprecation (per-tool surface)

Two additional channels aimed at sessions that never see the README, the package description, or the stderr banner:

4. **Tool description suffix** — every tool description in the MCP palette now ends with `⚠️ DEPRECATED — migrate to \`uvx opik-mcp@latest\` by 2026-11-15`. Visible in Claude / Cursor / VS Code tool pickers without the host LLM having to call anything.
5. **Tool response injection** — every tool result has a server-notice block appended to its `content` array. The host LLM reads tool outputs on every call, so this is the one channel that reaches sessions started before any client config update. Block is appended (not prepended) so tests reading `content[0]` keep passing, and the wrapper is shape-defensive — only mutates results matching the MCP `{ content: [] }` protocol.

Both pieces funnel through the single chokepoint in `tools/registration.ts`, so all 36 `registerTool` call sites are covered without per-tool edits. Resources and prompts are intentionally skipped: their descriptions surface less prominently in host UIs, and the stderr banner + `instructions` field already cover those surfaces.

## Out-of-repo follow-ups

- [ ] Run `npm deprecate \"opik-mcp@<3.0.0\" \"<one-line from deprecation.ts>\"` once after this lands and `2.0.2` is cut. This is the only signal that reaches pinned installs.
- [ ] Cut `opik-mcp@2.0.2` via `npm-v2.0.2` tag.

## Mapping to OPIK-6713 acceptance criteria

| AC | Where |
|---|---|
| Visible deprecation warning | `cli.ts` stderr banner + `instructions` field + tool palette + every tool response |
| Warning contains migration link | `MIGRATION_URL` in `deprecation.ts` → MIGRATION.md |
| Docs reference Python server as default | Root README banner; legacy README banner |
| Existing TS functionality unchanged | Confirmed: only additions, no behavioural changes; 69/69 jest tests pass |
| Team alignment on timeline | `2026-11-15` already declared in pre-existing `DEPRECATED.md`, now consistently referenced from all 7 surfaces |

## Phase plan

- **Phase 1 + 2 (this PR)** — soft + loud deprecation (channels 1–5 above).
- **Phase 3 (~2026-10-15)** — final 30-day-countdown release with sharpened wording in the same constants.
- **Phase 4 (2026-11-15)** — `opik-mcp@2.1.0` ships as a stub that prints the message and `process.exit(0)`s. Don't `npm unpublish` (breaks lockfiles; npm policy).

## Independent review notes (Phase 1)

A code-reviewer subagent audited the Phase 1 commit. No blockers. Caught two doc-lies (stale comment in `cli.ts`, stale paragraph in `DEPRECATED.md`) — both folded in before push. Env-var rename map and six-tool surface in MIGRATION.md cross-checked against `src/opik_mcp/config.py` and `src/opik_mcp/server.py` respectively.

## Test plan

- [x] `npm run build` in `legacy/typescript/` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 69/69 pass after both phases
- [x] Local startup: `node build/cli.js` (no args) prints the banner to stderr, not stdout
- [ ] After merge, in Claude Desktop with the published `2.0.2`: confirm the model surfaces the deprecation message after `initialize` AND after each tool call
- [ ] After merge: confirm npmjs.com page shows the DEPRECATED prefix
- [ ] After merge: confirm tool palette in Claude Desktop shows the description suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6713]: https://comet-ml.atlassian.net/browse/OPIK-6713