### PR TITLE
[OPIK-6742] [BE] feat: opik-mcp forwards OAuth bearer + serves RFC 9728 protected-resource metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ docker-build:
 
 docker-run:
 	# Explicit 127.0.0.1 binding: on Linux, `-p 8080:8080` listens on
-	# 0.0.0.0, which combined with the dev-token-123 default token would
-	# expose MCP on every network interface of a dev VM or CI runner.
+	# 0.0.0.0, exposing MCP on every network interface of a dev VM or CI
+	# runner. opik-mcp does no local token validation (the backend does),
+	# so keep the port loopback-only.
 	docker run --rm -p 127.0.0.1:8080:8080 \
-	  -e OPIK_MCP_DEV_TOKEN=$${OPIK_MCP_DEV_TOKEN:-dev-token-123} \
 	  -e COMET_URL_OVERRIDE=$${COMET_URL_OVERRIDE:-https://www.comet.com} \
 	  --name opik-mcp opik-mcp:dev
 

--- a/README.md
+++ b/README.md
@@ -314,8 +314,26 @@ Every setting is an environment variable. Required ones in **bold**.
 | `OPIK_MCP_HOST` | `127.0.0.1` | uvicorn bind host (`streamable-http` only). |
 | `OPIK_MCP_PORT` | `8080` | uvicorn bind port (`streamable-http` only). |
 | `OPIK_MCP_RELOAD` | `false` | `true` to enable uvicorn `--reload` (dev only). |
-| `OPIK_MCP_DEV_TOKEN` | `dev-token-123` | Bearer token the HTTP transport requires. |
+| `OPIK_MCP_AS_URL` | _unset_ | OAuth Authorization Server URL, advertised in `/.well-known/oauth-protected-resource` (RFC 9728) and used as the proxy target for AS-discovery probes. Required for MCP hosts to bootstrap the OAuth dance over HTTP. |
+| `OPIK_MCP_RESOURCE_URI` | _unset_ | Canonical public URI of this server, advertised as `resource` in the protected-resource metadata and used to derive the `WWW-Authenticate` hint. |
 | `OPIK_MCP_LOG_LEVEL` | `INFO` | stderr logger threshold. |
+
+#### Choosing a transport
+
+opik-mcp performs **no local credential validation** on HTTP transport: any
+well-formed `Authorization: Bearer …` (an Opik API key or an `opik_at_…`
+OAuth access token) is forwarded verbatim to opik-backend, which is the
+single point of auth enforcement. Pick the transport by deployment shape:
+
+| Scenario | Transport |
+|---|---|
+| MCP client and Opik on the same machine (local OSS install) | **stdio** (recommended — simplest, no port, no OAuth setup) |
+| Local MCP client → remote Opik (Comet cloud / self-hosted) | stdio with `OPIK_API_KEY`, or HTTP with OAuth (`OPIK_MCP_AS_URL` pointing at the backend) |
+| Hosted opik-mcp behind the same edge as opik-backend | **HTTP** — bearers are validated by the backend per request |
+
+Note for local OSS installs: the OSS backend does not authenticate requests,
+so an HTTP opik-mcp in front of it is as open as the OSS REST API itself.
+Keep the default `127.0.0.1` bind (and prefer stdio) on shared networks.
 
 ### Ollie / long calls
 

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -338,6 +338,24 @@ def _run_transport(settings: Settings, transport: str) -> None:
         settings.opik_mcp_reload,
     )
 
+    # OAuth on HTTP transport needs an explicit resource URI. RFC 9728 makes
+    # `resource` REQUIRED in the protected-resource doc, and the AS validates
+    # the authorize `resource` param by exact-equality against its own
+    # MCP_OAUTH_RESOURCE_URI — so a missing value yields a non-compliant doc and
+    # a host-derived fallback that fails every authorize with invalid_target.
+    # Fail fast. (No AS configured = API-key-only mode; resource URI N/A.)
+    if settings.opik_mcp_as_url and not settings.opik_mcp_resource_uri:
+        logger.error(
+            "Refusing to start: OPIK_MCP_AS_URL=%r enables OAuth but "
+            "OPIK_MCP_RESOURCE_URI is unset. Set it to the exact resource URI the "
+            "Authorization Server is configured with (its MCP_OAUTH_RESOURCE_URI, "
+            "default <issuer>/api/v1/mcp) — the two must match byte-for-byte or "
+            "every /authorize fails with invalid_target.",
+            settings.opik_mcp_as_url,
+        )
+        _emit_startup_error(phase="config", error_kind="invalid_config", transport=transport)
+        sys.exit(1)
+
     # Imported lazily so stdio mode doesn't pay the Starlette import cost.
     from opik_mcp.server import build_app
 

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -341,12 +341,21 @@ def _run_transport(settings: Settings, transport: str) -> None:
         settings.opik_mcp_reload,
     )
 
-    if settings.opik_mcp_dev_token == INSECURE_DEFAULT_TOKEN:
+    # Dev-token bind check applies only when dev-token mode is opted in.
+    # OAuth-passthrough mode (the default) doesn't carry a server-side
+    # secret — opik-backend validates the forwarded bearer — so binding to
+    # non-loopback is safe there.
+    if (
+        settings.opik_mcp_dev_token_enabled
+        and settings.opik_mcp_dev_token == INSECURE_DEFAULT_TOKEN
+    ):
         if settings.opik_mcp_host not in LOOPBACK_HOSTS:
             logger.error(
-                "Refusing to start: OPIK_MCP_DEV_TOKEN is the insecure default %r "
-                "and OPIK_MCP_HOST=%r is not a loopback address. Set a strong "
-                "OPIK_MCP_DEV_TOKEN secret, or bind to 127.0.0.1/::1/localhost.",
+                "Refusing to start: OPIK_MCP_DEV_TOKEN_ENABLED=true with the insecure "
+                "default OPIK_MCP_DEV_TOKEN %r and OPIK_MCP_HOST=%r is not a loopback "
+                "address. Either disable dev-token mode (OPIK_MCP_DEV_TOKEN_ENABLED=false, "
+                "the default), set a strong OPIK_MCP_DEV_TOKEN secret, or bind to "
+                "127.0.0.1/::1/localhost.",
                 INSECURE_DEFAULT_TOKEN,
                 settings.opik_mcp_host,
             )
@@ -357,7 +366,7 @@ def _run_transport(settings: Settings, transport: str) -> None:
             )
             sys.exit(1)
         logger.warning(
-            "OPIK_MCP_DEV_TOKEN is using the insecure default %r. "
+            "OPIK_MCP_DEV_TOKEN_ENABLED=true with the insecure default token %r. "
             "Set a strong secret before exposing this server beyond localhost.",
             INSECURE_DEFAULT_TOKEN,
         )

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -24,9 +24,6 @@ from opik_mcp.config import Settings, get_settings
 
 logger = logging.getLogger("opik_mcp")
 
-INSECURE_DEFAULT_TOKEN = "dev-token-123"
-LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
-
 # Best-effort drain budget on the startup-error path. The daemon worker that
 # normally POSTs analytics events is killed by the imminent sys.exit/re-raise,
 # so we must block long enough for the in-flight POST to land — but not so
@@ -324,8 +321,8 @@ def main() -> None:
 def _run_transport(settings: Settings, transport: str) -> None:
     if transport == "stdio":
         # Default: Claude Code (or any MCP client) launches this process and
-        # speaks MCP over stdin/stdout. No port, no bearer token, no uvicorn.
-        # OPIK_MCP_DEV_TOKEN is only relevant in HTTP mode (see below).
+        # speaks MCP over stdin/stdout. No port, no inbound auth, no uvicorn —
+        # whoever can spawn the process already owns its stdio.
         from opik_mcp.analytics.wrappers import install_tools_listed_emitter
         from opik_mcp.server import mcp
 
@@ -340,36 +337,6 @@ def _run_transport(settings: Settings, transport: str) -> None:
         settings.opik_mcp_port,
         settings.opik_mcp_reload,
     )
-
-    # Dev-token bind check applies only when dev-token mode is opted in.
-    # OAuth-passthrough mode (the default) doesn't carry a server-side
-    # secret — opik-backend validates the forwarded bearer — so binding to
-    # non-loopback is safe there.
-    if (
-        settings.opik_mcp_dev_token_enabled
-        and settings.opik_mcp_dev_token == INSECURE_DEFAULT_TOKEN
-    ):
-        if settings.opik_mcp_host not in LOOPBACK_HOSTS:
-            logger.error(
-                "Refusing to start: OPIK_MCP_DEV_TOKEN_ENABLED=true with the insecure "
-                "default OPIK_MCP_DEV_TOKEN %r and OPIK_MCP_HOST=%r is not a loopback "
-                "address. Either disable dev-token mode (OPIK_MCP_DEV_TOKEN_ENABLED=false, "
-                "the default), set a strong OPIK_MCP_DEV_TOKEN secret, or bind to "
-                "127.0.0.1/::1/localhost.",
-                INSECURE_DEFAULT_TOKEN,
-                settings.opik_mcp_host,
-            )
-            _emit_startup_error(
-                phase="http_bind_check",
-                error_kind="insecure_token_on_public_iface",
-                transport=transport,
-            )
-            sys.exit(1)
-        logger.warning(
-            "OPIK_MCP_DEV_TOKEN_ENABLED=true with the insecure default token %r. "
-            "Set a strong secret before exposing this server beyond localhost.",
-            INSECURE_DEFAULT_TOKEN,
-        )
 
     # Imported lazily so stdio mode doesn't pay the Starlette import cost.
     from opik_mcp.server import build_app

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -1,0 +1,32 @@
+"""Per-request inbound-auth propagation for OAuth-passthrough mode.
+
+When opik-mcp runs over HTTP transport with OAuth, the MCP host attaches
+`Authorization: Bearer opik_at_…` per RFC 6750 and opik-mcp's job is to
+forward that bearer onward to opik-backend's data API verbatim. Permission
+enforcement lives at the data API endpoint via `@RequiredPermissions`
+annotations; opik-mcp performs no local validation and makes no separate
+validator round-trip.
+
+These ContextVars are set by ``BearerAuthMiddleware`` for the duration of
+each inbound HTTP request and read by ``resolve_opik_config`` when the
+outbound :class:`OpikClient` is constructed for that request. When unset
+(stdio transport, or HTTP transport in dev-token mode), the outbound client
+falls back to ``OPIK_API_KEY`` / ``COMET_WORKSPACE`` from settings.
+
+ASGI runs every request in its own asyncio task, so ``ContextVar`` gives us
+per-request isolation without threading anything through the call signatures
+of the MCP tool implementations.
+"""
+
+from contextvars import ContextVar
+
+# Full inbound ``Authorization`` header value (e.g. ``"Bearer opik_at_…"``),
+# forwarded verbatim on outbound calls to opik-backend's data API. ``None``
+# means "no inbound bearer; fall back to settings.opik_api_key".
+inbound_authorization: ContextVar[str | None] = ContextVar("inbound_authorization", default=None)
+
+# Inbound ``Comet-Workspace`` header value, forwarded verbatim. opik-backend
+# cross-checks this against the token row server-side (`McpOAuthService.
+# verifyWorkspaceHeaderMatchesToken`) and rejects mismatches with 403 before
+# any downstream call. ``None`` means "fall back to settings.comet_workspace".
+inbound_workspace: ContextVar[str | None] = ContextVar("inbound_workspace", default=None)

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -10,8 +10,8 @@ validator round-trip.
 These ContextVars are set by ``BearerAuthMiddleware`` for the duration of
 each inbound HTTP request and read by ``resolve_opik_config`` when the
 outbound :class:`OpikClient` is constructed for that request. When unset
-(stdio transport, or HTTP transport in dev-token mode), the outbound client
-falls back to ``OPIK_API_KEY`` / ``COMET_WORKSPACE`` from settings.
+(stdio transport), the outbound client falls back to ``OPIK_API_KEY`` /
+``COMET_WORKSPACE`` from settings.
 
 ASGI runs every request in its own asyncio task, so ``ContextVar`` gives us
 per-request isolation without threading anything through the call signatures

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -64,6 +64,28 @@ class Settings(BaseSettings):
     opik_mcp_stream_idle_timeout_s: float = 300.0
 
     opik_mcp_dev_token: str = "dev-token-123"
+
+    # Inbound-auth mode toggle for HTTP transport.
+    # ``false`` (default): OAuth-passthrough — any well-formed
+    # ``Authorization: Bearer …`` header is accepted; opik-mcp forwards it
+    # verbatim to opik-backend's data API, which validates the bearer (API
+    # key or ``opik_at_…`` OAuth token) and enforces ``@RequiredPermissions``.
+    # ``true``: dev-token mode — only ``Bearer ${OPIK_MCP_DEV_TOKEN}`` is
+    # accepted. Local-testing scaffolding; refuses to start when the token is
+    # still the insecure default and the bind isn't loopback.
+    opik_mcp_dev_token_enabled: bool = False
+
+    # OAuth Authorization Server URL — advertised as ``authorization_servers``
+    # in ``/.well-known/oauth-protected-resource`` per RFC 9728. The MCP host
+    # follows this URL to discover the AS metadata and run the OAuth dance.
+    # Required for hosts to bootstrap OAuth; unset = discovery doc unavailable.
+    opik_mcp_as_url: str | None = None
+
+    # Canonical public URI of this resource server — advertised as
+    # ``resource`` in the protected-resource metadata. Typically the public
+    # ingress URL where MCP hosts reach this opik-mcp instance.
+    opik_mcp_resource_uri: str | None = None
+
     opik_mcp_log_level: str = "INFO"
     opik_mcp_transport: str = "stdio"
     opik_mcp_host: str = "127.0.0.1"

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -63,18 +63,6 @@ class Settings(BaseSettings):
     # Set to 0 to disable (debug only).
     opik_mcp_stream_idle_timeout_s: float = 300.0
 
-    opik_mcp_dev_token: str = "dev-token-123"
-
-    # Inbound-auth mode toggle for HTTP transport.
-    # ``false`` (default): OAuth-passthrough — any well-formed
-    # ``Authorization: Bearer …`` header is accepted; opik-mcp forwards it
-    # verbatim to opik-backend's data API, which validates the bearer (API
-    # key or ``opik_at_…`` OAuth token) and enforces ``@RequiredPermissions``.
-    # ``true``: dev-token mode — only ``Bearer ${OPIK_MCP_DEV_TOKEN}`` is
-    # accepted. Local-testing scaffolding; refuses to start when the token is
-    # still the insecure default and the bind isn't loopback.
-    opik_mcp_dev_token_enabled: bool = False
-
     # OAuth Authorization Server URL — advertised as ``authorization_servers``
     # in ``/.well-known/oauth-protected-resource`` per RFC 9728. The MCP host
     # follows this URL to discover the AS metadata and run the OAuth dance.

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -640,8 +640,13 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str, str | None]:
             "OPIK_API_KEY (or an inbound Authorization header) is required to call Opik REST"
         )
     # OAuth access tokens carry their workspace server-side (opik-backend
-    # derives it from the token row)
-    oauth_passthrough = inbound_auth is not None and "opik_at_" in inbound_auth
+    # derives it from the token row). Identified by token prefix — mirrors
+    # the backend's McpOAuthTokens.isMcpOAuthToken — so an API key that
+    # merely contains the marker can't skip the workspace requirement.
+    oauth_passthrough = False
+    if inbound_auth is not None:
+        scheme, _, token = inbound_auth.partition(" ")
+        oauth_passthrough = scheme.lower() == "bearer" and token.lstrip().startswith("opik_at_")
     if oauth_passthrough:
         workspace = inbound_ws
     else:

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -20,6 +20,7 @@ from typing import Any, ClassVar, Final, Literal, Protocol
 
 import httpx
 
+from opik_mcp.auth_context import inbound_authorization, inbound_workspace
 from opik_mcp.config import MissingConfigError, Settings
 from opik_mcp.error_kinds import ErrorKind
 
@@ -618,11 +619,28 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str, str]:
     ``OPIK_URL`` override or ``COMET_URL_OVERRIDE + "/opik/api"``. Both the
     score/comment orchestrator and the resource layer call this so the config
     contract lives in exactly one place.
+
+    **Per-request bearer + workspace forwarding.** When the process is
+    serving an inbound HTTP request that carried an ``Authorization``
+    header (OAuth-passthrough mode), the middleware populates
+    :mod:`opik_mcp.auth_context` ContextVars and we prefer those over the
+    env-bound ``OPIK_API_KEY`` / ``COMET_WORKSPACE``. opik-backend's
+    ``AuthFilter`` accepts both shapes (API key and ``Bearer opik_at_…``)
+    and enforces ``@RequiredPermissions`` per endpoint, so opik-mcp is a
+    thin forwarder either way.
     """
-    if not settings.opik_api_key:
-        raise MissingConfigError("OPIK_API_KEY is required to call Opik REST")
-    if not settings.comet_workspace:
-        raise MissingConfigError("COMET_WORKSPACE is required to call Opik REST")
+    inbound_auth = inbound_authorization.get()
+    inbound_ws = inbound_workspace.get()
+    api_key = inbound_auth if inbound_auth else settings.opik_api_key
+    workspace = inbound_ws if inbound_ws else settings.comet_workspace
+    if not api_key:
+        raise MissingConfigError(
+            "OPIK_API_KEY (or an inbound Authorization header) is required to call Opik REST"
+        )
+    if not workspace:
+        raise MissingConfigError(
+            "COMET_WORKSPACE (or an inbound Comet-Workspace header) is required to call Opik REST"
+        )
     if settings.opik_url:
         base = settings.opik_url.rstrip("/")
     else:
@@ -633,7 +651,7 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str, str]:
         if not settings.comet_url_override:
             raise MissingConfigError("OPIK_URL or COMET_URL_OVERRIDE is required to call Opik REST")
         base = f"{settings.comet_url_override.rstrip('/')}/opik/api"
-    return base, settings.opik_api_key, settings.comet_workspace
+    return base, api_key, workspace
 
 
 def make_opik_client(settings: Settings) -> OpikClient:

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -186,7 +186,7 @@ class OpikClient:
         self,
         base_url: str,
         api_key: str,
-        workspace: str,
+        workspace: str | None,
         *,
         client: httpx.AsyncClient | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
@@ -507,12 +507,15 @@ class OpikClient:
     # -- internals --
 
     def _headers(self) -> dict[str, str]:
-        return {
+        headers = {
             "Authorization": self._api_key,
-            "Comet-Workspace": self._workspace,
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+        # Omitted for OAuth tokens — opik-backend derives the workspace from the token row
+        if self._workspace:
+            headers["Comet-Workspace"] = self._workspace
+        return headers
 
     @asynccontextmanager
     async def _http(self) -> AsyncIterator[httpx.AsyncClient]:
@@ -612,7 +615,7 @@ class OpikClient:
             return await http.request(method, url, content=content, headers=headers)
 
 
-def resolve_opik_config(settings: Settings) -> tuple[str, str, str]:
+def resolve_opik_config(settings: Settings) -> tuple[str, str, str | None]:
     """Resolve ``(opik_base_url, api_key, workspace)`` from settings or raise.
 
     Centralizes the rule for deriving Opik's REST base from either an explicit
@@ -632,15 +635,20 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str, str]:
     inbound_auth = inbound_authorization.get()
     inbound_ws = inbound_workspace.get()
     api_key = inbound_auth if inbound_auth else settings.opik_api_key
-    workspace = inbound_ws if inbound_ws else settings.comet_workspace
     if not api_key:
         raise MissingConfigError(
             "OPIK_API_KEY (or an inbound Authorization header) is required to call Opik REST"
         )
-    if not workspace:
-        raise MissingConfigError(
-            "COMET_WORKSPACE (or an inbound Comet-Workspace header) is required to call Opik REST"
-        )
+    # OAuth access tokens carry their workspace server-side (opik-backend derives it from the token row)
+    oauth_passthrough = bool(inbound_auth) and "opik_at_" in inbound_auth
+    if oauth_passthrough:
+        workspace = inbound_ws
+    else:
+        workspace = inbound_ws if inbound_ws else settings.comet_workspace
+        if not workspace:
+            raise MissingConfigError(
+                "COMET_WORKSPACE (or an inbound Comet-Workspace header) is required to call Opik REST"
+            )
     if settings.opik_url:
         base = settings.opik_url.rstrip("/")
     else:

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -639,15 +639,17 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str, str | None]:
         raise MissingConfigError(
             "OPIK_API_KEY (or an inbound Authorization header) is required to call Opik REST"
         )
-    # OAuth access tokens carry their workspace server-side (opik-backend derives it from the token row)
-    oauth_passthrough = bool(inbound_auth) and "opik_at_" in inbound_auth
+    # OAuth access tokens carry their workspace server-side (opik-backend
+    # derives it from the token row)
+    oauth_passthrough = inbound_auth is not None and "opik_at_" in inbound_auth
     if oauth_passthrough:
         workspace = inbound_ws
     else:
         workspace = inbound_ws if inbound_ws else settings.comet_workspace
         if not workspace:
             raise MissingConfigError(
-                "COMET_WORKSPACE (or an inbound Comet-Workspace header) is required to call Opik REST"
+                "COMET_WORKSPACE (or an inbound Comet-Workspace header) "
+                "is required to call Opik REST"
             )
     if settings.opik_url:
         base = settings.opik_url.rstrip("/")

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -16,7 +16,8 @@ from starlette.types import ASGIApp
 from opik_mcp.analytics.events import bucket_count
 from opik_mcp.analytics.wrappers import install_tools_listed_emitter, instrument_tool
 from opik_mcp.ask_ollie import AskOllieResult, run_ask_ollie
-from opik_mcp.config import get_settings
+from opik_mcp.auth_context import inbound_authorization, inbound_workspace
+from opik_mcp.config import Settings, get_settings
 from opik_mcp.instructions import render_instructions
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
 from opik_mcp.read_list import run_list, run_read
@@ -503,6 +504,12 @@ async def schema(
 # misconfiguration would otherwise return 401.
 _HEALTH_PATHS = frozenset({"/health", "/health/ready"})
 
+# Protected-resource metadata is the bootstrap entry point for the OAuth
+# dance: MCP hosts fetch it (per RFC 9728) before they have any credentials,
+# so it must be reachable without an Authorization header.
+_PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
+_UNAUTH_PATHS = _HEALTH_PATHS | frozenset({_PROTECTED_RESOURCE_METADATA_PATH})
+
 # Bounded total budget for the upstream reachability check used by
 # /health/ready. Probes run every 5-10s; a hung upstream must not stall the
 # probe past the probe's own timeout, or readiness flips to "unknown" instead
@@ -511,17 +518,81 @@ _READY_PROBE_TIMEOUT_S = 2.0
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: ASGIApp, token: str) -> None:
+    """Inbound auth + per-request bearer-capture for outbound forwarding.
+
+    Two modes selected at construction time from ``OPIK_MCP_DEV_TOKEN_ENABLED``:
+
+    * **OAuth-passthrough (default).** Any well-formed
+      ``Authorization: Bearer …`` header is accepted. The full header value
+      is captured into a ContextVar and forwarded verbatim on the outbound
+      call to opik-backend (see :mod:`opik_mcp.auth_context`). opik-backend's
+      ``AuthFilter`` validates the bearer (API key or ``opik_at_…`` OAuth
+      token) and enforces ``@RequiredPermissions`` on the data API endpoint;
+      opik-mcp performs no local validation.
+
+    * **Dev-token mode** (``OPIK_MCP_DEV_TOKEN_ENABLED=true``). Strict
+      ``constant_time`` comparison against ``OPIK_MCP_DEV_TOKEN``. Local
+      testing scaffolding; ``__main__`` refuses to start when this mode is
+      enabled with the default token on a non-loopback bind.
+
+    In both modes, missing/empty ``Authorization`` returns 401 with a
+    ``WWW-Authenticate`` header that points MCP hosts at
+    ``/.well-known/oauth-protected-resource`` so they can bootstrap the
+    OAuth dance per RFC 6750 + RFC 9728. Health probes and the metadata
+    endpoint are exempt from auth.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        dev_token_enabled: bool,
+        dev_token: str,
+        resource_metadata_url: str | None,
+    ) -> None:
         super().__init__(app)
-        self._expected = f"Bearer {token}"
+        self._dev_token_enabled = dev_token_enabled
+        self._expected_dev_token = f"Bearer {dev_token}"
+        self._resource_metadata_url = resource_metadata_url
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        if request.url.path in _HEALTH_PATHS:
+        if request.url.path in _UNAUTH_PATHS:
             return await call_next(request)
+
         auth = request.headers.get("authorization", "")
-        if not secrets.compare_digest(auth, self._expected):
-            return JSONResponse({"error": "unauthorized"}, status_code=401)
-        return await call_next(request)
+        if not auth:
+            return self._unauthorized()
+
+        if self._dev_token_enabled:
+            if not secrets.compare_digest(auth, self._expected_dev_token):
+                return self._unauthorized()
+        elif not auth.lower().startswith("bearer "):
+            # OAuth-passthrough still requires the canonical "Bearer …" shape
+            # so the WWW-Authenticate hint we return on failure is consistent
+            # with what the host expects to send next.
+            return self._unauthorized()
+
+        # Capture the inbound auth + workspace headers for the duration of
+        # this request so the outbound :class:`OpikClient` can forward them.
+        auth_token = inbound_authorization.set(auth)
+        workspace = request.headers.get("comet-workspace")
+        workspace_token = inbound_workspace.set(workspace)
+        try:
+            return await call_next(request)
+        finally:
+            inbound_authorization.reset(auth_token)
+            inbound_workspace.reset(workspace_token)
+
+    def _unauthorized(self) -> Response:
+        # RFC 6750 §3 + RFC 9728: pointing MCP hosts at protected-resource
+        # metadata is what kicks off automatic OAuth discovery — without
+        # this, hosts have no way to find the AS without out-of-band config.
+        headers: dict[str, str] = {}
+        if self._resource_metadata_url:
+            headers["WWW-Authenticate"] = (
+                f'Bearer realm="opik-mcp", resource_metadata="{self._resource_metadata_url}"'
+            )
+        return JSONResponse({"error": "unauthorized"}, status_code=401, headers=headers)
 
 
 # --- health endpoints ---------------------------------------------------- #
@@ -567,13 +638,57 @@ async def _readiness(_request: Request) -> JSONResponse:
     return JSONResponse({"status": "not_ready", "reason": reason}, status_code=503)
 
 
+async def _oauth_protected_resource(_request: Request) -> JSONResponse:
+    """RFC 9728 protected-resource metadata.
+
+    Returned to MCP hosts so they can discover the Authorization Server and
+    run the OAuth dance against it without needing the AS URL preconfigured.
+
+    When ``OPIK_MCP_AS_URL`` is unset, the discovery doc is unavailable —
+    this opik-mcp instance is then only useful with ``OPIK_API_KEY``-style
+    auth (or dev-token mode). Returning 503 makes the misconfiguration loud
+    and steers operators to set ``OPIK_MCP_AS_URL``.
+    """
+    s = get_settings()
+    if not s.opik_mcp_as_url:
+        return JSONResponse({"error": "OPIK_MCP_AS_URL not configured"}, status_code=503)
+    body: dict[str, Any] = {
+        "authorization_servers": [s.opik_mcp_as_url],
+    }
+    if s.opik_mcp_resource_uri:
+        body["resource"] = s.opik_mcp_resource_uri
+    return JSONResponse(body)
+
+
+def _resource_metadata_url(settings: Settings) -> str | None:
+    """Build the absolute URL we advertise in ``WWW-Authenticate``.
+
+    Prefers ``OPIK_MCP_RESOURCE_URI + /.well-known/oauth-protected-resource``;
+    falls back to a relative path when no public URI is configured, which is
+    still useful for hosts that resolve relative to the 401 URL.
+    """
+    if settings.opik_mcp_resource_uri:
+        return f"{settings.opik_mcp_resource_uri.rstrip('/')}{_PROTECTED_RESOURCE_METADATA_PATH}"
+    return _PROTECTED_RESOURCE_METADATA_PATH
+
+
 def build_app() -> Starlette:
     install_tools_listed_emitter(mcp)
-    # The bearer token is captured at construction time and held for the
-    # process lifetime; rotation requires a server restart (Settings is
-    # lru_cache'd). Documented as a Phase-1 limitation; Phase 2 moves to OAuth.
     app = mcp.streamable_http_app()
     app.router.routes.append(Route("/health", _liveness, methods=["GET"]))
     app.router.routes.append(Route("/health/ready", _readiness, methods=["GET"]))
-    app.add_middleware(BearerAuthMiddleware, token=get_settings().opik_mcp_dev_token)
+    app.router.routes.append(
+        Route(
+            _PROTECTED_RESOURCE_METADATA_PATH,
+            _oauth_protected_resource,
+            methods=["GET"],
+        )
+    )
+    s = get_settings()
+    app.add_middleware(
+        BearerAuthMiddleware,
+        dev_token_enabled=s.opik_mcp_dev_token_enabled,
+        dev_token=s.opik_mcp_dev_token,
+        resource_metadata_url=_resource_metadata_url(s),
+    )
     return app

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -1,5 +1,4 @@
 import logging
-import secrets
 from typing import Annotated, Any
 from urllib.parse import urlparse
 
@@ -18,7 +17,7 @@ from opik_mcp.analytics.events import bucket_count
 from opik_mcp.analytics.wrappers import install_tools_listed_emitter, instrument_tool
 from opik_mcp.ask_ollie import AskOllieResult, run_ask_ollie
 from opik_mcp.auth_context import inbound_authorization, inbound_workspace
-from opik_mcp.config import Settings, get_settings
+from opik_mcp.config import MissingConfigError, Settings, get_settings
 from opik_mcp.instructions import render_instructions
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
 from opik_mcp.read_list import run_list, run_read
@@ -404,6 +403,14 @@ async def run_experiment(
     settings = get_settings()
     client = make_opik_client(settings)
     _, _, workspace = resolve_opik_config(settings)
+    # Workspace may be None when an OAuth bearer arrives without a
+    # Comet-Workspace header (the backend derives it from the token row, but
+    # we need the name client-side to build the experiment summary URL).
+    if workspace is None:
+        raise MissingConfigError(
+            "run_experiment requires a workspace — set COMET_WORKSPACE or "
+            "send a Comet-Workspace header"
+        )
     comet_base = settings.comet_url_override.rstrip("/")
     return await run_experiment_impl(
         config=config,
@@ -545,25 +552,20 @@ _READY_PROBE_TIMEOUT_S = 2.0
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
-    """Inbound auth + per-request bearer-capture for outbound forwarding.
+    """Bearer-shape check + per-request bearer-capture for outbound forwarding.
 
-    Two modes selected at construction time from ``OPIK_MCP_DEV_TOKEN_ENABLED``:
+    opik-mcp performs **no local credential validation**. Any well-formed
+    ``Authorization: Bearer …`` header is accepted; the full header value is
+    captured into a ContextVar and forwarded verbatim on the outbound call to
+    opik-backend (see :mod:`opik_mcp.auth_context`). opik-backend's
+    ``AuthFilter`` is the single point of auth enforcement — it validates the
+    bearer (API key or ``opik_at_…`` OAuth token) and enforces
+    ``@RequiredPermissions`` on the data API endpoint. Deployments where the
+    backend enforces auth are protected end-to-end; OSS installs without
+    backend auth are as open via MCP as via their own REST API.
 
-    * **OAuth-passthrough (default).** Any well-formed
-      ``Authorization: Bearer …`` header is accepted. The full header value
-      is captured into a ContextVar and forwarded verbatim on the outbound
-      call to opik-backend (see :mod:`opik_mcp.auth_context`). opik-backend's
-      ``AuthFilter`` validates the bearer (API key or ``opik_at_…`` OAuth
-      token) and enforces ``@RequiredPermissions`` on the data API endpoint;
-      opik-mcp performs no local validation.
-
-    * **Dev-token mode** (``OPIK_MCP_DEV_TOKEN_ENABLED=true``). Strict
-      ``constant_time`` comparison against ``OPIK_MCP_DEV_TOKEN``. Local
-      testing scaffolding; ``__main__`` refuses to start when this mode is
-      enabled with the default token on a non-loopback bind.
-
-    In both modes, missing/empty ``Authorization`` returns 401 with a
-    ``WWW-Authenticate`` header that points MCP hosts at
+    Missing/empty ``Authorization`` returns 401 with a ``WWW-Authenticate``
+    header that points MCP hosts at
     ``/.well-known/oauth-protected-resource`` so they can bootstrap the
     OAuth dance per RFC 6750 + RFC 9728. Health probes and the metadata
     endpoint are exempt from auth.
@@ -573,13 +575,9 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         self,
         app: ASGIApp,
         *,
-        dev_token_enabled: bool,
-        dev_token: str,
         resource_metadata_url: str | None,
     ) -> None:
         super().__init__(app)
-        self._dev_token_enabled = dev_token_enabled
-        self._expected_dev_token = f"Bearer {dev_token}"
         self._resource_metadata_url = resource_metadata_url
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
@@ -601,13 +599,10 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         if not auth:
             return self._unauthorized()
 
-        if self._dev_token_enabled:
-            if not secrets.compare_digest(auth, self._expected_dev_token):
-                return self._unauthorized()
-        elif not auth.lower().startswith("bearer "):
-            # OAuth-passthrough still requires the canonical "Bearer …" shape
-            # so the WWW-Authenticate hint we return on failure is consistent
-            # with what the host expects to send next.
+        if not auth.lower().startswith("bearer "):
+            # Require the canonical "Bearer …" shape so the WWW-Authenticate
+            # hint we return on failure is consistent with what the host
+            # expects to send next.
             return self._unauthorized()
 
         # Capture the inbound auth + workspace headers for the duration of
@@ -684,8 +679,8 @@ async def _oauth_protected_resource(_request: Request) -> JSONResponse:
 
     When ``OPIK_MCP_AS_URL`` is unset, the discovery doc is unavailable —
     this opik-mcp instance is then only useful with ``OPIK_API_KEY``-style
-    auth (or dev-token mode). Returning 503 makes the misconfiguration loud
-    and steers operators to set ``OPIK_MCP_AS_URL``.
+    bearers. Returning 503 makes the misconfiguration loud and steers
+    operators to set ``OPIK_MCP_AS_URL``.
     """
     s = get_settings()
     if not s.opik_mcp_as_url:
@@ -739,9 +734,7 @@ async def _proxy_to_as(request: Request) -> Response:
     """
     s = get_settings()
     if not s.opik_mcp_as_url:
-        return JSONResponse(
-            {"error": "OPIK_MCP_AS_URL not configured"}, status_code=503
-        )
+        return JSONResponse({"error": "OPIK_MCP_AS_URL not configured"}, status_code=503)
     target_path = _PROXIED_OAUTH_PATHS.get(request.url.path)
     if target_path is None:
         return JSONResponse({"error": "not found"}, status_code=404)
@@ -751,9 +744,7 @@ async def _proxy_to_as(request: Request) -> Response:
         target = f"{target}?{qs}"
     body = await request.body()
     forwarded_headers = {
-        k: v
-        for k, v in request.headers.items()
-        if k.lower() not in _PROXY_DROP_REQUEST_HEADERS
+        k: v for k, v in request.headers.items() if k.lower() not in _PROXY_DROP_REQUEST_HEADERS
     }
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
         upstream = await client.request(
@@ -763,9 +754,7 @@ async def _proxy_to_as(request: Request) -> Response:
             content=body,
         )
     response_headers = {
-        k: v
-        for k, v in upstream.headers.items()
-        if k.lower() not in _PROXY_DROP_RESPONSE_HEADERS
+        k: v for k, v in upstream.headers.items() if k.lower() not in _PROXY_DROP_RESPONSE_HEADERS
     }
     return Response(
         content=upstream.content,
@@ -833,14 +822,10 @@ def build_app() -> Starlette:
     # because some SDKs refuse to follow cross-origin OAuth-discovery
     # redirects and silently break their bootstrap.
     for path in _PROXIED_OAUTH_PATHS:
-        app.router.routes.append(
-            Route(path, _proxy_to_as, methods=["GET", "POST"])
-        )
+        app.router.routes.append(Route(path, _proxy_to_as, methods=["GET", "POST"]))
     s = get_settings()
     app.add_middleware(
         BearerAuthMiddleware,
-        dev_token_enabled=s.opik_mcp_dev_token_enabled,
-        dev_token=s.opik_mcp_dev_token,
         resource_metadata_url=_resource_metadata_url(s),
     )
     return app

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -1,6 +1,7 @@
 import logging
 import secrets
 from typing import Annotated, Any
+from urllib.parse import urlparse
 
 import httpx
 from mcp.server.fastmcp import Context, FastMCP
@@ -508,7 +509,33 @@ _HEALTH_PATHS = frozenset({"/health", "/health/ready"})
 # dance: MCP hosts fetch it (per RFC 9728) before they have any credentials,
 # so it must be reachable without an Authorization header.
 _PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
-_UNAUTH_PATHS = _HEALTH_PATHS | frozenset({_PROTECTED_RESOURCE_METADATA_PATH})
+
+# AS-discovery / OAuth-flow paths that MCP host SDKs probe on the resource
+# server's host before they have a token. In production opik-mcp sits behind
+# the same edge as opik-backend so these paths "just work" — but locally
+# they're on different ports, so we redirect to the configured AS to keep
+# the SDK's discovery chain unbroken. Anything not in this set or
+# ``_HEALTH_PATHS`` requires a bearer.
+_PROXIED_OAUTH_PATHS = {
+    # AS metadata + OIDC fallback some SDKs probe before the protected-resource doc
+    "/.well-known/oauth-authorization-server": "/.well-known/oauth-authorization-server",
+    "/.well-known/openid-configuration": "/.well-known/oauth-authorization-server",
+    # OAuth 2.1 flow endpoints; SDK convention is to find them at the RS root
+    "/register": "/oauth/register",
+    "/authorize": "/oauth/authorize",
+    "/token": "/oauth/token",
+    "/revoke": "/oauth/revoke",
+    "/oauth/register": "/oauth/register",
+    "/oauth/authorize": "/oauth/authorize",
+    "/oauth/token": "/oauth/token",
+    "/oauth/revoke": "/oauth/revoke",
+}
+
+_UNAUTH_PATHS = (
+    _HEALTH_PATHS
+    | frozenset({_PROTECTED_RESOURCE_METADATA_PATH})
+    | frozenset(_PROXIED_OAUTH_PATHS.keys())
+)
 
 # Bounded total budget for the upstream reachability check used by
 # /health/ready. Probes run every 5-10s; a hung upstream must not stall the
@@ -556,7 +583,18 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         self._resource_metadata_url = resource_metadata_url
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        if request.url.path in _UNAUTH_PATHS:
+        path = request.url.path
+        # Discovery + bootstrap paths are unauthenticated by spec — RFC 9728
+        # well-known metadata, OIDC/OAuth AS metadata, and the OAuth-flow
+        # endpoints all run pre-credentials. Returning 401 on these would
+        # break the host's discovery chain; many SDKs probe path-prefixed
+        # variants too (``/.well-known/foo/mcp``, ``/mcp/.well-known/foo``),
+        # so we accept the whole prefix.
+        if (
+            path in _UNAUTH_PATHS
+            or path.startswith("/.well-known/")
+            or path.startswith("/mcp/.well-known/")
+        ):
             return await call_next(request)
 
         auth = request.headers.get("authorization", "")
@@ -660,21 +698,125 @@ async def _oauth_protected_resource(_request: Request) -> JSONResponse:
     return JSONResponse(body)
 
 
+# Headers that must not be forwarded from inbound → outbound on the proxy
+# path. ``host`` would override httpx's auto-set Host; ``content-length`` is
+# recomputed from the body; hop-by-hop framing headers don't make sense to
+# forward; and ``cookie`` is intentionally dropped because OAuth flows use
+# the AS's own session cookies and we don't want to leak SDK cookies upstream.
+_PROXY_DROP_REQUEST_HEADERS = frozenset(
+    {"host", "content-length", "connection", "transfer-encoding", "cookie"}
+)
+
+# Hop-by-hop response headers per RFC 7230 §6.1 — must not be forwarded back
+# unchanged or httpx/Starlette's framing assumptions break.
+_PROXY_DROP_RESPONSE_HEADERS = frozenset(
+    {"content-encoding", "content-length", "transfer-encoding", "connection"}
+)
+
+
+async def _proxy_to_as(request: Request) -> Response:
+    """Proxy AS-flow / discovery requests to the configured AS host.
+
+    MCP host SDKs probe ``/register``, ``/authorize``, ``/.well-known/oauth-
+    authorization-server`` etc. at the resource server's host before they
+    have a token. In production opik-mcp sits behind the same edge as
+    opik-backend so these paths route correctly without ceremony. Locally
+    (or in any split-host deploy) we proxy them to the configured AS so
+    the SDK sees a same-origin response — earlier attempts using HTTP 307
+    redirects failed because some SDKs do not follow cross-origin OAuth-
+    discovery redirects.
+
+    Proxying preserves method, body, query string, and most headers, and
+    returns the AS response inline. The proxied AS metadata still contains
+    absolute opik-backend URLs in its endpoint fields (``authorization_
+    endpoint``, ``token_endpoint``, etc.) — SDKs that use those directly
+    talk to the AS over the network; SDKs that probe ``/register`` etc. at
+    the RS root land here again and we proxy that too.
+
+    Returns 503 when ``OPIK_MCP_AS_URL`` is unset — the only safe answer:
+    we don't know where to send the probe, and silently 404'ing would
+    mislead clients into thinking the resource doesn't support OAuth.
+    """
+    s = get_settings()
+    if not s.opik_mcp_as_url:
+        return JSONResponse(
+            {"error": "OPIK_MCP_AS_URL not configured"}, status_code=503
+        )
+    target_path = _PROXIED_OAUTH_PATHS.get(request.url.path)
+    if target_path is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    qs = request.url.query
+    target = f"{s.opik_mcp_as_url.rstrip('/')}{target_path}"
+    if qs:
+        target = f"{target}?{qs}"
+    body = await request.body()
+    forwarded_headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in _PROXY_DROP_REQUEST_HEADERS
+    }
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+        upstream = await client.request(
+            method=request.method,
+            url=target,
+            headers=forwarded_headers,
+            content=body,
+        )
+    response_headers = {
+        k: v
+        for k, v in upstream.headers.items()
+        if k.lower() not in _PROXY_DROP_RESPONSE_HEADERS
+    }
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=response_headers,
+        media_type=upstream.headers.get("content-type"),
+    )
+
+
 def _resource_metadata_url(settings: Settings) -> str | None:
     """Build the absolute URL we advertise in ``WWW-Authenticate``.
 
-    Prefers ``OPIK_MCP_RESOURCE_URI + /.well-known/oauth-protected-resource``;
-    falls back to a relative path when no public URI is configured, which is
-    still useful for hosts that resolve relative to the 401 URL.
+    The metadata route is registered at the application root, so the URL we
+    advertise must match: derived from the resource URI's scheme + authority
+    rather than appended under its path. RFC 9728 §3.1 permits both
+    path-prefixed and host-relative forms; MCP hosts in practice follow the
+    host-relative form, and our Starlette ``Route`` registration sits at
+    ``/`` + the well-known path (not nested under ``/mcp``). Appending under
+    the resource path produces a URL that 404s (or falls through to the MCP
+    path's auth middleware and 401s), silently breaking host bootstrap.
+
+    Falls back to the bare relative path when no public URI is configured —
+    still useful for hosts that resolve relative to the 401 URL, though that
+    pathway has the same authority as the request that triggered it.
     """
     if settings.opik_mcp_resource_uri:
-        return f"{settings.opik_mcp_resource_uri.rstrip('/')}{_PROTECTED_RESOURCE_METADATA_PATH}"
+        parsed = urlparse(settings.opik_mcp_resource_uri)
+        if parsed.scheme and parsed.netloc:
+            return f"{parsed.scheme}://{parsed.netloc}{_PROTECTED_RESOURCE_METADATA_PATH}"
     return _PROTECTED_RESOURCE_METADATA_PATH
+
+
+async def _not_found_json(scope: Any, receive: Any, send: Any) -> None:
+    """Default-route handler — returns 404 as JSON instead of ``text/plain``.
+
+    Starlette's stock 404 is ``Content-Type: text/plain`` with body ``Not
+    Found``. MCP host SDKs that JSON-parse every response (including
+    discovery probes that legitimately end in 404) choke on the plain
+    text and abort their bootstrap with "Failed to parse JSON". Returning
+    a tiny JSON envelope keeps every error response on the canonical
+    content-type contract.
+    """
+    response = JSONResponse({"error": "not_found"}, status_code=404)
+    await response(scope, receive, send)
 
 
 def build_app() -> Starlette:
     install_tools_listed_emitter(mcp)
     app = mcp.streamable_http_app()
+    # Replace Starlette's default plain-text 404 — see ``_not_found_json``.
+    app.router.default = _not_found_json
     app.router.routes.append(Route("/health", _liveness, methods=["GET"]))
     app.router.routes.append(Route("/health/ready", _readiness, methods=["GET"]))
     app.router.routes.append(
@@ -684,6 +826,16 @@ def build_app() -> Starlette:
             methods=["GET"],
         )
     )
+    # AS / OAuth-flow probe paths — proxy to the configured AS so
+    # split-host deployments (local docker-compose, dev clusters where
+    # opik-mcp and opik-backend bind to different addresses) work the
+    # same as the production single-edge deploy. Proxying (not redirect)
+    # because some SDKs refuse to follow cross-origin OAuth-discovery
+    # redirects and silently break their bootstrap.
+    for path in _PROXIED_OAUTH_PATHS:
+        app.router.routes.append(
+            Route(path, _proxy_to_as, methods=["GET", "POST"])
+        )
     s = get_settings()
     app.add_middleware(
         BearerAuthMiddleware,

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -599,10 +599,11 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         if not auth:
             return self._unauthorized()
 
-        if not auth.lower().startswith("bearer "):
-            # Require the canonical "Bearer …" shape so the WWW-Authenticate
-            # hint we return on failure is consistent with what the host
-            # expects to send next.
+        if not auth.lower().startswith("bearer ") or not auth[len("Bearer ") :].strip():
+            # Require the canonical "Bearer <token>" shape — non-Bearer
+            # schemes and empty tokens are rejected here rather than
+            # forwarded, so the host gets the WWW-Authenticate hint and a
+            # clean recovery path instead of an opaque upstream 401.
             return self._unauthorized()
 
         # Capture the inbound auth + workspace headers for the duration of

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,6 @@ from httpx import ASGITransport
 # explicit override in the environment still wins.
 os.environ.setdefault("OPIK_MCP_ANALYTICS_ENABLED", "false")
 
-# Run the integration suite in dev-token mode so existing tests that assert
-# "Bearer wrong" returns 401 continue to pass. The FastMCP
-# ``StreamableHTTPSessionManager`` is a process-level singleton so the
-# session-scoped ``http_client`` fixture below builds the app exactly once;
-# OAuth-passthrough behavior is exercised by unit tests against the
-# middleware directly (see ``test_oauth_passthrough_mode.py``). ``setdefault``
-# so individual tests / CI jobs can flip to OAuth-passthrough at session start.
-os.environ.setdefault("OPIK_MCP_DEV_TOKEN_ENABLED", "true")
-
 
 @pytest.fixture(autouse=True)
 def _reset_analytics_wrappers_state() -> Generator[None]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,15 @@ from httpx import ASGITransport
 # explicit override in the environment still wins.
 os.environ.setdefault("OPIK_MCP_ANALYTICS_ENABLED", "false")
 
+# Run the integration suite in dev-token mode so existing tests that assert
+# "Bearer wrong" returns 401 continue to pass. The FastMCP
+# ``StreamableHTTPSessionManager`` is a process-level singleton so the
+# session-scoped ``http_client`` fixture below builds the app exactly once;
+# OAuth-passthrough behavior is exercised by unit tests against the
+# middleware directly (see ``test_oauth_passthrough_mode.py``). ``setdefault``
+# so individual tests / CI jobs can flip to OAuth-passthrough at session start.
+os.environ.setdefault("OPIK_MCP_DEV_TOKEN_ENABLED", "true")
+
 
 @pytest.fixture(autouse=True)
 def _reset_analytics_wrappers_state() -> Generator[None]:

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -397,3 +397,49 @@ def test_fallback_client_honors_analytics_disabled_env(
         main_mod.main()
 
     assert not route.called, "analytics_enabled=false must suppress emit even on config-fail"
+
+
+# --- startup_error: OAuth resource URI required on HTTP transport ----------- #
+
+
+def test_startup_error_when_oauth_enabled_without_resource_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HTTP + OPIK_MCP_AS_URL but no OPIK_MCP_RESOURCE_URI must fail fast.
+
+    RFC 9728 requires `resource` in the protected-resource doc, and the AS
+    exact-matches the authorize `resource` param against its own config — so
+    serving the doc without it would 401-loop hosts with invalid_target.
+    """
+    recorder = _install_recorder(monkeypatch)
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://example.test/opik")
+    monkeypatch.delenv("OPIK_MCP_RESOURCE_URI", raising=False)
+
+    with pytest.raises(SystemExit):
+        main_mod.main()
+
+    props = next(p for et, p in recorder.events if et == EVENT_STARTUP_ERROR)
+    assert props["phase"] == "config"
+    assert props["error_kind"] == "invalid_config"
+    assert props["transport"] == "http"
+    assert recorder.flush_calls, "startup_error must be flushed synchronously before exit"
+
+
+def test_no_startup_error_when_resource_uri_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP + both AS URL and resource URI set must pass the guard and boot."""
+    recorder = _install_recorder(monkeypatch)
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://example.test/opik")
+    monkeypatch.setenv("OPIK_MCP_RESOURCE_URI", "https://example.test/opik/api/v1/mcp")
+
+    # Stub out the actual server boot — we only care that the config guard passes.
+    monkeypatch.setattr(main_mod, "_preflight_bind_check", lambda host, port: None)
+    monkeypatch.setattr("opik_mcp.server.build_app", lambda: object())
+    monkeypatch.setattr(main_mod.uvicorn, "run", lambda *a, **k: None)
+
+    main_mod.main()
+
+    error_props = [p for et, p in recorder.events if et == EVENT_STARTUP_ERROR]
+    assert error_props == [], "guard must not fire when resource URI is set"
+    assert EVENT_SERVER_STARTED in [e[0] for e in recorder.events]

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -154,35 +154,6 @@ def test_startup_error_omits_pii_from_invalid_config_event(
     assert canary not in payload, f"PII leak: {canary!r} surfaced in {payload!r}"
 
 
-# --- startup_error: insecure default token + non-loopback ----------------- #
-
-
-def test_startup_error_on_insecure_token_non_loopback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """HTTP mode with the default dev token + a public bind must emit before exit."""
-    recorder = _install_recorder(monkeypatch)
-    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "streamable-http")
-    monkeypatch.setenv("OPIK_MCP_HOST", "0.0.0.0")
-    # OPIK_MCP_DEV_TOKEN stays at the insecure default by not setting it.
-    monkeypatch.delenv("OPIK_MCP_DEV_TOKEN", raising=False)
-
-    with pytest.raises(SystemExit) as exc_info:
-        main_mod.main()
-    assert exc_info.value.code == 1
-
-    event_types = [e[0] for e in recorder.events]
-    # server_started fires earlier in the flow (boot was attempted) — leave
-    # the existing behaviour intact; startup_error correlates the failure.
-    assert EVENT_SERVER_STARTED in event_types
-    assert EVENT_STARTUP_ERROR in event_types
-    props = next(p for et, p in recorder.events if et == EVENT_STARTUP_ERROR)
-    assert props["phase"] == "http_bind_check"
-    assert props["error_kind"] == "insecure_token_on_public_iface"
-    assert props["transport"] == "streamable-http"
-    assert recorder.flush_calls, "must flush before sys.exit"
-
-
 # --- startup_error: unexpected exception during transport.run ------------- #
 
 

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -436,7 +436,7 @@ def test_no_startup_error_when_resource_uri_set(monkeypatch: pytest.MonkeyPatch)
     # Stub out the actual server boot — we only care that the config guard passes.
     monkeypatch.setattr(main_mod, "_preflight_bind_check", lambda host, port: None)
     monkeypatch.setattr("opik_mcp.server.build_app", lambda: object())
-    monkeypatch.setattr(main_mod.uvicorn, "run", lambda *a, **k: None)
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: None)
 
     main_mod.main()
 

--- a/tests/test_analytics_subprocess.py
+++ b/tests/test_analytics_subprocess.py
@@ -215,7 +215,6 @@ def test_preflight_handles_ipv6_loopback_via_getaddrinfo(capture: _CaptureServer
                 "OPIK_MCP_TRANSPORT": "streamable-http",
                 "OPIK_MCP_HOST": "::1",
                 "OPIK_MCP_PORT": str(held_port),
-                "OPIK_MCP_DEV_TOKEN": "test-token-not-default-1234567890",
             }
         )
     finally:
@@ -258,8 +257,6 @@ def test_port_in_use_emits_transport_crash_in_subprocess(capture: _CaptureServer
                 "OPIK_MCP_TRANSPORT": "streamable-http",
                 "OPIK_MCP_HOST": "127.0.0.1",
                 "OPIK_MCP_PORT": str(held_port),
-                # Bypass the http_bind_check that would otherwise short-circuit.
-                "OPIK_MCP_DEV_TOKEN": "test-token-not-default-1234567890",
             }
         )
     finally:

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,3 +1,12 @@
+"""Integration tests for inbound auth on the HTTP transport.
+
+opik-mcp performs no local credential validation — any well-formed
+``Authorization: Bearer …`` is accepted and forwarded verbatim to
+opik-backend, which is the single point of auth enforcement. The middleware
+only rejects requests that carry no usable bearer at all (missing header or
+a non-Bearer scheme), returning 401 so MCP hosts bootstrap the OAuth dance.
+"""
+
 import httpx
 import pytest
 
@@ -21,18 +30,25 @@ async def test_no_auth_returns_401(http_client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.anyio
-async def test_wrong_token_returns_401(http_client: httpx.AsyncClient) -> None:
-    r = await http_client.post("/mcp", json=INITIALIZE, headers={"Authorization": "Bearer wrong"})
+async def test_non_bearer_scheme_returns_401(http_client: httpx.AsyncClient) -> None:
+    r = await http_client.post(
+        "/mcp", json=INITIALIZE, headers={"Authorization": "Basic dXNlcjpwYXNz"}
+    )
     assert r.status_code == 401
 
 
 @pytest.mark.anyio
-async def test_correct_token_initializes(http_client: httpx.AsyncClient) -> None:
+async def test_any_bearer_initializes(http_client: httpx.AsyncClient) -> None:
+    """No local validation: opik-mcp accepts the bearer and forwards it.
+
+    ``initialize`` makes no outbound opik-backend call, so it succeeds
+    regardless of whether the token would later be accepted upstream.
+    """
     r = await http_client.post(
         "/mcp",
         json=INITIALIZE,
         headers={
-            "Authorization": "Bearer dev-token-123",
+            "Authorization": "Bearer opik_at_anything",
             "Accept": "application/json, text/event-stream",
         },
     )

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -1,10 +1,8 @@
-"""Unit tests for ``BearerAuthMiddleware`` in OAuth-passthrough mode.
+"""Unit tests for ``BearerAuthMiddleware`` (OAuth passthrough).
 
-The integration ``http_client`` fixture runs in dev-token mode (FastMCP's
-``StreamableHTTPSessionManager`` is a process-level singleton so the app is
-built exactly once per session). OAuth-passthrough behavior is exercised
-here by driving the middleware directly with stub call_next + manually
-constructed Starlette ``Request`` objects.
+The middleware is exercised here by driving it directly with stub call_next
++ manually constructed Starlette ``Request`` objects, asserting the
+ContextVar capture/reset behavior the integration suite can't observe.
 """
 
 from typing import Any
@@ -37,30 +35,22 @@ def _make_request(headers: dict[str, str], path: str = "/mcp") -> Request:
     return Request(scope)
 
 
-async def _ok(_request: Request) -> Response:
-    return JSONResponse({"ok": True})
-
-
 def _build_middleware(
     *,
-    dev_token_enabled: bool = False,
-    dev_token: str = "dev-token-123",
     resource_metadata_url: str | None = "https://opik.host/.well-known/oauth-protected-resource",
 ) -> BearerAuthMiddleware:
     return BearerAuthMiddleware(
         app=None,  # type: ignore[arg-type]  # we never call call_next via the ASGI app
-        dev_token_enabled=dev_token_enabled,
-        dev_token=dev_token,
         resource_metadata_url=resource_metadata_url,
     )
 
 
 @pytest.mark.anyio
 async def test_passthrough_accepts_any_well_formed_bearer() -> None:
-    """OAuth-passthrough's whole point: accept any Bearer, forward verbatim.
+    """The middleware's whole point: accept any Bearer, forward verbatim.
     opik-backend's AuthFilter validates the token; opik-mcp is a thin pipe.
     """
-    mw = _build_middleware(dev_token_enabled=False)
+    mw = _build_middleware()
     request = _make_request({"authorization": "Bearer opik_at_abc123"})
 
     captured: dict[str, str | None] = {}
@@ -85,7 +75,7 @@ async def test_passthrough_accepts_any_well_formed_bearer() -> None:
 
 @pytest.mark.anyio
 async def test_passthrough_captures_comet_workspace_header() -> None:
-    mw = _build_middleware(dev_token_enabled=False)
+    mw = _build_middleware()
     request = _make_request(
         {
             "authorization": "Bearer opik_at_abc",
@@ -104,12 +94,11 @@ async def test_passthrough_captures_comet_workspace_header() -> None:
 
 
 @pytest.mark.anyio
-async def test_passthrough_missing_authorization_returns_401_with_www_authenticate() -> None:
+async def test_missing_authorization_returns_401_with_www_authenticate() -> None:
     """The 401 must point hosts at the protected-resource metadata so they
     can bootstrap the OAuth dance — without it, hosts have no path forward.
     """
     mw = _build_middleware(
-        dev_token_enabled=False,
         resource_metadata_url="https://opik.host/.well-known/oauth-protected-resource",
     )
     request = _make_request({})
@@ -126,11 +115,11 @@ async def test_passthrough_missing_authorization_returns_401_with_www_authentica
 
 
 @pytest.mark.anyio
-async def test_passthrough_rejects_malformed_authorization() -> None:
-    """Non-Bearer schemes are rejected up front in passthrough mode — keeps
-    the WWW-Authenticate hint consistent with the host's next attempt.
+async def test_rejects_malformed_authorization() -> None:
+    """Non-Bearer schemes are rejected up front — keeps the
+    WWW-Authenticate hint consistent with the host's next attempt.
     """
-    mw = _build_middleware(dev_token_enabled=False)
+    mw = _build_middleware()
     request = _make_request({"authorization": "Basic dXNlcjpwYXNz"})
 
     async def call_next(_r: Request) -> Response:
@@ -141,45 +130,17 @@ async def test_passthrough_rejects_malformed_authorization() -> None:
 
 
 @pytest.mark.anyio
-async def test_dev_token_mode_still_rejects_wrong_token() -> None:
-    """Dev-token mode preserves the original behavior — only the matching
-    token is accepted — and is now opt-in via OPIK_MCP_DEV_TOKEN_ENABLED.
-    """
-    mw = _build_middleware(dev_token_enabled=True, dev_token="secret")
-    request = _make_request({"authorization": "Bearer wrong"})
-
-    async def call_next(_r: Request) -> Response:
-        raise AssertionError("should not reach call_next")
-
-    resp = await mw.dispatch(request, call_next)
-    assert resp.status_code == 401
-
-
-@pytest.mark.anyio
-async def test_dev_token_mode_accepts_correct_token() -> None:
-    mw = _build_middleware(dev_token_enabled=True, dev_token="secret")
-    request = _make_request({"authorization": "Bearer secret"})
-
-    async def call_next(_r: Request) -> Response:
-        return JSONResponse({"ok": True})
-
-    resp = await mw.dispatch(request, call_next)
-    assert resp.status_code == 200
-
-
-@pytest.mark.anyio
-async def test_health_paths_bypass_auth_in_both_modes() -> None:
+async def test_health_paths_bypass_auth() -> None:
     """Liveness/readiness probes have no credentials by design."""
-    for mode in (True, False):
-        mw = _build_middleware(dev_token_enabled=mode)
-        for path in ("/health", "/health/ready"):
-            request = _make_request({}, path=path)
+    mw = _build_middleware()
+    for path in ("/health", "/health/ready"):
+        request = _make_request({}, path=path)
 
-            async def call_next(_r: Request) -> Response:
-                return JSONResponse({"status": "ok"})
+        async def call_next(_r: Request) -> Response:
+            return JSONResponse({"status": "ok"})
 
-            resp = await mw.dispatch(request, call_next)
-            assert resp.status_code == 200, f"mode={mode} path={path}"
+        resp = await mw.dispatch(request, call_next)
+        assert resp.status_code == 200, f"path={path}"
 
 
 @pytest.mark.anyio
@@ -187,7 +148,7 @@ async def test_protected_resource_metadata_bypasses_auth() -> None:
     """Discovery doc is the bootstrap entry point — must be reachable
     pre-credentials.
     """
-    mw = _build_middleware(dev_token_enabled=False)
+    mw = _build_middleware()
     request = _make_request({}, path="/.well-known/oauth-protected-resource")
 
     async def call_next(_r: Request) -> Response:
@@ -198,11 +159,11 @@ async def test_protected_resource_metadata_bypasses_auth() -> None:
 
 
 @pytest.mark.anyio
-async def test_passthrough_unauthorized_without_resource_metadata_url() -> None:
+async def test_unauthorized_without_resource_metadata_url() -> None:
     """When the resource-metadata URL is unset, ``WWW-Authenticate`` is
     omitted entirely (vs. an empty value, which some host parsers reject).
     """
-    mw = _build_middleware(dev_token_enabled=False, resource_metadata_url=None)
+    mw = _build_middleware(resource_metadata_url=None)
     request = _make_request({})
 
     async def call_next(_r: Request) -> Response:

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -1,0 +1,214 @@
+"""Unit tests for ``BearerAuthMiddleware`` in OAuth-passthrough mode.
+
+The integration ``http_client`` fixture runs in dev-token mode (FastMCP's
+``StreamableHTTPSessionManager`` is a process-level singleton so the app is
+built exactly once per session). OAuth-passthrough behavior is exercised
+here by driving the middleware directly with stub call_next + manually
+constructed Starlette ``Request`` objects.
+"""
+
+from typing import Any
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from opik_mcp.auth_context import inbound_authorization, inbound_workspace
+from opik_mcp.server import BearerAuthMiddleware
+
+
+def _make_request(headers: dict[str, str], path: str = "/mcp") -> Request:
+    """Build a minimal ASGI scope for the middleware under test."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+    scope: dict[str, Any] = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": raw_headers,
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "root_path": "",
+        "http_version": "1.1",
+        "extensions": {},
+    }
+    return Request(scope)
+
+
+async def _ok(_request: Request) -> Response:
+    return JSONResponse({"ok": True})
+
+
+def _build_middleware(
+    *,
+    dev_token_enabled: bool = False,
+    dev_token: str = "dev-token-123",
+    resource_metadata_url: str | None = "https://opik.host/.well-known/oauth-protected-resource",
+) -> BearerAuthMiddleware:
+    return BearerAuthMiddleware(
+        app=None,  # type: ignore[arg-type]  # we never call call_next via the ASGI app
+        dev_token_enabled=dev_token_enabled,
+        dev_token=dev_token,
+        resource_metadata_url=resource_metadata_url,
+    )
+
+
+@pytest.mark.anyio
+async def test_passthrough_accepts_any_well_formed_bearer() -> None:
+    """OAuth-passthrough's whole point: accept any Bearer, forward verbatim.
+    opik-backend's AuthFilter validates the token; opik-mcp is a thin pipe.
+    """
+    mw = _build_middleware(dev_token_enabled=False)
+    request = _make_request({"authorization": "Bearer opik_at_abc123"})
+
+    captured: dict[str, str | None] = {}
+
+    async def call_next(_r: Request) -> Response:
+        captured["auth"] = inbound_authorization.get()
+        captured["workspace"] = inbound_workspace.get()
+        return JSONResponse({"ok": True})
+
+    resp = await mw.dispatch(request, call_next)
+
+    assert resp.status_code == 200
+    # Bearer captured exactly as inbound so outbound forwarding preserves it.
+    assert captured["auth"] == "Bearer opik_at_abc123"
+    # No workspace header on this request → ContextVar reads as None.
+    assert captured["workspace"] is None
+    # ContextVar is reset after the request returns — no leakage to the
+    # next request handled by the same worker.
+    assert inbound_authorization.get() is None
+    assert inbound_workspace.get() is None
+
+
+@pytest.mark.anyio
+async def test_passthrough_captures_comet_workspace_header() -> None:
+    mw = _build_middleware(dev_token_enabled=False)
+    request = _make_request(
+        {
+            "authorization": "Bearer opik_at_abc",
+            "comet-workspace": "my-team",
+        }
+    )
+
+    captured: dict[str, str | None] = {}
+
+    async def call_next(_r: Request) -> Response:
+        captured["workspace"] = inbound_workspace.get()
+        return JSONResponse({"ok": True})
+
+    await mw.dispatch(request, call_next)
+    assert captured["workspace"] == "my-team"
+
+
+@pytest.mark.anyio
+async def test_passthrough_missing_authorization_returns_401_with_www_authenticate() -> None:
+    """The 401 must point hosts at the protected-resource metadata so they
+    can bootstrap the OAuth dance — without it, hosts have no path forward.
+    """
+    mw = _build_middleware(
+        dev_token_enabled=False,
+        resource_metadata_url="https://opik.host/.well-known/oauth-protected-resource",
+    )
+    request = _make_request({})
+
+    async def call_next(_r: Request) -> Response:
+        raise AssertionError("should not reach call_next")
+
+    resp = await mw.dispatch(request, call_next)
+
+    assert resp.status_code == 401
+    www_auth = resp.headers.get("www-authenticate", "")
+    assert 'realm="opik-mcp"' in www_auth
+    assert 'resource_metadata="https://opik.host/.well-known/oauth-protected-resource"' in www_auth
+
+
+@pytest.mark.anyio
+async def test_passthrough_rejects_malformed_authorization() -> None:
+    """Non-Bearer schemes are rejected up front in passthrough mode — keeps
+    the WWW-Authenticate hint consistent with the host's next attempt.
+    """
+    mw = _build_middleware(dev_token_enabled=False)
+    request = _make_request({"authorization": "Basic dXNlcjpwYXNz"})
+
+    async def call_next(_r: Request) -> Response:
+        raise AssertionError("should not reach call_next")
+
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_dev_token_mode_still_rejects_wrong_token() -> None:
+    """Dev-token mode preserves the original behavior — only the matching
+    token is accepted — and is now opt-in via OPIK_MCP_DEV_TOKEN_ENABLED.
+    """
+    mw = _build_middleware(dev_token_enabled=True, dev_token="secret")
+    request = _make_request({"authorization": "Bearer wrong"})
+
+    async def call_next(_r: Request) -> Response:
+        raise AssertionError("should not reach call_next")
+
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_dev_token_mode_accepts_correct_token() -> None:
+    mw = _build_middleware(dev_token_enabled=True, dev_token="secret")
+    request = _make_request({"authorization": "Bearer secret"})
+
+    async def call_next(_r: Request) -> Response:
+        return JSONResponse({"ok": True})
+
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_health_paths_bypass_auth_in_both_modes() -> None:
+    """Liveness/readiness probes have no credentials by design."""
+    for mode in (True, False):
+        mw = _build_middleware(dev_token_enabled=mode)
+        for path in ("/health", "/health/ready"):
+            request = _make_request({}, path=path)
+
+            async def call_next(_r: Request) -> Response:
+                return JSONResponse({"status": "ok"})
+
+            resp = await mw.dispatch(request, call_next)
+            assert resp.status_code == 200, f"mode={mode} path={path}"
+
+
+@pytest.mark.anyio
+async def test_protected_resource_metadata_bypasses_auth() -> None:
+    """Discovery doc is the bootstrap entry point — must be reachable
+    pre-credentials.
+    """
+    mw = _build_middleware(dev_token_enabled=False)
+    request = _make_request({}, path="/.well-known/oauth-protected-resource")
+
+    async def call_next(_r: Request) -> Response:
+        return JSONResponse({"authorization_servers": ["x"]})
+
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_passthrough_unauthorized_without_resource_metadata_url() -> None:
+    """When the resource-metadata URL is unset, ``WWW-Authenticate`` is
+    omitted entirely (vs. an empty value, which some host parsers reject).
+    """
+    mw = _build_middleware(dev_token_enabled=False, resource_metadata_url=None)
+    request = _make_request({})
+
+    async def call_next(_r: Request) -> Response:
+        raise AssertionError("should not reach call_next")
+
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 401
+    # Starlette ``MutableHeaders`` is case-insensitive — direct ``in`` is enough.
+    assert "www-authenticate" not in resp.headers

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -130,6 +130,23 @@ async def test_rejects_malformed_authorization() -> None:
 
 
 @pytest.mark.anyio
+async def test_rejects_bearer_with_empty_token() -> None:
+    """``Bearer`` with no (or whitespace-only) token is rejected locally
+    with the WWW-Authenticate hint rather than forwarded for an opaque
+    upstream 401.
+    """
+    mw = _build_middleware()
+    for value in ("Bearer ", "Bearer    "):
+        request = _make_request({"authorization": value})
+
+        async def call_next(_r: Request) -> Response:
+            raise AssertionError("should not reach call_next")
+
+        resp = await mw.dispatch(request, call_next)
+        assert resp.status_code == 401, f"authorization={value!r}"
+
+
+@pytest.mark.anyio
 async def test_health_paths_bypass_auth() -> None:
     """Liveness/readiness probes have no credentials by design."""
     mw = _build_middleware()

--- a/tests/test_oauth_protected_resource.py
+++ b/tests/test_oauth_protected_resource.py
@@ -1,0 +1,77 @@
+"""Tests for the RFC 9728 protected-resource metadata endpoint.
+
+This endpoint is the bootstrap entry point for the MCP host's OAuth dance:
+hosts fetch it without credentials, parse out ``authorization_servers``, and
+then run discovery against the AS. Tests cover the configured-AS happy path,
+the no-AS misconfiguration case, and the auth-exempt status.
+"""
+
+import httpx
+import pytest
+
+from opik_mcp.config import get_settings
+
+PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache() -> None:
+    """Settings is ``lru_cache(maxsize=1)``-d. Clear it between tests that
+    mutate env so each test sees the values it set, not the previous test's.
+    """
+    get_settings.cache_clear()
+
+
+@pytest.mark.anyio
+async def test_protected_resource_metadata_unconfigured_returns_503(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPIK_MCP_AS_URL", raising=False)
+    get_settings.cache_clear()
+    r = await http_client.get(PROTECTED_RESOURCE_METADATA_PATH)
+    assert r.status_code == 503
+    assert r.json() == {"error": "OPIK_MCP_AS_URL not configured"}
+
+
+@pytest.mark.anyio
+async def test_protected_resource_metadata_configured(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://www.comet.com")
+    monkeypatch.setenv("OPIK_MCP_RESOURCE_URI", "https://www.comet.com/api/v1/mcp")
+    get_settings.cache_clear()
+    r = await http_client.get(PROTECTED_RESOURCE_METADATA_PATH)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["authorization_servers"] == ["https://www.comet.com"]
+    assert body["resource"] == "https://www.comet.com/api/v1/mcp"
+
+
+@pytest.mark.anyio
+async def test_protected_resource_metadata_without_resource_uri(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``resource`` field is optional — omitted from the JSON when unset."""
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://www.comet.com")
+    monkeypatch.delenv("OPIK_MCP_RESOURCE_URI", raising=False)
+    get_settings.cache_clear()
+    r = await http_client.get(PROTECTED_RESOURCE_METADATA_PATH)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["authorization_servers"] == ["https://www.comet.com"]
+    assert "resource" not in body
+
+
+@pytest.mark.anyio
+async def test_protected_resource_metadata_is_auth_exempt(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bootstrapping the OAuth dance requires reaching this endpoint without
+    any credentials — otherwise the host can never discover the AS in the
+    first place.
+    """
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://www.comet.com")
+    get_settings.cache_clear()
+    # No Authorization header — would 401 on /mcp; must succeed here.
+    r = await http_client.get(PROTECTED_RESOURCE_METADATA_PATH)
+    assert r.status_code == 200

--- a/tests/test_oauth_redirect.py
+++ b/tests/test_oauth_redirect.py
@@ -1,0 +1,193 @@
+"""Tests for AS-probe proxy routes.
+
+MCP host SDKs probe AS-discovery + OAuth-flow endpoints at the resource
+server's host before they have a token. opik-mcp proxies those probes to
+the configured AS (``OPIK_MCP_AS_URL``) so split-host deployments (local
+docker-compose, dev clusters where opik-mcp and opik-backend bind to
+different addresses) work the same as the production single-edge deploy.
+
+Proxying (rather than redirect) because some host SDKs refuse to follow
+cross-origin OAuth-discovery redirects and silently break their bootstrap.
+"""
+
+import httpx
+import pytest
+import respx
+
+from opik_mcp.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache() -> None:
+    get_settings.cache_clear()
+
+
+@pytest.mark.anyio
+async def test_well_known_as_metadata_proxied_to_configured_as(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "http://localhost:5173/api")
+    get_settings.cache_clear()
+    upstream_body = {
+        "issuer": "http://localhost:5173/api",
+        "authorization_endpoint": "http://localhost:5173/api/oauth/authorize",
+        "token_endpoint": "http://localhost:5173/api/oauth/token",
+    }
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(
+            "http://localhost:5173/api/.well-known/oauth-authorization-server"
+        ).mock(return_value=httpx.Response(200, json=upstream_body))
+        r = await http_client.get(
+            "/.well-known/oauth-authorization-server", follow_redirects=False
+        )
+    assert r.status_code == 200
+    assert r.json() == upstream_body
+
+
+@pytest.mark.anyio
+async def test_oidc_config_proxied_to_as_metadata(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SDKs that fall back to OIDC discovery get the same AS metadata doc —
+    RFC 8414 metadata is a superset of what the SDK needs.
+    """
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "http://localhost:5173/api")
+    get_settings.cache_clear()
+    upstream_body = {"issuer": "http://localhost:5173/api"}
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(
+            "http://localhost:5173/api/.well-known/oauth-authorization-server"
+        ).mock(return_value=httpx.Response(200, json=upstream_body))
+        r = await http_client.get(
+            "/.well-known/openid-configuration", follow_redirects=False
+        )
+    assert r.status_code == 200
+    assert r.json() == upstream_body
+
+
+@pytest.mark.anyio
+async def test_register_post_proxied_with_body(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DCR is ``POST /oauth/register`` on the AS. The proxy forwards the
+    JSON body and returns the AS's 201 with the minted client_id.
+    """
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "http://localhost:5173/api")
+    get_settings.cache_clear()
+    upstream_body = {
+        "client_id": "abc-123",
+        "client_name": "test",
+        "redirect_uris": ["http://x"],
+    }
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.post("http://localhost:5173/api/oauth/register").mock(
+            return_value=httpx.Response(201, json=upstream_body)
+        )
+        r = await http_client.post(
+            "/register",
+            json={"client_name": "test", "redirect_uris": ["http://x"]},
+            follow_redirects=False,
+        )
+    assert r.status_code == 201
+    assert r.json() == upstream_body
+    assert route.called
+
+
+@pytest.mark.anyio
+async def test_authorize_get_preserves_query_string(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``/oauth/authorize`` carries client_id, PKCE, state, etc. — must
+    round-trip through the proxy. A redirect from the AS (302 to the
+    consent UI) propagates back as a 302 to the SDK / browser.
+    """
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "http://localhost:5173/api")
+    get_settings.cache_clear()
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get(
+            "http://localhost:5173/api/oauth/authorize"
+        ).mock(
+            return_value=httpx.Response(
+                302,
+                headers={"location": "http://localhost:5173/oauth/consent?x=1"},
+            )
+        )
+        r = await http_client.get(
+            "/authorize?client_id=abc&state=xyz", follow_redirects=False
+        )
+    assert r.status_code == 302
+    assert r.headers["location"] == "http://localhost:5173/oauth/consent?x=1"
+    # Confirm the proxy forwarded the query string upstream.
+    assert "client_id=abc" in str(route.calls.last.request.url)
+    assert "state=xyz" in str(route.calls.last.request.url)
+
+
+@pytest.mark.anyio
+async def test_proxy_unconfigured_returns_503(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPIK_MCP_AS_URL", raising=False)
+    get_settings.cache_clear()
+    r = await http_client.get(
+        "/.well-known/oauth-authorization-server", follow_redirects=False
+    )
+    assert r.status_code == 503
+
+
+@pytest.mark.anyio
+async def test_proxy_paths_are_auth_exempt(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The probes happen pre-token, so the auth middleware must NOT
+    intercept them. The integration ``http_client`` runs in dev-token
+    mode; a 401 here would indicate the auth middleware fired before
+    the proxy route ran.
+    """
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "http://localhost:5173/api")
+    get_settings.cache_clear()
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(
+            "http://localhost:5173/api/.well-known/oauth-authorization-server"
+        ).mock(return_value=httpx.Response(200, json={"issuer": "x"}))
+        # No Authorization header — must NOT 401.
+        r = await http_client.get(
+            "/.well-known/oauth-authorization-server", follow_redirects=False
+        )
+    assert r.status_code != 401, "AS probe must bypass the auth middleware"
+
+
+@pytest.mark.anyio
+async def test_path_prefixed_well_known_bypasses_auth(
+    http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Some SDKs probe path-prefixed variants like
+    ``/.well-known/oauth-protected-resource/mcp`` and
+    ``/mcp/.well-known/openid-configuration``. We don't serve those
+    routes, but the auth middleware must let them through to the 404
+    handler instead of intercepting with 401 — otherwise the SDK
+    interprets the 401 as a fatal auth failure and aborts bootstrap.
+    """
+    for path in (
+        "/.well-known/oauth-protected-resource/mcp",
+        "/.well-known/oauth-authorization-server/mcp",
+        "/mcp/.well-known/openid-configuration",
+    ):
+        r = await http_client.get(path, follow_redirects=False)
+        assert r.status_code != 401, f"{path} must bypass auth, got 401"
+
+
+@pytest.mark.anyio
+async def test_404_returns_json_not_plain_text(
+    http_client: httpx.AsyncClient,
+) -> None:
+    """Starlette's default 404 is ``text/plain`` with body ``Not Found``;
+    MCP host SDKs that JSON-parse every response abort with "Failed to
+    parse JSON" when they probe a path-prefixed well-known endpoint and
+    hit that 404. Our default-route handler returns JSON instead.
+    """
+    r = await http_client.get(
+        "/.well-known/oauth-protected-resource/mcp", follow_redirects=False
+    )
+    assert r.status_code == 404
+    assert r.headers["content-type"].startswith("application/json")
+    assert r.json() == {"error": "not_found"}

--- a/tests/test_oauth_redirect.py
+++ b/tests/test_oauth_redirect.py
@@ -34,12 +34,10 @@ async def test_well_known_as_metadata_proxied_to_configured_as(
         "token_endpoint": "http://localhost:5173/api/oauth/token",
     }
     with respx.mock(assert_all_called=False) as mock:
-        mock.get(
-            "http://localhost:5173/api/.well-known/oauth-authorization-server"
-        ).mock(return_value=httpx.Response(200, json=upstream_body))
-        r = await http_client.get(
-            "/.well-known/oauth-authorization-server", follow_redirects=False
+        mock.get("http://localhost:5173/api/.well-known/oauth-authorization-server").mock(
+            return_value=httpx.Response(200, json=upstream_body)
         )
+        r = await http_client.get("/.well-known/oauth-authorization-server", follow_redirects=False)
     assert r.status_code == 200
     assert r.json() == upstream_body
 
@@ -55,12 +53,10 @@ async def test_oidc_config_proxied_to_as_metadata(
     get_settings.cache_clear()
     upstream_body = {"issuer": "http://localhost:5173/api"}
     with respx.mock(assert_all_called=False) as mock:
-        mock.get(
-            "http://localhost:5173/api/.well-known/oauth-authorization-server"
-        ).mock(return_value=httpx.Response(200, json=upstream_body))
-        r = await http_client.get(
-            "/.well-known/openid-configuration", follow_redirects=False
+        mock.get("http://localhost:5173/api/.well-known/oauth-authorization-server").mock(
+            return_value=httpx.Response(200, json=upstream_body)
         )
+        r = await http_client.get("/.well-known/openid-configuration", follow_redirects=False)
     assert r.status_code == 200
     assert r.json() == upstream_body
 
@@ -104,17 +100,13 @@ async def test_authorize_get_preserves_query_string(
     monkeypatch.setenv("OPIK_MCP_AS_URL", "http://localhost:5173/api")
     get_settings.cache_clear()
     with respx.mock(assert_all_called=False) as mock:
-        route = mock.get(
-            "http://localhost:5173/api/oauth/authorize"
-        ).mock(
+        route = mock.get("http://localhost:5173/api/oauth/authorize").mock(
             return_value=httpx.Response(
                 302,
                 headers={"location": "http://localhost:5173/oauth/consent?x=1"},
             )
         )
-        r = await http_client.get(
-            "/authorize?client_id=abc&state=xyz", follow_redirects=False
-        )
+        r = await http_client.get("/authorize?client_id=abc&state=xyz", follow_redirects=False)
     assert r.status_code == 302
     assert r.headers["location"] == "http://localhost:5173/oauth/consent?x=1"
     # Confirm the proxy forwarded the query string upstream.
@@ -128,9 +120,7 @@ async def test_proxy_unconfigured_returns_503(
 ) -> None:
     monkeypatch.delenv("OPIK_MCP_AS_URL", raising=False)
     get_settings.cache_clear()
-    r = await http_client.get(
-        "/.well-known/oauth-authorization-server", follow_redirects=False
-    )
+    r = await http_client.get("/.well-known/oauth-authorization-server", follow_redirects=False)
     assert r.status_code == 503
 
 
@@ -139,20 +129,17 @@ async def test_proxy_paths_are_auth_exempt(
     http_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The probes happen pre-token, so the auth middleware must NOT
-    intercept them. The integration ``http_client`` runs in dev-token
-    mode; a 401 here would indicate the auth middleware fired before
-    the proxy route ran.
+    intercept them. A 401 here would indicate the auth middleware fired
+    before the proxy route ran.
     """
     monkeypatch.setenv("OPIK_MCP_AS_URL", "http://localhost:5173/api")
     get_settings.cache_clear()
     with respx.mock(assert_all_called=False) as mock:
-        mock.get(
-            "http://localhost:5173/api/.well-known/oauth-authorization-server"
-        ).mock(return_value=httpx.Response(200, json={"issuer": "x"}))
-        # No Authorization header — must NOT 401.
-        r = await http_client.get(
-            "/.well-known/oauth-authorization-server", follow_redirects=False
+        mock.get("http://localhost:5173/api/.well-known/oauth-authorization-server").mock(
+            return_value=httpx.Response(200, json={"issuer": "x"})
         )
+        # No Authorization header — must NOT 401.
+        r = await http_client.get("/.well-known/oauth-authorization-server", follow_redirects=False)
     assert r.status_code != 401, "AS probe must bypass the auth middleware"
 
 
@@ -185,9 +172,7 @@ async def test_404_returns_json_not_plain_text(
     parse JSON" when they probe a path-prefixed well-known endpoint and
     hit that 404. Our default-route handler returns JSON instead.
     """
-    r = await http_client.get(
-        "/.well-known/oauth-protected-resource/mcp", follow_redirects=False
-    )
+    r = await http_client.get("/.well-known/oauth-protected-resource/mcp", follow_redirects=False)
     assert r.status_code == 404
     assert r.headers["content-type"].startswith("application/json")
     assert r.json() == {"error": "not_found"}

--- a/tests/test_opik_client.py
+++ b/tests/test_opik_client.py
@@ -345,6 +345,31 @@ def test_resolve_opik_config_requires_workspace() -> None:
         resolve_opik_config(s)
 
 
+def test_resolve_opik_config_oauth_token_makes_workspace_optional() -> None:
+    from opik_mcp.auth_context import inbound_authorization
+    from opik_mcp.config import Settings
+    from opik_mcp.opik_client import resolve_opik_config
+
+    s = Settings(opik_api_key=None, comet_workspace=None, opik_url="https://opik.example.com")
+    token = inbound_authorization.set("Bearer opik_at_abc123")
+    try:
+        base, api_key, workspace = resolve_opik_config(s)
+    finally:
+        inbound_authorization.reset(token)
+
+    assert api_key == "Bearer opik_at_abc123"
+    assert workspace is None
+
+
+def test_oauth_client_omits_workspace_header() -> None:
+    from opik_mcp.opik_client import OpikClient
+
+    client = OpikClient(base_url="https://opik.example.com", api_key="Bearer opik_at_x", workspace=None)
+    headers = client._headers()
+    assert "Comet-Workspace" not in headers
+    assert headers["Authorization"] == "Bearer opik_at_x"
+
+
 # --- execute_experiment ------------------------------------------------------- #
 
 

--- a/tests/test_opik_client.py
+++ b/tests/test_opik_client.py
@@ -361,6 +361,23 @@ def test_resolve_opik_config_oauth_token_makes_workspace_optional() -> None:
     assert workspace is None
 
 
+def test_resolve_opik_config_oauth_detection_is_prefix_not_substring() -> None:
+    """A bearer that merely *contains* the OAuth marker mid-string is not an
+    OAuth token — the workspace requirement must still apply.
+    """
+    from opik_mcp.auth_context import inbound_authorization
+    from opik_mcp.config import MissingConfigError, Settings
+    from opik_mcp.opik_client import resolve_opik_config
+
+    s = Settings(opik_api_key=None, comet_workspace=None, opik_url="https://opik.example.com")
+    token = inbound_authorization.set("Bearer sk-xopik_at_y")
+    try:
+        with pytest.raises(MissingConfigError, match="COMET_WORKSPACE"):
+            resolve_opik_config(s)
+    finally:
+        inbound_authorization.reset(token)
+
+
 def test_oauth_client_omits_workspace_header() -> None:
     from opik_mcp.opik_client import OpikClient
 

--- a/tests/test_opik_client.py
+++ b/tests/test_opik_client.py
@@ -353,7 +353,7 @@ def test_resolve_opik_config_oauth_token_makes_workspace_optional() -> None:
     s = Settings(opik_api_key=None, comet_workspace=None, opik_url="https://opik.example.com")
     token = inbound_authorization.set("Bearer opik_at_abc123")
     try:
-        base, api_key, workspace = resolve_opik_config(s)
+        _base, api_key, workspace = resolve_opik_config(s)
     finally:
         inbound_authorization.reset(token)
 
@@ -364,7 +364,9 @@ def test_resolve_opik_config_oauth_token_makes_workspace_optional() -> None:
 def test_oauth_client_omits_workspace_header() -> None:
     from opik_mcp.opik_client import OpikClient
 
-    client = OpikClient(base_url="https://opik.example.com", api_key="Bearer opik_at_x", workspace=None)
+    client = OpikClient(
+        base_url="https://opik.example.com", api_key="Bearer opik_at_x", workspace=None
+    )
     headers = client._headers()
     assert "Comet-Workspace" not in headers
     assert headers["Authorization"] == "Bearer opik_at_x"

--- a/tests/test_resource_metadata_url.py
+++ b/tests/test_resource_metadata_url.py
@@ -1,0 +1,55 @@
+"""Unit tests for ``_resource_metadata_url``.
+
+The URL advertised in ``WWW-Authenticate`` must match where the
+protected-resource metadata route actually lives on the server. The route
+is registered at the application root (``/.well-known/oauth-protected-resource``),
+not nested under the resource path. So when the resource URI is
+``http://127.0.0.1:8888/mcp``, the advertised metadata URL must be
+``http://127.0.0.1:8888/.well-known/oauth-protected-resource`` and NOT
+``http://127.0.0.1:8888/mcp/.well-known/oauth-protected-resource`` — the
+latter falls through to the MCP path's auth middleware and 401s, silently
+breaking the host's discovery chain.
+"""
+
+from opik_mcp.config import Settings
+from opik_mcp.server import _resource_metadata_url
+
+
+def _settings(resource_uri: str | None) -> Settings:
+    return Settings(opik_mcp_resource_uri=resource_uri, _env_file=None)  # type: ignore[call-arg]
+
+
+def test_resource_uri_with_path_strips_to_host_root() -> None:
+    """Resource URI with a path → metadata URL uses scheme://authority only."""
+    url = _resource_metadata_url(_settings("http://127.0.0.1:8888/mcp"))
+    assert url == "http://127.0.0.1:8888/.well-known/oauth-protected-resource"
+
+
+def test_resource_uri_already_at_host_root() -> None:
+    """No path on the resource URI — same behavior."""
+    url = _resource_metadata_url(_settings("http://127.0.0.1:8888"))
+    assert url == "http://127.0.0.1:8888/.well-known/oauth-protected-resource"
+
+
+def test_resource_uri_with_trailing_slash() -> None:
+    url = _resource_metadata_url(_settings("http://127.0.0.1:8888/mcp/"))
+    assert url == "http://127.0.0.1:8888/.well-known/oauth-protected-resource"
+
+
+def test_https_authority_preserved() -> None:
+    url = _resource_metadata_url(_settings("https://www.comet.com/api/v1/mcp"))
+    assert url == "https://www.comet.com/.well-known/oauth-protected-resource"
+
+
+def test_unconfigured_falls_back_to_relative_path() -> None:
+    """No resource URI configured — fall back to the bare path. Hosts that
+    resolve relative to the 401 URL will land on the right authority anyway.
+    """
+    url = _resource_metadata_url(_settings(None))
+    assert url == "/.well-known/oauth-protected-resource"
+
+
+def test_malformed_resource_uri_falls_back_to_relative_path() -> None:
+    """Garbage in the resource URI → safe fallback, not a crash."""
+    url = _resource_metadata_url(_settings("not-a-url"))
+    assert url == "/.well-known/oauth-protected-resource"


### PR DESCRIPTION
## Summary

Implements opik-mcp's resource-server-transport role for the hosted OAuth flow ([OPIK-6742](https://comet-ml.atlassian.net/browse/OPIK-6742)). opik-mcp becomes a thin transport adapter on HTTP transport — no local bearer validation, no permission knowledge, no separate validator round-trip. opik-backend's `AuthFilter` (shipped in [opik#6900](https://github.com/comet-ml/opik/pull/6900)) is the single point of truth and accepts both API keys and `opik_at_…` OAuth tokens, so opik-mcp just forwards.

Companion design: [OPIK-6666 design doc](https://www.notion.so/cometml/Opik-MCP-OAuth-36c7124010a38086b246f41c201ef569).

## What changed

**Inbound auth (`server.py`, new `auth_context.py`)**
- `BearerAuthMiddleware` performs **no local credential validation**: any well-formed `Bearer …` is accepted, captured into ContextVars (`inbound_authorization`, `inbound_workspace`), and forwarded verbatim on the outbound opik-backend call. The backend is the single point of auth enforcement.
- Missing/empty `Authorization` or a non-Bearer scheme → 401 + `WWW-Authenticate: Bearer realm="opik-mcp", resource_metadata="<discovery-url>"` so MCP hosts can bootstrap the OAuth dance per RFC 6750.
- Health probes, the discovery endpoint, and AS-probe paths are auth-exempt.

**Dev-token mode removed (`config.py`, `__main__.py`, `Makefile`)**
- `OPIK_MCP_DEV_TOKEN` is deleted entirely. Its only use case — local HTTP testing — is covered by passthrough: send `Authorization: Bearer <OPIK_API_KEY>` and the backend validates it (comet-backend strips the `Bearer ` prefix; OSS installs don't authenticate at all, so a token gate there was never a real boundary). No deployment manifest anywhere sets it.
- The "refuse to start with default token on non-loopback bind" guard goes with it — passthrough carries no server-side secret, so the security posture is exactly that of the backend behind it. Documented in the README (see below); default bind stays `127.0.0.1`.

**Discovery (`server.py`)**
- New `GET /.well-known/oauth-protected-resource` per RFC 9728. Returns `{authorization_servers: [OPIK_MCP_AS_URL], resource: OPIK_MCP_RESOURCE_URI}`. 503 when `OPIK_MCP_AS_URL` isn't set — makes the misconfiguration loud rather than silently breaking the OAuth bootstrap.
- AS-probe proxying: MCP host SDKs probe `/register`, `/authorize`, `/token`, `/.well-known/oauth-authorization-server`, OIDC fallback, etc. at the RS host pre-token. These are proxied to `OPIK_MCP_AS_URL` (proxy, not redirect — some SDKs refuse cross-origin OAuth-discovery redirects) so split-host deploys work like the production single-edge deploy.
- Starlette's plain-text 404 replaced with a JSON 404 — SDKs that JSON-parse every discovery response choke on `text/plain`.

**Bearer forwarding (`opik_client.py`)**
- `resolve_opik_config()` prefers the inbound `Authorization` + `Comet-Workspace` headers (via ContextVars) over the env-bound `OPIK_API_KEY` / `COMET_WORKSPACE`. Same code path handles both API keys and `opik_at_…` tokens — opik-backend's `AuthFilter` already discriminates server-side.
- For `opik_at_…` tokens the workspace is optional client-side (the backend derives it from the token row); `Comet-Workspace` is omitted from outbound headers when absent. `run_experiment` still requires a workspace (needed client-side for the summary URL) and fails with a clear error when neither env nor header provides one.

**New config (`config.py`)**
- `OPIK_MCP_AS_URL: str | None = None` — advertised as `authorization_servers` in the discovery doc; proxy target for AS probes.
- `OPIK_MCP_RESOURCE_URI: str | None = None` — advertised as `resource`; derives the `WWW-Authenticate` metadata URL.

**README**
- New "Choosing a transport" section: stdio recommended for same-machine local OSS; stdio + API key or HTTP + OAuth for local→remote; HTTP for hosted opik-mcp behind the same edge as opik-backend. Notes explicitly that OSS backends don't authenticate, so an HTTP opik-mcp in front of one is as open as the OSS REST API itself.
- Env-var table: `OPIK_MCP_DEV_TOKEN` row replaced with `OPIK_MCP_AS_URL` / `OPIK_MCP_RESOURCE_URI`.

## What's NOT in this PR (by design)

- **OAuth on stdio transport.** Out of scope — would require opik-mcp to act as the OAuth client (PKCE dance, browser, OS-keychain token storage). stdio + API key continues to work exactly as before; stdio has no inbound auth at all (whoever can spawn the process owns its stdio).
- **`comet_client.py` bearer forwarding.** `ask_ollie` / `run_experiment` are Comet-Cloud-only and use the Comet API key directly; not affected by this change.
- **Telemetry `auth_mode` tagging.** Will follow in a separate commit.

## Test plan

- [x] `make check` — ruff clean, mypy clean (101 files), 967 passed / 2 skipped
- [x] New tests:
  - `test_oauth_protected_resource.py` (4) — configured/unconfigured/auth-exempt
  - `test_oauth_passthrough_mode.py` (7) — Bearer accepted + ContextVar capture/reset, Comet-Workspace captured, missing-auth → 401 + WWW-Authenticate, malformed-auth rejected, health + discovery paths exempt
  - `test_oauth_redirect.py` (8) — AS-probe proxying: metadata/OIDC/DCR/authorize round-trips, query-string preservation, 503 unconfigured, auth-exempt, JSON 404
  - `test_resource_metadata_url.py` (6) — WWW-Authenticate URL derivation from the resource URI
- [x] `test_http_auth.py` reworked for the single passthrough mode: no-auth → 401, non-Bearer scheme → 401, any Bearer → initialize 200
- [ ] Manual smoke test: opik-mcp HTTP transport against a local OSS opik-backend with `MCP_OAUTH_ENABLED=true` — pending PR landing so we can pick it up in the OPIK-6666 testing matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6742]: https://comet-ml.atlassian.net/browse/OPIK-6742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
