### PR TITLE
fix(analytics): retry transient POST failures so server_started lands

### DIFF
--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -30,13 +30,16 @@ LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 # Best-effort drain budget on the startup-error path. The daemon worker that
 # normally POSTs analytics events is killed by the imminent sys.exit/re-raise,
 # so we must block long enough for the in-flight POST to land — but not so
-# long that a broken receiver hangs the user-facing crash.
-_STARTUP_ERROR_FLUSH_DEADLINE_S = 2.0
+# long that a broken receiver hangs the user-facing crash. Widened from 2.0s
+# to give a cold first POST (DNS+TLS handshake) — plus the worker's first
+# retry — a fair chance to land within the deadline. flush() returns as soon
+# as the queue drains, so this is a ceiling, not a fixed wait.
+_STARTUP_ERROR_FLUSH_DEADLINE_S = 3.5
 # Shutdown shares the same constraint (daemon worker about to be killed) but
 # is intentionally a separate constant so the startup and shutdown budgets
 # can evolve independently — e.g. shutdown may need a longer drain once we
 # add larger trailing event payloads (lifespan stats, session summaries).
-_SHUTDOWN_FLUSH_DEADLINE_S = 2.0
+_SHUTDOWN_FLUSH_DEADLINE_S = 3.5
 
 # Bounded allowlist for ``exception_type`` on the transport-crash path. Any
 # class outside this set is bucketed to ``"unknown"`` to preserve the low-

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -11,6 +11,7 @@ import platform
 import queue
 import sys
 import threading
+import time
 from datetime import UTC, datetime
 from typing import Any
 
@@ -38,8 +39,16 @@ class AnalyticsClient:
         *,
         http_client: httpx.Client | None = None,
         max_queue_size: int = 100,
+        retry_backoff_s: tuple[float, ...] = (0.0, 0.5, 1.5),
     ) -> None:
         self._settings = settings
+        # One entry per delivery attempt; the value is the delay (seconds) to
+        # sleep *before* that attempt. The first 0.0 means "try immediately".
+        # The second attempt reuses the pooled connection the first one warmed,
+        # which is why a single retry recovers the lost-cold-POST case. Empty is
+        # normalised to one immediate attempt so a stray ``()`` can never mean
+        # "never send" (it would silently drop every event with zero attempts).
+        self._retry_backoff_s = retry_backoff_s or (0.0,)
         self._http = http_client or httpx.Client(
             timeout=httpx.Timeout(
                 connect=settings.opik_mcp_analytics_connect_timeout_s,
@@ -145,13 +154,33 @@ class AnalyticsClient:
             try:
                 if event is _QUEUE_SENTINEL:
                     return
-                try:
-                    resp = self._http.post(self._settings.opik_mcp_analytics_url, json=event)
-                    resp.raise_for_status()
-                except Exception:
-                    logger.warning("analytics POST failed", exc_info=True)
+                self._dispatch_with_retry(event)
             finally:
                 self._queue.task_done()
+
+    def _dispatch_with_retry(self, event: dict[str, Any]) -> None:
+        """POST one event, retrying transient failures per ``_retry_backoff_s``.
+
+        The first cold POST routinely loses the DNS+TLS race; a retry on the
+        warmed pooled connection lands. We retry on *any* exception (network,
+        timeout, 5xx via ``raise_for_status``) because at this layer they are
+        indistinguishable from the transient class we care about, and a wasted
+        retry on a genuine permanent error is cheap (events are tiny).
+        """
+        for delay in self._retry_backoff_s:
+            if delay:
+                time.sleep(delay)
+            try:
+                resp = self._http.post(self._settings.opik_mcp_analytics_url, json=event)
+                resp.raise_for_status()
+                return
+            except Exception:
+                logger.debug("analytics POST attempt failed", exc_info=True)
+        logger.warning(
+            "analytics POST failed after %d attempt(s) for event_type=%s",
+            len(self._retry_backoff_s),
+            event.get("event_type"),
+        )
 
     def _build_event(self, event_type: str, properties: dict[str, str]) -> dict[str, Any]:
         common: dict[str, str] = {

--- a/tests/test_analytics_client.py
+++ b/tests/test_analytics_client.py
@@ -331,7 +331,8 @@ def test_disabled_skips_post() -> None:
 @respx.mock
 def test_worker_swallows_exceptions() -> None:
     respx.post(URL).mock(side_effect=httpx.ConnectError("boom"))
-    client = AnalyticsClient(_settings())
+    # Zero backoff so the retry chain doesn't add real sleeps to the suite.
+    client = AnalyticsClient(_settings(), retry_backoff_s=(0.0, 0.0, 0.0))
     try:
         # Must not raise.
         client.track_event("opik_mcp_test", {})
@@ -353,7 +354,12 @@ def test_queue_full_drops_silently(caplog: pytest.LogCaptureFixture) -> None:
         def close(self) -> None:
             pass
 
-    client = AnalyticsClient(_settings(), http_client=BlockingClient(), max_queue_size=2)  # type: ignore[arg-type]
+    client = AnalyticsClient(
+        _settings(),
+        http_client=BlockingClient(),  # type: ignore[arg-type]
+        max_queue_size=2,
+        retry_backoff_s=(0.0,),  # single attempt; the blocking client makes retries irrelevant
+    )
     try:
         with caplog.at_level(logging.DEBUG, logger="opik_mcp.analytics"):
             # Fire enough events to overflow the tiny queue — none must raise.
@@ -401,9 +407,11 @@ def test_track_event_safe_without_running_event_loop() -> None:
 
 @respx.mock
 def test_http_500_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
-    """Worker must log a WARNING when the analytics endpoint returns 5xx."""
-    respx.post(URL).mock(return_value=httpx.Response(500, text="internal error"))
-    client = AnalyticsClient(_settings())
+    """A 5xx that never recovers must exhaust the retry chain (one POST per
+    configured attempt) and then log a single WARNING."""
+    route = respx.post(URL).mock(return_value=httpx.Response(500, text="internal error"))
+    # Three zero-delay attempts: proves the worker retries and then gives up.
+    client = AnalyticsClient(_settings(), retry_backoff_s=(0.0, 0.0, 0.0))
     try:
         with caplog.at_level(logging.WARNING, logger="opik_mcp.analytics"):
             client.track_event("opik_mcp_test", {"k": "v"})
@@ -411,8 +419,74 @@ def test_http_500_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
     finally:
         client.close()
 
+    assert route.call_count == 3, "expected one POST per configured retry attempt"
     warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert warning_records, "Expected at least one WARNING log for HTTP 500 response"
+    # Exactly one — the warning fires once after exhaustion, NOT per failed
+    # attempt (a regression moving it into the except block would log 3).
+    assert len(warning_records) == 1, f"expected one exhaustion WARNING, got {len(warning_records)}"
+
+
+@respx.mock
+def test_retry_succeeds_on_second_attempt() -> None:
+    """A transient failure on the first POST must be retried, and the event
+    lands on the second attempt (which reuses the now-warm pooled connection).
+
+    This is the core server_started fix: the first cold POST eats the DNS+TLS
+    handshake and often errors/times out; without a retry it is lost forever
+    even though a second attempt would land instantly.
+    """
+    route = respx.post(URL).mock(
+        side_effect=[httpx.ConnectError("cold handshake"), httpx.Response(200)]
+    )
+    client = AnalyticsClient(_settings(), retry_backoff_s=(0.0, 0.0))
+    try:
+        client.track_event("opik_mcp_test", {"k": "v"})
+        _drain(client)
+    finally:
+        client.close()
+
+    assert route.call_count == 2, "expected one failed attempt then a successful retry"
+
+
+@respx.mock
+def test_worker_survives_failed_event_and_delivers_next() -> None:
+    """An event that exhausts all retries must NOT kill the worker thread —
+    the next enqueued event still gets delivered. Guards the `while True` loop
+    against an exception escaping past the per-attempt handling."""
+    route = respx.post(URL).mock(
+        side_effect=[
+            httpx.ConnectError("e1"),  # event 1: attempt 1
+            httpx.ConnectError("e1"),  # event 1: attempt 2
+            httpx.ConnectError("e1"),  # event 1: attempt 3 → exhausted
+            httpx.Response(200),  # event 2: lands
+        ]
+    )
+    client = AnalyticsClient(_settings(), retry_backoff_s=(0.0, 0.0, 0.0))
+    try:
+        client.track_event("first", {})
+        client.track_event("second", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    assert route.call_count == 4, "worker must keep processing after an exhausted event"
+
+
+@respx.mock
+def test_empty_retry_backoff_still_attempts_once() -> None:
+    """An empty retry_backoff_s must not silently drop the event with zero
+    delivery attempts (and a misleading 'after 0 attempt(s)' warning). It
+    normalises to a single immediate attempt — `()` differs from `(0.0,)` by
+    one character but must not mean 'never send'."""
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(), retry_backoff_s=())
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    assert route.call_count == 1, "empty schedule must still attempt delivery once"
 
 
 def _has_running_loop() -> bool:

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -104,6 +104,25 @@ def test_main_emits_server_started_then_runs(monkeypatch: pytest.MonkeyPatch) ->
     assert started["install_id_freshly_generated"] in {"true", "false"}
 
 
+def test_clean_exit_flushes_with_configured_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The clean-exit shutdown emit must drain synchronously with the
+    configured deadline — guards against a regression to 0 (which would drop a
+    cold in-flight POST) and keeps the deadline bump intentional."""
+    recorder = _install_recorder(monkeypatch)
+
+    class _StubMcp:
+        def run(self, *, transport: str) -> None:
+            return  # clean exit
+
+    monkeypatch.setattr("opik_mcp.server.mcp", _StubMcp())
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+    monkeypatch.setenv("OPIK_MCP_ANALYTICS_ENABLED", "true")
+
+    main_mod.main()
+
+    assert recorder.flush_calls == [main_mod._SHUTDOWN_FLUSH_DEADLINE_S]
+
+
 # --- startup_error: config validation -------------------------------------- #
 
 


### PR DESCRIPTION
## Problem

The fire-and-forget analytics worker did a **single** `POST` per event and dropped it on any failure (timeout, DNS, reset, 5xx) — `logger.warning("analytics POST failed")` and move on, no retry.

The **first** event of a session, `server_started`, pays the cold DNS+TLS handshake, so its POST routinely times out/errors and is lost forever — even though that failed attempt *warms the connection pool* and a retry would land instantly. By the time `tool_called` fires, the pool is warm, so those land. That's exactly the production signature:

> ~87% of v0.1.7+ `install_id`s that emit `tool_called` have **no** `server_started` row in Redshift. All dashboards that JOIN per-call events to a `server_started` cohort under-count installs.

## Root cause

`src/opik_mcp/analytics/client.py::_run_worker` — one POST, no retry, daemon worker killed on exit with the in-flight POST. The cold first attempt loses the DNS+TLS race against process teardown / the bounded flush.

## Fix (lean)

- **Retry-with-backoff** in the worker (`_dispatch_with_retry`, `retry_backoff_s=(0.0, 0.5, 1.5)`). The second attempt reuses the connection the first one warmed, which is what recovers the lost cold POST. Retries on any exception (network/timeout/5xx) — a wasted retry on a permanent error is cheap (events are tiny).
- **Widen the exit-flush deadline** `2.0 → 3.5s` (`_STARTUP_ERROR_FLUSH_DEADLINE_S` / `_SHUTDOWN_FLUSH_DEADLINE_S`) so a cold attempt has room to land within the bounded drain. `flush()` returns as soon as the queue drains, so this is a ceiling, not a fixed wait.
- Empty `retry_backoff_s` normalises to one attempt (a stray `()` can never mean "never send"); the failed event's `event_type` is now visible in the warning message itself.

### Contracts preserved
`track_event()` stays non-blocking and never raises; the worker remains a daemon thread; delivery is **at-least-once** (BI tolerates dedup on `install_id, event_type, original_timestamp`). No new dependency, no schema change, no new env var (`retry_backoff_s` is injectable for tests only).

> **Note on versioning:** the ticket called for a manual bump to `0.1.9`, but `main` has since migrated to dynamic versioning (`version.txt` MAJOR.MINOR + generated `_version.py`) and is already on `0.2.x`. No manual version edit is included here — the release tooling owns the version.

## What this deliberately does NOT do

A durable on-disk buffer (WAL) for the residual cases — SIGKILL within the first second, ultra-short cold sessions where even one attempt exceeds the flush window — is **deferred as a measured follow-up**. The plan: ship this, re-run the diagnostic SQL post-release, and add the WAL only if we don't reach the ≥99% target. (`connect_timeout` is 5.0s, so a single cold attempt can still exceed the 3.5s flush ceiling; retry + the warm-pool effect cover the common path.)

## Tests

`pytest`: **945 passed**; `ruff`, `ruff format`, `mypy` clean.

New/changed in `tests/test_analytics_client.py`:
- `test_retry_succeeds_on_second_attempt` — ConnectError then 200 → lands on attempt 2.
- `test_worker_survives_failed_event_and_delivers_next` — an exhausted event doesn't kill the worker; the next event still delivers.
- `test_empty_retry_backoff_still_attempts_once` — `()` normalises to one attempt.
- `test_http_500_logs_warning` strengthened: asserts one POST per attempt and exactly one exhaustion WARNING.
- `test_worker_swallows_exceptions` / `test_queue_full_drops_silently` pass `retry_backoff_s=(0, …)` so the suite doesn't add real backoff sleeps.

`tests/test_analytics_server_startup.py`: `test_clean_exit_flushes_with_configured_deadline` guards the flush deadline value (a regression to 0 would drop a cold in-flight POST).

## Release / verification

- Release **alongside #136** (per the ticket).
- Post-release (+7d) re-run the diagnostic SQL, setting the version threshold to the release this ships in (the current `0.2.x` line). Expect `orphan_pct` to drop from ~87% toward < 1%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
