### PR TITLE
chore(legacy/ts): bump npm opik-mcp to 2.0.2

### DIFF
--- a/legacy/typescript/package-lock.json
+++ b/legacy/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opik-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opik-mcp",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.29",

--- a/legacy/typescript/package.json
+++ b/legacy/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opik-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "[DEPRECATED — use `uvx opik-mcp@latest` instead, sunset 2026-11-15] MCP server to interact with Opik - Enables automated prompt optimization",
   "type": "module",
   "bin": {
@@ -80,7 +80,9 @@
         {
           "useESM": true,
           "diagnostics": {
-            "ignoreCodes": [151002]
+            "ignoreCodes": [
+              151002
+            ]
           }
         }
       ]


### PR DESCRIPTION
First post-deprecation release. Carries the Phase 1 + Phase 2 soft-and-loud deprecation surface added in #135.

## What ships in 2.0.2

- **stderr banner** at startup (`cli.ts`)
- **MCP `instructions` field** set on `initialize` — host LLM surfaces the migration message
- **package.json description prefix** — visible on npmjs.com
- **per-tool description suffix** — visible in every MCP host's tool palette
- **per-call response-block injection** — host LLM reads the deprecation notice on every tool call
- **MIGRATION.md** with env-var rename map and the new six-tool surface
- **README banners** (root + legacy)

No behavioural changes to any tool — purely deprecation channels. 71/71 tests pass.

## How deploy fires

Pushing tag `npm-v2.0.2` after this merges triggers `.github/workflows/legacy-ts-deploy.yml` which:
1. Builds + lints + tests
2. Syncs `server.json` version from the tag
3. Publishes to npm via Trusted Publishing (OIDC — no npm token needed)
4. Publishes to the MCP Registry via `mcp-publisher`

## Post-publish

- [ ] Confirm `npm view opik-mcp version` returns `2.0.2`
- [ ] Confirm npmjs.com page shows `[DEPRECATED — ...]` prefix
- [ ] In Claude Desktop with `npx -y opik-mcp`: confirm host LLM surfaces the deprecation message and that every tool call appends the server notice
- [ ] (Optional, requires npm owner credentials) Run `npm deprecate "opik-mcp@<3.0.0" "<one-line from deprecation.ts>"` to reach lockfile-pinned installs

Refs [OPIK-6713](https://comet-ml.atlassian.net/browse/OPIK-6713).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6713]: https://comet-ml.atlassian.net/browse/OPIK-6713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ