### PR TITLE
Dockerfile: numeric USER (1000) for runAsNonRoot compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ FROM python:3.13-slim-bookworm AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends tini \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd --create-home --shell /bin/bash app
+    && useradd --create-home --shell /bin/bash --uid 1000 app
 
 WORKDIR /app
 
@@ -55,7 +55,9 @@ WORKDIR /app
 COPY --from=build --chown=app:app /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:${PATH}"
 
-USER app
+# Numeric UID (not the name "app") so Kubernetes runAsNonRoot can verify
+# non-root from the image config without starting the container.
+USER 1000
 
 EXPOSE 8080
 ENV OPIK_MCP_TRANSPORT=http \


### PR DESCRIPTION
The image set `USER app` (a name). Under Kubernetes `runAsNonRoot: true`, the kubelet verifies non-root from the image config **before** starting the container and can't resolve a name to a UID, so the pod fails:

```
container has runAsNonRoot and image has non-numeric user (app), cannot verify user is non-root
```

Fix: create the user with an explicit `--uid 1000` and set a **numeric** `USER 1000`. The named account still exists (file ownership/`chown app:app` resolves), but the directive is numeric so the check passes — no per-deployment `runAsUser` patching needed.

Verified locally: image builds, runs as `uid=1000(app)`, app imports and version resolves.