### PR TITLE
[OPIK-6742] [BE] feat: configurable streamable HTTP path (OPIK_MCP_HTTP_PATH)

### DIFF
--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -78,6 +78,14 @@ class Settings(BaseSettings):
     opik_mcp_transport: str = "stdio"
     opik_mcp_host: str = "127.0.0.1"
     opik_mcp_port: int = 8080
+
+    # HTTP path the streamable-MCP transport is mounted at (default "/mcp").
+    # The advertised resource URI and the served path must be the same string,
+    # so when fronted by a path-prefix proxy that can't rewrite (e.g. an ALB
+    # routing /opik/api/v1/mcp straight to this Service), set this to that full
+    # path — matching OPIK_MCP_RESOURCE_URI's path.
+    opik_mcp_http_path: str = "/mcp"
+
     opik_mcp_reload: bool = False
 
     # YOLO mode toggle. "enabled" (default) auto-approves every pod
@@ -100,6 +108,15 @@ class Settings(BaseSettings):
     @classmethod
     def _lowercase_toggle(cls, v: Any) -> Any:
         return v.lower() if isinstance(v, str) else v
+
+    @field_validator("opik_mcp_http_path", mode="before")
+    @classmethod
+    def _require_leading_slash(cls, v: Any) -> Any:
+        # Starlette routes must be absolute; fail loudly at startup rather than
+        # mount the transport at a path no client can reach.
+        if isinstance(v, str) and v and not v.startswith("/"):
+            raise ValueError(f"OPIK_MCP_HTTP_PATH must start with '/': got {v!r}")
+        return v
 
     @field_validator("comet_workspace_id", mode="before")
     @classmethod

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -804,6 +804,10 @@ async def _not_found_json(scope: Any, receive: Any, send: Any) -> None:
 
 def build_app() -> Starlette:
     install_tools_listed_emitter(mcp)
+    # Serve the transport at the configured path so it matches the advertised
+    # resource URI behind a non-rewriting path-prefix proxy. Read at app-build
+    # time (streamable_http_app reads it then), so env overrides take effect.
+    mcp.settings.streamable_http_path = get_settings().opik_mcp_http_path
     app = mcp.streamable_http_app()
     # Replace Starlette's default plain-text 404 — see ``_not_found_json``.
     app.router.default = _not_found_json

--- a/tests/test_http_path_config.py
+++ b/tests/test_http_path_config.py
@@ -1,0 +1,37 @@
+"""OPIK_MCP_HTTP_PATH mounts the streamable transport at the path the advertised
+resource URI uses — needed behind a non-rewriting path-prefix proxy (e.g. an
+ALB routing /opik/api/v1/mcp straight to the Service), where the served path
+and the advertised `resource` must match.
+
+The build_app wiring (mcp.settings.streamable_http_path = get_settings()...) is
+exercised by the session-scoped http_client fixture at the default "/mcp"
+(see test_http_auth). A second build_app() can't run in-process — the FastMCP
+session manager is a process-level singleton — so here we cover the config
+surface directly.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from opik_mcp.config import Settings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache() -> None:
+    get_settings.cache_clear()
+
+
+def test_http_path_defaults_to_mcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPIK_MCP_HTTP_PATH", raising=False)
+    assert Settings().opik_mcp_http_path == "/mcp"
+
+
+def test_http_path_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPIK_MCP_HTTP_PATH", "/opik/api/v1/mcp")
+    assert Settings().opik_mcp_http_path == "/opik/api/v1/mcp"
+
+
+def test_http_path_requires_leading_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPIK_MCP_HTTP_PATH", "opik/api/v1/mcp")
+    with pytest.raises(ValidationError):
+        Settings()


### PR DESCRIPTION
## Problem

In the hosted deployment, opik-mcp is fronted by a path-prefix proxy (ALB) that routes `https://dev.comet.com/opik/api/v1/mcp` straight to the Service **without rewriting**. But the streamable transport mounts at FastMCP's default `/mcp`, so the advertised resource URI and the served path diverge. Verified on dev — after the OAuth dance completes, a real `initialize` to the resource URL 404s:

```
$ curl -XPOST https://dev.comet.com/opik/api/v1/mcp \
    -H 'authorization: Bearer opik_at_…' -H 'accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
HTTP/2 404
{"error":"not_found"}        # reached opik-mcp, passed auth, no route at /opik/api/v1/mcp
```

ALB can't rewrite paths and opik-mcp had no setting to move the mount, so config alone couldn't fix it.

## Change

- New setting `OPIK_MCP_HTTP_PATH` (default `"/mcp"`).
- `build_app()` applies it to `mcp.settings.streamable_http_path` **before** `mcp.streamable_http_app()` reads it (confirmed FastMCP reads it at app-build time), so the env override takes effect.
- `field_validator` rejects a non-absolute path at startup (Starlette routes must be absolute) rather than mounting somewhere unreachable.

Set `OPIK_MCP_HTTP_PATH=/opik/api/v1/mcp` in the hosted values so the served path equals the advertised `resource`. Backward compatible: default `/mcp`; stdio and laptop HTTP unaffected.

## Tests

`tests/test_http_path_config.py` — default `/mcp`, env override, and leading-slash validation. (A second `build_app()` can't run in-process — the FastMCP session manager is a process-level singleton — so the default-path wiring stays covered by the existing `/mcp` http-transport tests.) Full suite: 978 passed, 2 skipped; ruff clean.

## Rollout (comet-gitops dev)
1. Release opik-mcp with this change.
2. dev values: bump image + add `env.OPIK_MCP_HTTP_PATH: "/opik/api/v1/mcp"`.
3. Re-probe: `initialize` to `/opik/api/v1/mcp` reaches the handler instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)