### PR TITLE
[OPIK-6742] [BE] feat: configurable transport-security allowlist (hosted Host)

### DIFF
--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -99,6 +99,21 @@ class Settings(BaseSettings):
     # path — matching OPIK_MCP_RESOURCE_URI's path.
     opik_mcp_http_path: str = "/mcp"
 
+    # DNS-rebinding protection for the streamable HTTP transport (the MCP SDK's
+    # production-recommended posture; Bearer auth is the primary control, this
+    # is defense-in-depth). ON by default. The default allow-lists cover only
+    # localhost — when hosted behind a public host, add it to
+    # OPIK_MCP_ALLOWED_HOSTS (e.g. "dev.comet.com,dev.comet.com:*"). Browser MCP
+    # clients (e.g. claude.ai) also need their Origin in OPIK_MCP_ALLOWED_ORIGINS;
+    # CLI/desktop clients send no Origin and are unaffected. Env values may be a
+    # comma-separated string. Disable only as a deliberate per-env trade-off.
+    opik_mcp_dns_rebinding_protection: bool = True
+    # Comma-separated (str, not list, so a plain Helm env value works — a
+    # list[str] field would be JSON-decoded by pydantic-settings). Read via the
+    # allowed_hosts_list / allowed_origins_list properties.
+    opik_mcp_allowed_hosts: str = "127.0.0.1:*,localhost:*,[::1]:*"
+    opik_mcp_allowed_origins: str = "http://127.0.0.1:*,http://localhost:*,http://[::1]:*"
+
     opik_mcp_reload: bool = False
 
     # YOLO mode toggle. "enabled" (default) auto-approves every pod
@@ -130,6 +145,14 @@ class Settings(BaseSettings):
         if isinstance(v, str) and v and not v.startswith("/"):
             raise ValueError(f"OPIK_MCP_HTTP_PATH must start with '/': got {v!r}")
         return v
+
+    @property
+    def allowed_hosts_list(self) -> list[str]:
+        return [h.strip() for h in self.opik_mcp_allowed_hosts.split(",") if h.strip()]
+
+    @property
+    def allowed_origins_list(self) -> list[str]:
+        return [o.strip() for o in self.opik_mcp_allowed_origins.split(",") if o.strip()]
 
     @field_validator("comet_workspace_id", mode="before")
     @classmethod

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 import httpx
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import Field
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -804,10 +805,19 @@ async def _not_found_json(scope: Any, receive: Any, send: Any) -> None:
 
 def build_app() -> Starlette:
     install_tools_listed_emitter(mcp)
+    s = get_settings()
     # Serve the transport at the configured path so it matches the advertised
     # resource URI behind a non-rewriting path-prefix proxy. Read at app-build
     # time (streamable_http_app reads it then), so env overrides take effect.
-    mcp.settings.streamable_http_path = get_settings().opik_mcp_http_path
+    mcp.settings.streamable_http_path = s.opik_mcp_http_path
+    # DNS-rebinding/Host-Origin guard. Default allow-lists cover localhost only,
+    # so hosted deployments must add their public host (and browser-client
+    # origins). Applied here for the same read-at-build-time reason as above.
+    mcp.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=s.opik_mcp_dns_rebinding_protection,
+        allowed_hosts=s.allowed_hosts_list,
+        allowed_origins=s.allowed_origins_list,
+    )
     app = mcp.streamable_http_app()
     # Replace Starlette's default plain-text 404 — see ``_not_found_json``.
     app.router.default = _not_found_json

--- a/tests/test_http_path_config.py
+++ b/tests/test_http_path_config.py
@@ -35,3 +35,34 @@ def test_http_path_requires_leading_slash(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("OPIK_MCP_HTTP_PATH", "opik/api/v1/mcp")
     with pytest.raises(ValidationError):
         Settings()
+
+
+# --- transport security (DNS-rebinding / Host-Origin allowlist) ------------- #
+
+
+def test_transport_security_defaults_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "OPIK_MCP_DNS_REBINDING_PROTECTION",
+        "OPIK_MCP_ALLOWED_HOSTS",
+        "OPIK_MCP_ALLOWED_ORIGINS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    s = Settings()
+    assert s.opik_mcp_dns_rebinding_protection is True
+    assert s.allowed_hosts_list == ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+    assert s.allowed_origins_list == ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
+
+
+def test_allowed_hosts_parses_comma_separated_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPIK_MCP_ALLOWED_HOSTS", "dev.comet.com, dev.comet.com:*")
+    assert Settings().allowed_hosts_list == ["dev.comet.com", "dev.comet.com:*"]
+
+
+def test_allowed_origins_parses_comma_separated_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPIK_MCP_ALLOWED_ORIGINS", "https://claude.ai")
+    assert Settings().allowed_origins_list == ["https://claude.ai"]
+
+
+def test_dns_rebinding_protection_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPIK_MCP_DNS_REBINDING_PROTECTION", "false")
+    assert Settings().opik_mcp_dns_rebinding_protection is False


### PR DESCRIPTION
## Problem

FastMCP enables DNS-rebinding protection by default with a **localhost-only** allowlist (`allowed_hosts=["127.0.0.1:*","localhost:*","[::1]:*"]`). opik-mcp never configured `transport_security`, so a hosted deployment behind a public host gets `421 "Invalid Host header"` on every MCP call. Verified on dev after 0.2.7 rolled (the `/opik/api/v1/mcp` 404 is gone; authenticated `initialize` now returns 421):

```
HTTP/2 421
Invalid Host header        # Host: dev.comet.com not in the localhost allowlist
```

Local/stdio use was fine because the Host is localhost.

## Change

Make transport security configurable, applied to `mcp.settings.transport_security` in `build_app()` (read at app-build time, same mechanism as `streamable_http_path`):

- `OPIK_MCP_DNS_REBINDING_PROTECTION` (bool, default **true** — protection stays on)
- `OPIK_MCP_ALLOWED_HOSTS` (comma-separated str; default localhost)
- `OPIK_MCP_ALLOWED_ORIGINS` (comma-separated str; default localhost)

Comma-separated **strings** (not `list[str]`) so a plain Helm env value works — a list field would be JSON-decoded by pydantic-settings. Exposed as `allowed_hosts_list` / `allowed_origins_list` properties.

Defaults reproduce FastMCP's localhost allowlist, so **local HTTP and stdio are unchanged**. Hosted envs add their public host. Bearer auth is the primary control; this is defense-in-depth, so protection stays ON by default (we keep it on in cloud; allowlist per env).

## Transport scope

HTTP-only by construction: `build_app()` runs only on the HTTP transport; stdio calls `mcp.run(transport="stdio")` and never builds the app. Host/Origin validation is an HTTP concept with no stdio analogue, so stdio is a no-op.

## Tests

`tests/test_http_path_config.py` — defaults (protection on + localhost lists), comma-separated env parsing for hosts and origins, and the protection toggle. Full suite: 985 passed, 2 skipped; ruff clean. (A live HTTP allowlist assertion isn't unit-testable in-process — FastMCP's session manager is a process-level singleton — so the wiring is covered at the config level + the live dev probe.)

## Rollout (comet-gitops dev)
Add to the dev opik-mcp env (keeping protection on):
```yaml
OPIK_MCP_ALLOWED_HOSTS: "dev.comet.com,dev.comet.com:*"
```
Then re-probe: authenticated `initialize` to `/opik/api/v1/mcp` should return the MCP response instead of 421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)