### PR TITLE
feat(config): OPIK_WORKSPACE env var + optional workspace (default "default") [OPIK-6783]

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS / Linux
 You'll need two things from your Opik workspace:
 
 - **`OPIK_API_KEY`** — get it from [`comet.com/api/my/settings/`](https://www.comet.com/api/my/settings/).
-- **`COMET_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `COMET_WORKSPACE=acme-ai`. Required for `ask_ollie`; optional but recommended everywhere else (used for scoping and analytics).
+- **`OPIK_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. Optional — defaults to `default` (the Opik SDK convention), which is correct for local/OSS installs; cloud users with a named workspace should set it. `COMET_WORKSPACE` is accepted as a deprecated alias.
 
 > **Pre-release note:** `opik-mcp` (Python) is not yet published to PyPI. Until
 > the first PyPI release lands, replace `uvx opik-mcp` in any snippet below with:
@@ -51,7 +51,7 @@ Add the server with one command:
 ```bash
 claude mcp add --transport stdio opik-mcp \
   --env OPIK_API_KEY=<your-key> \
-  --env COMET_WORKSPACE=<your-workspace> \
+  --env OPIK_WORKSPACE=<your-workspace> \
   -- uvx opik-mcp
 ```
 
@@ -66,7 +66,7 @@ Or edit `~/.claude.json` directly:
       "args": ["opik-mcp"],
       "env": {
         "OPIK_API_KEY": "<your-key>",
-        "COMET_WORKSPACE": "<your-workspace>"
+        "OPIK_WORKSPACE": "<your-workspace>"
       }
     }
   }
@@ -91,7 +91,7 @@ Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project), or open
       "args": ["opik-mcp"],
       "env": {
         "OPIK_API_KEY": "<your-key>",
-        "COMET_WORKSPACE": "<your-workspace>"
+        "OPIK_WORKSPACE": "<your-workspace>"
       }
     }
   }
@@ -118,7 +118,7 @@ connection. Ask in chat: **"list my Opik projects"**.
       "args": ["opik-mcp"],
       "env": {
         "OPIK_API_KEY": "<your-key>",
-        "COMET_WORKSPACE": "<your-workspace>"
+        "OPIK_WORKSPACE": "<your-workspace>"
       }
     }
   }
@@ -131,7 +131,7 @@ the server is reachable. Ask in chat: **"list my Opik projects"**.
 ### MCP Inspector (manual testing)
 
 ```bash
-OPIK_API_KEY=<your-key> COMET_WORKSPACE=<your-workspace> \
+OPIK_API_KEY=<your-key> OPIK_WORKSPACE=<your-workspace> \
   npx @modelcontextprotocol/inspector uvx opik-mcp
 ```
 
@@ -300,7 +300,8 @@ Every setting is an environment variable. Required ones in **bold**.
 | Variable | Default | Notes |
 |---|---|---|
 | **`OPIK_API_KEY`** | — | Required for `ask_ollie` and any authenticated read/write. |
-| **`COMET_WORKSPACE`** | — | Workspace name. Required for `ask_ollie`. |
+| `OPIK_WORKSPACE` | `default` | Workspace name. Optional — falls back to `default` (Opik SDK convention). Cloud users with a named workspace should set it. |
+| `COMET_WORKSPACE` | — | Deprecated alias for `OPIK_WORKSPACE` (backward compat). `OPIK_WORKSPACE` wins if both are set. |
 | `COMET_WORKSPACE_ID` | — | Optional workspace UUID. Stamped into analytics events when set so BI can join on a stable id rather than the (mutable) workspace name. |
 | `COMET_URL_OVERRIDE` | `https://www.comet.com` | Set to your self-hosted Comet host, or `https://dev.comet.com` for staging. |
 | `OPIK_URL` | derived from `COMET_URL_OVERRIDE` + `/opik/api` | Override only if Opik lives on a different host/path than the Comet UI. |
@@ -406,7 +407,7 @@ Common targets:
 | `make dev` | Run via `mcp dev` (Inspector dev-mode wrapper). |
 | `make inspect` | Launch MCP Inspector against a running server. |
 | `make test` | `uv run pytest -q`. |
-| `make test-live` | Live end-to-end against `dev.comet.com` (set `OPIK_API_KEY` + `COMET_WORKSPACE`). |
+| `make test-live` | Live end-to-end against `dev.comet.com` (set `OPIK_API_KEY` + `OPIK_WORKSPACE`). |
 | `make lint` | `ruff check` + format check. |
 | `make format` | `ruff format` + `ruff check --fix`. |
 | `make typecheck` | `mypy`. |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ You'll need two things from your Opik workspace:
 > the first PyPI release lands, replace `uvx opik-mcp` in any snippet below with:
 > `uvx --from git+https://github.com/comet-ml/opik-mcp.git opik-mcp`
 
+> **`OPIK_WORKSPACE` is optional.** Omit the `OPIK_WORKSPACE` line/key in any
+> snippet below and the server uses the `default` workspace (correct for
+> local/OSS installs). Set it only if you connect to a named cloud workspace.
+
 ### Claude Code
 
 Add the server with one command:

--- a/src/opik_mcp/comet_client.py
+++ b/src/opik_mcp/comet_client.py
@@ -110,7 +110,7 @@ class CometClient:
         if resp.status_code == 403:
             raise CometPermissionError(
                 "Comet rejected the request (403). The API key is valid "
-                "but lacks access to this workspace. Check COMET_WORKSPACE."
+                "but lacks access to this workspace. Check OPIK_WORKSPACE."
             )
         if resp.status_code == 400:
             preview = resp.text[:300].replace("\n", " ")

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -2,10 +2,15 @@ from functools import lru_cache
 from typing import Any, ClassVar, Literal
 from uuid import UUID
 
-from pydantic import field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from opik_mcp.error_kinds import ErrorKind
+
+# Workspace name used when none is configured — mirrors the Opik Python SDK
+# (`OPIK_WORKSPACE_DEFAULT_NAME = "default"`). Lets local/OSS users run without
+# setting a workspace at all; cloud users with named workspaces still set one.
+DEFAULT_WORKSPACE = "default"
 
 
 class MissingConfigError(RuntimeError):
@@ -21,10 +26,18 @@ class MissingConfigError(RuntimeError):
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(extra="ignore", case_sensitive=False)
+    model_config = SettingsConfigDict(extra="ignore", case_sensitive=False, populate_by_name=True)
 
     opik_api_key: str | None = None
-    comet_workspace: str | None = None
+    # Workspace name. OPIK_WORKSPACE is the primary env var (matches the Opik
+    # SDK and opik-mcp's OPIK_ convention); COMET_WORKSPACE is a deprecated
+    # backward-compat fallback. Kept ``str | None`` (not defaulted) so the
+    # analytics `has_workspace` flag still reflects whether the user set one;
+    # the "default" fallback is applied at the resolve sites, not here.
+    comet_workspace: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("opik_workspace", "comet_workspace"),
+    )
     # Optional workspace UUID. Stamped into analytics events as
     # `workspace_id` when set so BI can JOIN on a stable identifier instead
     # of the workspace name (which is mutable). Unset means the field is
@@ -148,6 +161,7 @@ def get_settings() -> Settings:
 def require_ollie_config(settings: Settings) -> tuple[str, str]:
     if not settings.opik_api_key:
         raise MissingConfigError("OPIK_API_KEY is required to use ask_ollie")
-    if not settings.comet_workspace:
-        raise MissingConfigError("COMET_WORKSPACE is required to use ask_ollie")
-    return settings.opik_api_key, settings.comet_workspace
+    # Workspace is optional — fall back to "default" (Opik SDK convention).
+    # Cloud pod discovery for a non-"default" account will surface its own
+    # clear error downstream, which beats a hard config failure here.
+    return settings.opik_api_key, settings.comet_workspace or DEFAULT_WORKSPACE

--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from opik_mcp.config import Settings, get_settings
+from opik_mcp.config import DEFAULT_WORKSPACE, Settings, get_settings
 from opik_mcp.writes.registry import WRITE_OPERATIONS
 
 _TEMPLATE = """\
@@ -78,7 +78,7 @@ def render_instructions(
     generic placeholder if the config is partial.
     """
     s = settings if settings is not None else get_settings()
-    workspace = s.comet_workspace or "(workspace not configured)"
+    workspace = s.comet_workspace or DEFAULT_WORKSPACE
     if s.opik_url:
         opik_url = s.opik_url.rstrip("/")
     elif s.comet_url_override:

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -20,7 +20,7 @@ from typing import Any, ClassVar, Final, Literal, Protocol
 
 import httpx
 
-from opik_mcp.config import MissingConfigError, Settings
+from opik_mcp.config import DEFAULT_WORKSPACE, MissingConfigError, Settings
 from opik_mcp.error_kinds import ErrorKind
 
 # --- errors --------------------------------------------------------------- #
@@ -621,8 +621,9 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str, str]:
     """
     if not settings.opik_api_key:
         raise MissingConfigError("OPIK_API_KEY is required to call Opik REST")
-    if not settings.comet_workspace:
-        raise MissingConfigError("COMET_WORKSPACE is required to call Opik REST")
+    # Workspace is optional — fall back to "default" (Opik SDK convention)
+    # instead of hard-failing. Lets local/OSS users run without a workspace.
+    workspace = settings.comet_workspace or DEFAULT_WORKSPACE
     if settings.opik_url:
         base = settings.opik_url.rstrip("/")
     else:
@@ -633,7 +634,7 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str, str]:
         if not settings.comet_url_override:
             raise MissingConfigError("OPIK_URL or COMET_URL_OVERRIDE is required to call Opik REST")
         base = f"{settings.comet_url_override.rstrip('/')}/opik/api"
-    return base, settings.opik_api_key, settings.comet_workspace
+    return base, settings.opik_api_key, workspace
 
 
 def make_opik_client(settings: Settings) -> OpikClient:
@@ -655,12 +656,12 @@ def _raise_for_status(resp: httpx.Response, entity_hint: str) -> None:
     suffix = f" — {detail}" if detail else ""
     if status == 401:
         raise OpikAuthError(
-            f"Opik rejected the request (401). Check OPIK_API_KEY and COMET_WORKSPACE.{suffix}"
+            f"Opik rejected the request (401). Check OPIK_API_KEY and OPIK_WORKSPACE.{suffix}"
         )
     if status == 403:
         raise OpikPermissionError(
             f"Opik rejected the request (403). The API key is valid but lacks "
-            f"permission for {entity_hint}. Check COMET_WORKSPACE access.{suffix}"
+            f"permission for {entity_hint}. Check OPIK_WORKSPACE access.{suffix}"
         )
     if status == 404:
         raise OpikNotFoundError(f"{entity_hint} not found (404).{suffix}")

--- a/src/opik_mcp/run_experiment.py
+++ b/src/opik_mcp/run_experiment.py
@@ -51,7 +51,7 @@ def _raise_for_execute_status(resp: httpx.Response) -> None:
     if resp.status_code == 403:
         raise OpikPermissionError(
             "Opik rejected the experiment execute request (403). The API key is "
-            "valid but lacks permission for this workspace. Check COMET_WORKSPACE."
+            "valid but lacks permission for this workspace. Check OPIK_WORKSPACE."
         )
     if resp.status_code == 404:
         raise OpikNotFoundError(f"Test suite not found (404) — {body_excerpt}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,29 @@ from opik_mcp.config import MissingConfigError, Settings, require_ollie_config
 
 
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in ("OPIK_API_KEY", "COMET_WORKSPACE", "COMET_URL_OVERRIDE"):
+    for var in ("OPIK_API_KEY", "OPIK_WORKSPACE", "COMET_WORKSPACE", "COMET_URL_OVERRIDE"):
         monkeypatch.delenv(var, raising=False)
+
+
+def test_opik_workspace_env_populates_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OPIK_WORKSPACE is the primary (OPIK_-prefixed) env var for the workspace,
+    matching the Opik SDK and the rest of opik-mcp's OPIK_ convention."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("OPIK_WORKSPACE", "ws-opik")
+    s = Settings()
+    assert s.comet_workspace == "ws-opik"
+
+
+def test_opik_workspace_takes_precedence_over_comet_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both are set, the OPIK_-prefixed var wins; COMET_WORKSPACE is the
+    deprecated fallback."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("OPIK_WORKSPACE", "ws-opik")
+    monkeypatch.setenv("COMET_WORKSPACE", "ws-comet")
+    s = Settings()
+    assert s.comet_workspace == "ws-opik"
 
 
 def test_defaults_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -39,10 +60,13 @@ def test_require_ollie_config_missing_api_key() -> None:
         require_ollie_config(s)
 
 
-def test_require_ollie_config_missing_workspace() -> None:
+def test_require_ollie_config_defaults_workspace_when_unset() -> None:
+    """Workspace is optional now — when unset it falls back to "default"
+    (matching the Opik SDK) instead of hard-failing."""
+    from opik_mcp.config import DEFAULT_WORKSPACE
+
     s = Settings(opik_api_key="k", comet_workspace=None)
-    with pytest.raises(MissingConfigError, match="COMET_WORKSPACE"):
-        require_ollie_config(s)
+    assert require_ollie_config(s) == ("k", DEFAULT_WORKSPACE)
 
 
 def test_default_project_name_parses_from_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -43,10 +43,15 @@ def test_render_uses_comet_url_override_when_opik_url_missing() -> None:
     assert "https://demo.comet.com/opik" in out
 
 
-def test_render_handles_missing_workspace_gracefully() -> None:
+def test_render_uses_default_workspace_when_unset() -> None:
+    """With no workspace configured the tools operate against "default"
+    (Opik SDK convention), so the LLM-facing context must say so rather than
+    "(workspace not configured)"."""
+    from opik_mcp.config import DEFAULT_WORKSPACE
+
     s = _settings(comet_workspace=None)
     out = render_instructions(s)
-    assert "workspace not configured" in out
+    assert f'workspace "{DEFAULT_WORKSPACE}"' in out
 
 
 def test_render_omits_user_clause_when_email_unknown() -> None:

--- a/tests/test_opik_client.py
+++ b/tests/test_opik_client.py
@@ -336,12 +336,24 @@ def test_resolve_opik_config_requires_api_key() -> None:
         resolve_opik_config(s)
 
 
-def test_resolve_opik_config_requires_workspace() -> None:
+def test_resolve_opik_config_defaults_workspace_when_unset() -> None:
+    """Workspace is optional — when unset, resolve_opik_config falls back to
+    "default" (matching the Opik SDK) instead of raising."""
+    from opik_mcp.config import DEFAULT_WORKSPACE, Settings
+    from opik_mcp.opik_client import resolve_opik_config
+
+    s = Settings(opik_api_key="k", comet_workspace=None, opik_url="https://opik.example.com/")
+    _base, _api_key, workspace = resolve_opik_config(s)
+    assert workspace == DEFAULT_WORKSPACE
+
+
+def test_resolve_opik_config_still_requires_api_key() -> None:
+    """The api key is still mandatory — only the workspace became optional."""
     from opik_mcp.config import MissingConfigError, Settings
     from opik_mcp.opik_client import resolve_opik_config
 
-    s = Settings(opik_api_key="k", comet_workspace=None)
-    with pytest.raises(MissingConfigError, match="COMET_WORKSPACE"):
+    s = Settings(opik_api_key=None, comet_workspace="ws")
+    with pytest.raises(MissingConfigError, match="OPIK_API_KEY"):
         resolve_opik_config(s)
 
 


### PR DESCRIPTION
## Summary

[OPIK-6783](https://comet-ml.atlassian.net/browse/OPIK-6783)

`COMET_WORKSPACE` was the only env var in opik-mcp that broke the `OPIK_` convention (the workspace var is `OPIK_WORKSPACE` in the Opik SDK, and opik-mcp already uses `OPIK_API_KEY`). It was also a hard requirement, which added friction for local/OSS users.

This PR:

1. **Adds `OPIK_WORKSPACE` as the primary env var** for the workspace, via a pydantic `AliasChoices("opik_workspace", "comet_workspace")` on the existing `comet_workspace` field. `COMET_WORKSPACE` stays as a **deprecated backward-compat alias**; `OPIK_WORKSPACE` wins if both are set. No breaking change.
2. **Makes the workspace optional** — `resolve_opik_config` and `require_ollie_config` now fall back to `"default"` (the Opik SDK's `OPIK_WORKSPACE_DEFAULT_NAME`) instead of raising `MissingConfigError`. Local/OSS users can run without setting a workspace.
3. Updates the LLM instructions text, the 401/403 error hints, and the README to reference `OPIK_WORKSPACE`.

## Notes

- The `comet_workspace` field stays `str | None` (not defaulted) on purpose, so the analytics `has_workspace` flag still reflects whether the user *explicitly* set a workspace — the `"default"` fallback is applied at the resolve sites, not on the field.
- `"default"` is correct for local/OSS and many cloud setups; **cloud users with a named workspace should still set `OPIK_WORKSPACE`** (documented in the README). For `ask_ollie`, a non-`"default"` cloud account that doesn't set it will get a clear pod-discovery error downstream rather than a hard config failure — strictly better than today.
- Out of scope (follow-up): aligning `COMET_WORKSPACE_ID` / `COMET_URL_OVERRIDE` to the `OPIK_` prefix the same way.

## Test plan

- New: `OPIK_WORKSPACE` populates the workspace; `OPIK_WORKSPACE` wins over `COMET_WORKSPACE`; `resolve_opik_config` / `require_ollie_config` return `"default"` when unset; api key still required; instructions render `workspace "default"` when unset.
- `COMET_WORKSPACE` and `Settings(comet_workspace=...)` kwargs still work (`populate_by_name=True`).
- `pytest`: **948 passed**; `ruff`, `ruff format`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OPIK-6783]: https://comet-ml.atlassian.net/browse/OPIK-6783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ