### PR TITLE
feat(analytics): BI events for the hosted auth/HTTPS flow (GAP#1/#2/#3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,11 +67,13 @@ ENV OPIK_MCP_TRANSPORT=http \
 
 STOPSIGNAL SIGTERM
 
-# Single worker by design: SSE streams are async-IO-bound, and multiple
-# workers would fragment in-memory MCP session state across processes.
-# Scale with replicas + Redis (see docs/phase-2.md), not workers.
-ENTRYPOINT ["tini", "--", "python", "-m", "uvicorn", \
-            "opik_mcp.server:build_app", "--factory", \
-            "--host", "0.0.0.0", "--port", "8080", \
-            "--workers", "1", \
-            "--no-access-log"]
+# Run via the package entrypoint (main()) rather than uvicorn directly, so the
+# full BI lifecycle fires in hosted mode exactly as in stdio: main() emits
+# server_started / server_shutdown / startup_error, runs the preflight bind
+# check and the OAuth-config guard, then serves HTTP via uvicorn (single worker,
+# access logging off). The build_app() lifespan defers to main() via the
+# _OPIK_MCP_LIFECYCLE_OWNED_BY_MAIN sentinel, so boots are never double-counted.
+# Transport/host/port come from the ENV above; single worker by design (SSE is
+# async-IO-bound and multiple workers would fragment in-memory session state —
+# scale with replicas + Redis, see docs/phase-2.md).
+ENTRYPOINT ["tini", "--", "python", "-m", "opik_mcp"]

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -389,7 +389,15 @@ def _run_transport(settings: Settings, transport: str) -> None:
             reload_dirs=["src"],
         )
     else:
-        uvicorn.run(build_app(), host=settings.opik_mcp_host, port=settings.opik_mcp_port)
+        # access_log=False: parity with the hosted image's old --no-access-log,
+        # and it keeps OAuth-flow query strings (which can carry tokens) out of
+        # stdout. BI + Sentry are the observability surface, not uvicorn logs.
+        uvicorn.run(
+            build_app(),
+            host=settings.opik_mcp_host,
+            port=settings.opik_mcp_port,
+            access_log=False,
+        )
 
 
 if __name__ == "__main__":

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -153,6 +153,15 @@ def _build_fallback_analytics_client() -> AnalyticsClient:
     source_override = os.getenv("OPIK_MCP_ANALYTICS_SOURCE")
     if source_override is not None:
         settings.opik_mcp_analytics_source = source_override
+    # Re-read the Opik destination URLs so installation_type (computed in
+    # AnalyticsClient.__init__) reports cloud/self-hosted/local correctly on the
+    # config-fail path — model_construct() ignored env, defaulting to cloud.
+    comet_url = os.getenv("COMET_URL_OVERRIDE")
+    if comet_url is not None:
+        settings.comet_url_override = comet_url
+    opik_url = os.getenv("OPIK_URL")
+    if opik_url is not None:
+        settings.opik_url = opik_url
     return AnalyticsClient(settings)
 
 
@@ -387,6 +396,7 @@ def _run_transport(settings: Settings, transport: str) -> None:
             port=settings.opik_mcp_port,
             reload=True,
             reload_dirs=["src"],
+            access_log=False,
         )
     else:
         # access_log=False: parity with the hosted image's old --no-access-log,

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -15,13 +15,9 @@ from opik_mcp.analytics import (
     boot_props,
     get_analytics,
     track_event,
-    transport_probe,
 )
-from opik_mcp.analytics.boot_props import collect_boot_props
 from opik_mcp.analytics.client import AnalyticsClient
 from opik_mcp.analytics.environment import collect_environment_fingerprint
-from opik_mcp.analytics.events import bucket_seconds
-from opik_mcp.analytics.identity import install_id_was_freshly_generated
 from opik_mcp.config import Settings, get_settings
 
 logger = logging.getLogger("opik_mcp")
@@ -218,13 +214,9 @@ def _emit_server_shutdown(
         elapsed = time.monotonic() - started_monotonic
         track_event(
             EVENT_SERVER_SHUTDOWN,
-            {
-                "reason": reason,
-                "lifespan_seconds_bucket": bucket_seconds(elapsed),
-                "first_rpc_received": str(transport_probe.first_rpc_received()).lower(),
-                "session_reached": str(transport_probe.session_reached()).lower(),
-                "lifecycle_source": lifecycle_source,
-            },
+            boot_props.server_shutdown_props(
+                reason=reason, elapsed_seconds=elapsed, lifecycle_source=lifecycle_source
+            ),
         )
         get_analytics().flush(deadline_s=_SHUTDOWN_FLUSH_DEADLINE_S)
     except BaseException:
@@ -285,20 +277,9 @@ def main() -> None:
 
     track_event(
         EVENT_SERVER_STARTED,
-        {
-            "transport": transport,
-            "analytics_enabled": str(settings.opik_mcp_analytics_enabled).lower(),
-            "has_workspace": str(settings.comet_workspace is not None).lower(),
-            "has_api_key": str(settings.opik_api_key is not None).lower(),
-            "has_default_project": str(settings.opik_default_project_name is not None).lower(),
-            "install_id_freshly_generated": str(install_id_was_freshly_generated()).lower(),
-            "lifecycle_source": "main",
-            # Settings-derived auth/transport props. Spread here (caller tier)
-            # so the settings-derived auth_mode wins over _build_event's
-            # contextvar fallback (which is "none" at boot — no request yet).
-            **collect_boot_props(settings),
-            **fingerprint_props,
-        },
+        boot_props.server_started_props(
+            settings, fingerprint_props=fingerprint_props, lifecycle_source="main"
+        ),
     )
 
     try:

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -12,10 +12,12 @@ from opik_mcp.analytics import (
     EVENT_SERVER_SHUTDOWN,
     EVENT_SERVER_STARTED,
     EVENT_STARTUP_ERROR,
+    boot_props,
     get_analytics,
     track_event,
     transport_probe,
 )
+from opik_mcp.analytics.boot_props import collect_boot_props
 from opik_mcp.analytics.client import AnalyticsClient
 from opik_mcp.analytics.environment import collect_environment_fingerprint
 from opik_mcp.analytics.events import bucket_seconds
@@ -23,6 +25,7 @@ from opik_mcp.analytics.identity import install_id_was_freshly_generated
 from opik_mcp.config import Settings, get_settings
 
 logger = logging.getLogger("opik_mcp")
+
 
 # Best-effort drain budget on the startup-error path. The daemon worker that
 # normally POSTs analytics events is killed by the imminent sys.exit/re-raise,
@@ -164,6 +167,7 @@ def _emit_startup_error(
     exception_type: str = "",
     transport: str = "",
     client: AnalyticsClient | None = None,
+    oauth_configured: str = "",
 ) -> None:
     """Fire ``opik_mcp_startup_error`` and synchronously drain the queue.
 
@@ -171,6 +175,11 @@ def _emit_startup_error(
     *message* is deliberately NOT included — it can carry paths, env values,
     or partial secrets. ``exception_type`` (class name) plus ``error_kind``
     gives BI enough to bucket failures without leaking user data.
+
+    ``oauth_configured`` lets BI segment boot failures by deployment shape; it is
+    optional because on the config-fail path ``Settings`` may not exist (the
+    caller reads it from the raw env). ``installation_type`` is NOT a param —
+    ``_build_event``'s common block stamps it on every event already.
 
     When ``client`` is passed (config-fail path), use it directly and close
     it after flush; the singleton route would re-hit the underlying
@@ -181,6 +190,8 @@ def _emit_startup_error(
         props["exception_type"] = exception_type
     if transport:
         props["transport"] = transport
+    if oauth_configured:
+        props["oauth_configured"] = oauth_configured
     try:
         target: AnalyticsClient = client if client is not None else get_analytics()
         target.track_event(EVENT_STARTUP_ERROR, props)
@@ -194,7 +205,9 @@ def _emit_startup_error(
         logger.debug("startup_error emit failed", exc_info=True)
 
 
-def _emit_server_shutdown(*, reason: str, started_monotonic: float) -> None:
+def _emit_server_shutdown(
+    *, reason: str, started_monotonic: float, lifecycle_source: str = "main"
+) -> None:
     """Fire ``opik_mcp_server_shutdown`` and synchronously drain the queue.
 
     Same drain pattern as ``_emit_startup_error`` — the daemon worker
@@ -210,6 +223,7 @@ def _emit_server_shutdown(*, reason: str, started_monotonic: float) -> None:
                 "lifespan_seconds_bucket": bucket_seconds(elapsed),
                 "first_rpc_received": str(transport_probe.first_rpc_received()).lower(),
                 "session_reached": str(transport_probe.session_reached()).lower(),
+                "lifecycle_source": lifecycle_source,
             },
         )
         get_analytics().flush(deadline_s=_SHUTDOWN_FLUSH_DEADLINE_S)
@@ -240,6 +254,9 @@ def main() -> None:
                 error_kind="invalid_config",
                 exception_type=type(e).__name__,
                 client=fallback,
+                # Settings construction failed → no installation_type; read
+                # oauth_configured straight from the env so the bucket survives.
+                oauth_configured=boot_props.oauth_configured_from_env(),
             )
         finally:
             fallback.close()
@@ -252,6 +269,11 @@ def main() -> None:
     # that might raise. No-op when OPIK_MCP_SENTRY_ENABLED=false; see
     # error_tracking.py.
     error_tracking.setup_sentry(settings)
+
+    # Claim lifecycle-event ownership before build_app() can run, so the
+    # build_app() Starlette lifespan (same process, or inherited by --reload
+    # workers) skips its own emit and we never double-count a boot.
+    boot_props.mark_lifecycle_owned_by_main()
 
     # Collect fingerprint BEFORE capturing the monotonic anchor. The
     # fingerprint calls out to subprocess + lsof on macOS (parent-process
@@ -270,6 +292,11 @@ def main() -> None:
             "has_api_key": str(settings.opik_api_key is not None).lower(),
             "has_default_project": str(settings.opik_default_project_name is not None).lower(),
             "install_id_freshly_generated": str(install_id_was_freshly_generated()).lower(),
+            "lifecycle_source": "main",
+            # Settings-derived auth/transport props. Spread here (caller tier)
+            # so the settings-derived auth_mode wins over _build_event's
+            # contextvar fallback (which is "none" at boot — no request yet).
+            **collect_boot_props(settings),
             **fingerprint_props,
         },
     )
@@ -296,6 +323,7 @@ def main() -> None:
             error_kind="transport_crash",
             exception_type=bucketed_type,
             transport=transport,
+            oauth_configured=boot_props.oauth_configured(settings),
         )
         # A transport crash is exactly the kind of failure Sentry exists for.
         # Mirror the analytics props so Sentry events have the same shape as
@@ -356,7 +384,12 @@ def _run_transport(settings: Settings, transport: str) -> None:
             "every /authorize fails with invalid_target.",
             settings.opik_mcp_as_url,
         )
-        _emit_startup_error(phase="config", error_kind="invalid_config", transport=transport)
+        _emit_startup_error(
+            phase="config",
+            error_kind="invalid_config",
+            transport=transport,
+            oauth_configured=boot_props.oauth_configured(settings),
+        )
         sys.exit(1)
 
     # Imported lazily so stdio mode doesn't pay the Starlette import cost.

--- a/src/opik_mcp/analytics/__init__.py
+++ b/src/opik_mcp/analytics/__init__.py
@@ -13,6 +13,7 @@ from opik_mcp.analytics import transport_probe
 from opik_mcp.analytics.client import AnalyticsClient
 from opik_mcp.analytics.events import (
     EVENT_ASK_OLLIE_COMPLETED,
+    EVENT_AUTH_REJECTED,
     EVENT_AUTO_APPROVAL,
     EVENT_SERVER_SHUTDOWN,
     EVENT_SERVER_STARTED,
@@ -21,6 +22,7 @@ from opik_mcp.analytics.events import (
     EVENT_TOOL_CALLED,
     EVENT_TOOLS_LISTED,
     bucket_count,
+    bucket_path,
     bucket_seconds,
     bucket_text_len,
     bucket_tokens,
@@ -29,6 +31,7 @@ from opik_mcp.config import get_settings
 
 __all__ = [
     "EVENT_ASK_OLLIE_COMPLETED",
+    "EVENT_AUTH_REJECTED",
     "EVENT_AUTO_APPROVAL",
     "EVENT_SERVER_SHUTDOWN",
     "EVENT_SERVER_STARTED",
@@ -37,6 +40,7 @@ __all__ = [
     "EVENT_TOOLS_LISTED",
     "EVENT_TOOL_CALLED",
     "bucket_count",
+    "bucket_path",
     "bucket_seconds",
     "bucket_text_len",
     "bucket_tokens",

--- a/src/opik_mcp/analytics/boot_props.py
+++ b/src/opik_mcp/analytics/boot_props.py
@@ -19,6 +19,7 @@ import os
 from urllib.parse import urlparse
 
 from opik_mcp.config import Settings
+from opik_mcp.config import installation_type as _config_installation_type
 
 # Lifecycle sentinel env-var name. An env var (not a module-level bool) so that
 # uvicorn ``--reload`` workers — spawned via multiprocessing — inherit it from
@@ -42,6 +43,7 @@ def lifecycle_owned_by_main() -> bool:
     ``build_app()`` lifespan to decide whether to emit."""
     return os.environ.get(LIFECYCLE_SENTINEL) == "1"
 
+
 # Derived from the pydantic schema default at import time — NOT a hand-copied
 # string literal. Immune to env overrides (reads the declared default, not a
 # live ``Settings`` instance) and self-corrects if ``config.py`` changes it.
@@ -58,18 +60,15 @@ def _normalise_hosts(raw: str) -> str:
 
 
 def installation_type(settings: Settings) -> str:
-    """``"cloud"`` / ``"self-hosted"`` / ``"local"``. Delegates to error_tracking.
+    """``"cloud"`` / ``"self-hosted"`` / ``"local"``. Delegates to ``config``.
 
-    Imported lazily so loading this module doesn't eagerly pull in
-    ``error_tracking`` (and ``sentry_sdk``) — boot_props is reached on the
-    per-event path in ``client._build_event``. It also keeps import order robust:
-    ``error_tracking`` imports ``analytics.identity``, so a lazy import sidesteps
-    any ordering fragility while the analytics package is initialising. The
-    module is cached after first import, so the per-call cost is a dict lookup.
+    The implementation lives in ``config`` (a leaf module) so this BI path and
+    ``error_tracking``'s Sentry tag share one source WITHOUT an import cycle —
+    error_tracking imports analytics.identity, so reaching it from here (which is
+    itself reached on the per-event path in ``client._build_event``) would close
+    a loop through the analytics package.
     """
-    from opik_mcp.error_tracking import _installation_type
-
-    return _installation_type(settings)
+    return _config_installation_type(settings)
 
 
 def resource_uri_scheme(settings: Settings) -> str:

--- a/src/opik_mcp/analytics/boot_props.py
+++ b/src/opik_mcp/analytics/boot_props.py
@@ -148,3 +148,52 @@ def collect_boot_props(settings: Settings) -> dict[str, str]:
         "allowed_hosts_is_default": allowed_hosts_is_default(settings),
         "auth_mode": auth_mode_at_boot(settings),
     }
+
+
+def server_started_props(
+    settings: Settings,
+    *,
+    fingerprint_props: dict[str, str],
+    lifecycle_source: str,
+) -> dict[str, str]:
+    """The full ``opik_mcp_server_started`` property dict.
+
+    Single source of truth shared by ``__main__.main()`` (lifecycle_source=main)
+    and the ``build_app()`` lifespan (lifecycle_source=lifespan) so the two boot
+    paths can never drift. ``fingerprint_props`` is passed in because the caller
+    controls WHEN ``collect_environment_fingerprint`` runs (it shells out on
+    macOS and is timed against the lifespan anchor).
+    """
+    from opik_mcp.analytics.identity import install_id_was_freshly_generated
+
+    return {
+        "transport": settings.opik_mcp_transport.lower(),
+        "analytics_enabled": str(settings.opik_mcp_analytics_enabled).lower(),
+        "has_workspace": str(settings.comet_workspace is not None).lower(),
+        "has_api_key": str(settings.opik_api_key is not None).lower(),
+        "has_default_project": str(settings.opik_default_project_name is not None).lower(),
+        "install_id_freshly_generated": str(install_id_was_freshly_generated()).lower(),
+        "lifecycle_source": lifecycle_source,
+        **collect_boot_props(settings),
+        **fingerprint_props,
+    }
+
+
+def server_shutdown_props(
+    *,
+    reason: str,
+    elapsed_seconds: float,
+    lifecycle_source: str,
+) -> dict[str, str]:
+    """The full ``opik_mcp_server_shutdown`` property dict (shared by main() and
+    the build_app() lifespan, same anti-drift rationale as server_started_props)."""
+    from opik_mcp.analytics import transport_probe
+    from opik_mcp.analytics.events import bucket_seconds
+
+    return {
+        "reason": reason,
+        "lifespan_seconds_bucket": bucket_seconds(elapsed_seconds),
+        "first_rpc_received": str(transport_probe.first_rpc_received()).lower(),
+        "session_reached": str(transport_probe.session_reached()).lower(),
+        "lifecycle_source": lifecycle_source,
+    }

--- a/src/opik_mcp/analytics/boot_props.py
+++ b/src/opik_mcp/analytics/boot_props.py
@@ -119,11 +119,12 @@ def auth_mode_at_boot(settings: Settings) -> str:
     ``opik_client.resolve_opik_config`` (inbound bearer wins) and surfaced as the
     per-request ``auth_mode`` in ``client._build_event``.
     """
-    if settings.opik_api_key:
-        return "api_key"
-    if settings.opik_mcp_as_url:
-        return "oauth"
-    return "none"
+    from opik_mcp.auth_context import settings_auth_mode
+
+    return settings_auth_mode(
+        has_api_key=bool(settings.opik_api_key),
+        has_as_url=bool(settings.opik_mcp_as_url),
+    )
 
 
 def oauth_configured_from_env() -> str:

--- a/src/opik_mcp/analytics/boot_props.py
+++ b/src/opik_mcp/analytics/boot_props.py
@@ -1,0 +1,130 @@
+"""Boot-time analytics properties derived from ``Settings``.
+
+Single source of truth for the auth/transport properties stamped on
+``server_started`` / ``startup_error`` / ``auth_rejected``, called identically
+from ``__main__.main()`` (``lifecycle_source="main"``) and the ``build_app()``
+lifespan (``lifecycle_source="lifespan"``) so the two launch paths can never
+drift in what they emit.
+
+PRIVACY: every value returned here is a bool-string or an allowlisted enum
+(``InstallationType`` / ``AuthMode`` / ``ResourceUriScheme`` in ``events.py``).
+Raw URLs, hosts, and keys never appear in a return value — only their derived
+class. CRITICAL: ``installation_type`` is "self-hosted" (hyphen), never
+"self_hosted"; BI filters key off the exact string.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+
+from opik_mcp.config import Settings
+
+# Lifecycle sentinel env-var name. An env var (not a module-level bool) so that
+# uvicorn ``--reload`` workers — spawned via multiprocessing — inherit it from
+# ``os.environ`` and correctly skip their own lifespan emit. Set by
+# ``__main__.main()``; read by the ``build_app()`` lifespan.
+LIFECYCLE_SENTINEL = "_OPIK_MCP_LIFECYCLE_OWNED_BY_MAIN"
+
+# Derived from the pydantic schema default at import time — NOT a hand-copied
+# string literal. Immune to env overrides (reads the declared default, not a
+# live ``Settings`` instance) and self-corrects if ``config.py`` changes it.
+_DEFAULT_ALLOWED_HOSTS: str = Settings.model_fields["opik_mcp_allowed_hosts"].default
+# Fail loudly at import if the field is ever switched to a ``default_factory``:
+# ``.default`` would then be ``PydanticUndefined`` and the ``str`` annotation
+# would lie, crashing every ``allowed_hosts_is_default()`` call instead.
+assert isinstance(_DEFAULT_ALLOWED_HOSTS, str)
+
+
+def _normalise_hosts(raw: str) -> str:
+    """Strip whitespace around comma-separated host entries for comparison."""
+    return ",".join(h.strip() for h in raw.split(","))
+
+
+def installation_type(settings: Settings) -> str:
+    """``"cloud"`` / ``"self-hosted"`` / ``"local"``. Delegates to error_tracking.
+
+    Imported lazily so loading this module doesn't eagerly pull in
+    ``error_tracking`` (and ``sentry_sdk``) — boot_props is reached on the
+    per-event path in ``client._build_event``. It also keeps import order robust:
+    ``error_tracking`` imports ``analytics.identity``, so a lazy import sidesteps
+    any ordering fragility while the analytics package is initialising. The
+    module is cached after first import, so the per-call cost is a dict lookup.
+    """
+    from opik_mcp.error_tracking import _installation_type
+
+    return _installation_type(settings)
+
+
+def resource_uri_scheme(settings: Settings) -> str:
+    """Scheme of ``OPIK_MCP_RESOURCE_URI``: "https", "http", or "none".
+
+    Never emits the raw URI. A scheme-less value (bare host) is assumed to be a
+    public ingress and reports "https"; anything other than http(s) reports
+    "none" so a misconfigured value is visible rather than mislabelled.
+    """
+    uri = settings.opik_mcp_resource_uri or ""
+    if not uri:
+        return "none"
+    parsed = urlparse(uri if "://" in uri else f"https://{uri}")
+    return parsed.scheme if parsed.scheme in ("https", "http") else "none"
+
+
+def oauth_configured(settings: Settings) -> str:
+    """bool-string: is an OAuth Authorization Server configured?"""
+    return str(bool(settings.opik_mcp_as_url)).lower()
+
+
+def dns_rebinding_protection(settings: Settings) -> str:
+    """bool-string: is the Host/Origin DNS-rebinding guard enabled?"""
+    return str(settings.opik_mcp_dns_rebinding_protection).lower()
+
+
+def allowed_hosts_is_default(settings: Settings) -> str:
+    """bool-string: is the Host allowlist still the shipped localhost default?
+
+    Catches hosted deployments that forgot to widen the allowlist (which would
+    421 every public request). Whitespace-insensitive so a cosmetically
+    reformatted default still counts as default, not deliberate hardening.
+    """
+    live = _normalise_hosts(settings.opik_mcp_allowed_hosts)
+    return str(live == _normalise_hosts(_DEFAULT_ALLOWED_HOSTS)).lower()
+
+
+def auth_mode_at_boot(settings: Settings) -> str:
+    """Settings-derived auth mode for boot events: "api_key" / "oauth" / "none".
+
+    A BOOT/process-level signal, NOT the per-request mode. It reflects what an
+    outbound Opik call would use absent an inbound bearer: an explicit
+    ``OPIK_API_KEY`` (the static credential) wins; else a configured AS
+    ("oauth"); else "none". An HTTP+OAuth process may have BOTH a static key and
+    an AS configured — this then reports "api_key" while ``oauth_configured``
+    reports "true", so BI should read the two together to spot hybrid deploys.
+    The real per-request credential is resolved in
+    ``opik_client.resolve_opik_config`` (inbound bearer wins) and surfaced as the
+    per-request ``auth_mode`` in ``client._build_event``.
+    """
+    if settings.opik_api_key:
+        return "api_key"
+    if settings.opik_mcp_as_url:
+        return "oauth"
+    return "none"
+
+
+def oauth_configured_from_env() -> str:
+    """bool-string fallback for the config-fail path where ``Settings`` could
+    not be constructed (so we read the raw env var directly)."""
+    return str(bool(os.getenv("OPIK_MCP_AS_URL"))).lower()
+
+
+def collect_boot_props(settings: Settings) -> dict[str, str]:
+    """All settings-derived boot properties. Safe to spread into an event's
+    ``properties`` dict alongside the existing has_* / fingerprint props."""
+    return {
+        "installation_type": installation_type(settings),
+        "oauth_configured": oauth_configured(settings),
+        "resource_uri_scheme": resource_uri_scheme(settings),
+        "dns_rebinding_protection": dns_rebinding_protection(settings),
+        "allowed_hosts_is_default": allowed_hosts_is_default(settings),
+        "auth_mode": auth_mode_at_boot(settings),
+    }

--- a/src/opik_mcp/analytics/boot_props.py
+++ b/src/opik_mcp/analytics/boot_props.py
@@ -26,6 +26,22 @@ from opik_mcp.config import Settings
 # ``__main__.main()``; read by the ``build_app()`` lifespan.
 LIFECYCLE_SENTINEL = "_OPIK_MCP_LIFECYCLE_OWNED_BY_MAIN"
 
+
+def mark_lifecycle_owned_by_main() -> None:
+    """Record that ``__main__.main()`` owns lifecycle emits.
+
+    The ``build_app()`` lifespan checks this and skips its own
+    server_started/shutdown emit so a boot is never double-counted. NOT
+    auto-reverted; tests clear it via the conftest autouse fixture.
+    """
+    os.environ[LIFECYCLE_SENTINEL] = "1"
+
+
+def lifecycle_owned_by_main() -> bool:
+    """True when ``main()`` has claimed lifecycle-emit ownership. Read by the
+    ``build_app()`` lifespan to decide whether to emit."""
+    return os.environ.get(LIFECYCLE_SENTINEL) == "1"
+
 # Derived from the pydantic schema default at import time — NOT a hand-copied
 # string literal. Immune to env overrides (reads the declared default, not a
 # live ``Settings`` instance) and self-corrects if ``config.py`` changes it.
@@ -118,10 +134,14 @@ def oauth_configured_from_env() -> str:
 
 
 def collect_boot_props(settings: Settings) -> dict[str, str]:
-    """All settings-derived boot properties. Safe to spread into an event's
-    ``properties`` dict alongside the existing has_* / fingerprint props."""
+    """Settings-derived boot properties for lifecycle events. Safe to spread
+    into an event's ``properties`` dict alongside the has_* / fingerprint props.
+
+    Deliberately omits ``installation_type``: that is stamped on EVERY event by
+    ``client._build_event``'s common block (the single source of truth), so
+    duplicating it here would be dead — common always wins the merge.
+    """
     return {
-        "installation_type": installation_type(settings),
         "oauth_configured": oauth_configured(settings),
         "resource_uri_scheme": resource_uri_scheme(settings),
         "dns_rebinding_protection": dns_rebinding_protection(settings),

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -24,8 +24,13 @@ from opik_mcp.analytics.identity import (
     get_install_id,
     resolve_anonymous_id,
 )
-from opik_mcp.auth_context import classify_bearer, inbound_authorization, inbound_workspace
-from opik_mcp.config import Settings
+from opik_mcp.auth_context import (
+    classify_bearer,
+    inbound_authorization,
+    inbound_workspace,
+    settings_auth_mode,
+)
+from opik_mcp.config import Settings, installation_type
 
 logger = logging.getLogger("opik_mcp.analytics")
 
@@ -63,6 +68,14 @@ class AnalyticsClient:
         self._worker: threading.Thread | None = None
         self._closed = False
         self._closed_lock = threading.Lock()
+        # Process-stable destination class — computed ONCE (settings are fixed
+        # for this client) so _build_event doesn't re-parse the URL per event.
+        # Falls back to "unknown" rather than dropping the key on any failure.
+        try:
+            self._installation_type = installation_type(settings)
+        except Exception:
+            logger.debug("installation_type computation failed", exc_info=True)
+            self._installation_type = "unknown"
         if self._settings.opik_mcp_analytics_enabled:
             self._warn_if_misconfigured_for_onprem()
             self._start_worker()
@@ -188,7 +201,9 @@ class AnalyticsClient:
         common: dict[str, str] = {
             "environment": self._settings.opik_mcp_analytics_environment,
             "opik_mcp_version": OPIK_MCP_VERSION,
-            "transport": self._settings.opik_mcp_transport,
+            # Lowercased so BI sees a canonical value regardless of how the env
+            # var was cased (main() also lowercases for transport selection).
+            "transport": self._settings.opik_mcp_transport.lower(),
             "install_id": get_install_id(),
             "python_version": (
                 f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
@@ -215,14 +230,10 @@ class AnalyticsClient:
             # Tells comet-stats to mark `on_prem=False` and skip IP enrichment;
             # matches the `OLLIE_SOURCE` / opik.sh convention.
             common["source"] = self._settings.opik_mcp_analytics_source
-        # Process-stable Opik destination class, stamped on every event so BI can
-        # split cloud / self-hosted without joining back to server_started.
-        try:
-            from opik_mcp.analytics.boot_props import installation_type
-
-            common["installation_type"] = installation_type(self._settings)
-        except Exception:
-            logger.debug("installation_type computation failed", exc_info=True)
+        # Process-stable Opik destination class (computed once in __init__),
+        # stamped on every event so BI can split cloud / self-hosted without
+        # joining back to server_started.
+        common["installation_type"] = self._installation_type
 
         per_request = self._per_request_props()
         # Merge precedence (lowest → highest): per-request contextvar enrichment,
@@ -270,12 +281,17 @@ class AnalyticsClient:
                     props["token_sha256"] = hashlib.sha256(token.encode("utf-8")).hexdigest()
             else:
                 # No inbound header: stdio or unauthenticated HTTP. Fall back to
-                # whether a static env key is configured. ALWAYS set so the
+                # the settings-derived mode (shared with auth_mode_at_boot, so an
+                # OAuth-only deploy reports "oauth" not "none"). ALWAYS set so the
                 # stdio / no-auth cohort is visible, not dark.
-                props["auth_mode"] = "api_key" if self._settings.opik_api_key else "none"
+                props["auth_mode"] = settings_auth_mode(
+                    has_api_key=bool(self._settings.opik_api_key),
+                    has_as_url=bool(self._settings.opik_mcp_as_url),
+                )
 
-            if ws_header and ws_header.strip():
-                props["request_workspace"] = ws_header.strip()
+            workspace = ws_header.strip() if ws_header else ""
+            if workspace:
+                props["request_workspace"] = workspace
         except Exception:
             logger.debug("per-request identity enrichment failed", exc_info=True)
         return props

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -6,6 +6,7 @@ Daemon-thread worker model (not asyncio): callable from any context, including
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import platform
 import queue
@@ -23,6 +24,7 @@ from opik_mcp.analytics.identity import (
     get_install_id,
     resolve_anonymous_id,
 )
+from opik_mcp.auth_context import inbound_authorization, inbound_workspace
 from opik_mcp.config import Settings
 
 logger = logging.getLogger("opik_mcp.analytics")
@@ -213,15 +215,73 @@ class AnalyticsClient:
             # Tells comet-stats to mark `on_prem=False` and skip IP enrichment;
             # matches the `OLLIE_SOURCE` / opik.sh convention.
             common["source"] = self._settings.opik_mcp_analytics_source
-        # Common props (environment, version, transport, …) are authoritative: a
-        # call site accidentally passing e.g. "environment" must not silently
-        # shadow the server-stamped value.  Spread caller properties first so
-        # common always wins on key conflicts.
+        # Process-stable Opik destination class, stamped on every event so BI can
+        # split cloud / self-hosted without joining back to server_started.
+        try:
+            from opik_mcp.analytics.boot_props import installation_type
+
+            common["installation_type"] = installation_type(self._settings)
+        except Exception:
+            logger.debug("installation_type computation failed", exc_info=True)
+
+        per_request = self._per_request_props()
+        # Merge precedence (lowest → highest): per-request contextvar enrichment,
+        # then caller-supplied properties, then the authoritative common block.
+        # common always wins (a call site accidentally passing e.g. "environment"
+        # must not shadow the server-stamped value); caller properties win over
+        # per-request so server_started's settings-derived auth_mode beats the
+        # contextvar-derived one (which is "none" at boot, no request in flight).
         return {
             # comet-stats indexes events by top-level `user_id`. Kept as
             # workspace name → install_id for dashboard continuity. The
             # per-user identity is in event_properties.api_key_sha256.
             "user_id": resolve_anonymous_id(self._settings),
             "event_type": event_type,
-            "event_properties": {**properties, **common},
+            "event_properties": {**per_request, **properties, **common},
         }
+
+    def _per_request_props(self) -> dict[str, str]:
+        """Identity derived from the inbound-auth ContextVars (HTTP/OAuth mode).
+
+        Runs in the caller's task (``_build_event`` builds synchronously before
+        enqueuing), so the request's ContextVars are live here — this is what
+        lets per-request OAuth identity reach BI in hosted mode.
+
+        ``auth_mode`` is ALWAYS set so stdio / no-auth events are not a dark
+        cohort. PRIVACY: the raw bearer token never enters the result — only its
+        sha256 digest, and only for ``opik_at_`` OAuth tokens. ``request_workspace``
+        mirrors the existing plaintext ``workspace`` posture (workspace names are
+        used as ``user_id`` in ``resolve_anonymous_id``).
+        """
+        props: dict[str, str] = {}
+        try:
+            inbound_auth = inbound_authorization.get()
+            ws_header = inbound_workspace.get()
+
+            if inbound_auth:
+                # Mirror opik_client.resolve_opik_config EXACTLY (same
+                # ``partition(" ")`` + ``lstrip`` + ``opik_at_`` prefix check) so
+                # BI's auth_mode and token_sha256 agree with the credential the
+                # process actually forwards outbound — even for odd whitespace.
+                scheme, _, token_raw = inbound_auth.partition(" ")
+                token = token_raw.lstrip()
+                if scheme.lower() == "bearer" and token.startswith("opik_at_"):
+                    props["auth_mode"] = "oauth"
+                    # PRIVACY: only the digest is emitted; the raw token never
+                    # enters the result.
+                    props["token_sha256"] = hashlib.sha256(token.encode("utf-8")).hexdigest()
+                else:
+                    # Any other inbound credential is forwarded verbatim as the
+                    # API key (resolve_opik_config: api_key = inbound_auth).
+                    props["auth_mode"] = "api_key"
+            else:
+                # No inbound header: stdio or unauthenticated HTTP. Fall back to
+                # whether a static env key is configured. ALWAYS set so the
+                # stdio / no-auth cohort is visible, not dark.
+                props["auth_mode"] = "api_key" if self._settings.opik_api_key else "none"
+
+            if ws_header and ws_header.strip():
+                props["request_workspace"] = ws_header.strip()
+        except Exception:
+            logger.debug("per-request identity enrichment failed", exc_info=True)
+        return props

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -24,7 +24,7 @@ from opik_mcp.analytics.identity import (
     get_install_id,
     resolve_anonymous_id,
 )
-from opik_mcp.auth_context import inbound_authorization, inbound_workspace
+from opik_mcp.auth_context import classify_bearer, inbound_authorization, inbound_workspace
 from opik_mcp.config import Settings
 
 logger = logging.getLogger("opik_mcp.analytics")
@@ -259,21 +259,15 @@ class AnalyticsClient:
             ws_header = inbound_workspace.get()
 
             if inbound_auth:
-                # Mirror opik_client.resolve_opik_config EXACTLY (same
-                # ``partition(" ")`` + ``lstrip`` + ``opik_at_`` prefix check) so
-                # BI's auth_mode and token_sha256 agree with the credential the
-                # process actually forwards outbound — even for odd whitespace.
-                scheme, _, token_raw = inbound_auth.partition(" ")
-                token = token_raw.lstrip()
-                if scheme.lower() == "bearer" and token.startswith("opik_at_"):
-                    props["auth_mode"] = "oauth"
+                # Shared classifier (see auth_context.classify_bearer) so BI's
+                # auth_mode/token_sha256 agree with the outbound credential and
+                # with AuthRejectionMiddleware.
+                mode, token = classify_bearer(inbound_auth)
+                props["auth_mode"] = mode
+                if token:  # oauth bearer
                     # PRIVACY: only the digest is emitted; the raw token never
                     # enters the result.
                     props["token_sha256"] = hashlib.sha256(token.encode("utf-8")).hexdigest()
-                else:
-                    # Any other inbound credential is forwarded verbatim as the
-                    # API key (resolve_opik_config: api_key = inbound_auth).
-                    props["auth_mode"] = "api_key"
             else:
                 # No inbound header: stdio or unauthenticated HTTP. Fall back to
                 # whether a static env key is configured. ALWAYS set so the

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -8,10 +8,12 @@ identifiable values. Thresholds picked to align with common LLM-context budgets
 
 Every analytics property is either a boolean string, a hardcoded-allowlist
 string, or a bucketed integer/duration. The allowlists below MUST stay in sync
-with the classifiers in ``environment.py`` and ``wrappers.py`` — adding a new
-bucket is a BI schema change and requires updating both the classifier and the
-corresponding Literal here. Tests that pin the BI shape live in
-``tests/test_analytics_privacy.py`` and ``tests/test_analytics_lifespan.py``.
+with the classifiers in ``environment.py`` (launch method / parent process) and
+``mcp_client_info.py`` (mcp host / host LLM family) — adding a new bucket is a BI
+schema change and requires updating both the classifier and the corresponding
+Literal here. Tests that pin the BI shape live in
+``tests/test_analytics_events.py``, ``tests/test_analytics_privacy.py`` and
+``tests/test_analytics_lifespan.py``.
 
 Each Literal documents the *only* values the receiver will ever see for that
 property. Anything outside the allowlist is bucketed to a fallback ("other",
@@ -51,8 +53,10 @@ ParentProcess = Literal[
     "other",
 ]
 
-# ``mcp_host``: bucketed MCP host (clientInfo.name). See
-# ``wrappers._MCP_HOST_PATTERNS``.
+# ``mcp_host``: bucketed MCP host (clientInfo.name). MUST stay in sync with
+# ``mcp_client_info._MCP_HOST_PATTERNS`` — every bucket that classifier can
+# emit is declared here (enforced by
+# ``test_analytics_events.test_mcp_host_literal_covers_all_classifier_buckets``).
 McpHost = Literal[
     "claude-desktop",
     "claude-code",
@@ -62,14 +66,25 @@ McpHost = Literal[
     "continue",
     "windsurf",
     "mcp-inspector",
+    "zed",
+    "vscode",
+    "goose",
+    "librechat",
+    "5ire",
+    "opencode",
+    "codex",
+    "gemini-cli",
     "other",
 ]
 
-# ``host_llm_family``: derived from the bucketed ``mcp_host``. See
-# ``wrappers._HOST_LLM_FAMILY``.
+# ``host_llm_family``: derived from the bucketed ``mcp_host``. MUST stay in sync
+# with ``mcp_client_info._HOST_LLM_FAMILY`` values (enforced by
+# ``test_analytics_events.test_host_llm_family_literal_covers_all_classifier_values``).
 HostLlmFamily = Literal[
     "anthropic",
     "cursor",
+    "openai",
+    "google",
     "mixed",
     "inspector",
     "unknown",

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -127,9 +127,9 @@ LifespanSecondsBucket = Literal[
 ]
 
 # ``installation_type``: Opik destination class. Mirrors
-# ``error_tracking._installation_type`` so opik-mcp and opik dashboards share
-# tag values. CRITICAL: the self-hosted value is hyphenated ("self-hosted"),
-# never "self_hosted" — BI filters key off the exact string.
+# ``config.installation_type`` (shared with error_tracking's Sentry tag) so
+# opik-mcp and opik dashboards share tag values. CRITICAL: the self-hosted value
+# is hyphenated ("self-hosted"), never "self_hosted" — BI keys off the exact string.
 InstallationType = Literal["cloud", "self-hosted", "local"]
 
 # ``auth_mode``: how the caller authenticated. At boot it is settings-derived

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -110,6 +110,20 @@ LifespanSecondsBucket = Literal[
     ">24h",
 ]
 
+# ``installation_type``: Opik destination class. Mirrors
+# ``error_tracking._installation_type`` so opik-mcp and opik dashboards share
+# tag values. CRITICAL: the self-hosted value is hyphenated ("self-hosted"),
+# never "self_hosted" — BI filters key off the exact string.
+InstallationType = Literal["cloud", "self-hosted", "local"]
+
+# ``auth_mode``: how the caller authenticated. At boot it is settings-derived
+# (``boot_props.auth_mode_at_boot``); per-request it is derived from the inbound
+# bearer in ``client._build_event``.
+AuthMode = Literal["oauth", "api_key", "none"]
+
+# ``resource_uri_scheme``: scheme of ``OPIK_MCP_RESOURCE_URI``; "none" when unset.
+ResourceUriScheme = Literal["https", "http", "none"]
+
 
 EVENT_SERVER_STARTED = "opik_mcp_server_started"
 EVENT_SESSION_INITIALIZED = "opik_mcp_session_initialized"

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -18,6 +18,22 @@ Literal here. Tests that pin the BI shape live in
 Each Literal documents the *only* values the receiver will ever see for that
 property. Anything outside the allowlist is bucketed to a fallback ("other",
 "unknown", "") at the emit site — the receiver never sees raw host input.
+
+Two declared exceptions to "boolean / enum / bucket":
+
+- Pseudonymous identity hashes (``api_key_sha256``, ``token_sha256``) are
+  64-char SHA-256 hex digests. Not enums, but safe: irreversible one-way
+  transforms of secrets the backend already holds (it joins on the digest).
+  The raw key/token NEVER leaves the process. This is enforced by tests that
+  call ``client._build_event`` directly
+  (``tests/test_analytics_client_build_event.py``); the recorder-based tests in
+  ``test_analytics_privacy.py`` intercept at ``track_event`` and never see what
+  ``_build_event`` builds, so they cannot catch a leak inside it.
+- Workspace fields (``workspace``, ``request_workspace``, ``workspace_id``) are
+  emitted as plaintext/UUID — an accepted posture, since the workspace name is
+  already used as the top-level ``user_id`` (``resolve_anonymous_id``).
+
+Never emit free-text queries, paths, filenames, or other user prose.
 """
 
 from __future__ import annotations

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -140,6 +140,12 @@ AuthMode = Literal["oauth", "api_key", "none"]
 # ``resource_uri_scheme``: scheme of ``OPIK_MCP_RESOURCE_URI``; "none" when unset.
 ResourceUriScheme = Literal["https", "http", "none"]
 
+# ``lifecycle_source`` (on server_started / server_shutdown): which path emitted
+# the lifecycle event — ``"main"`` (__main__.main) or ``"lifespan"`` (the
+# build_app() Starlette lifespan, the hosted Docker/--factory path). Lets BI
+# confirm the hosted fleet is no longer dark for boot events (GAP#1).
+LifecycleSource = Literal["main", "lifespan"]
+
 
 EVENT_SERVER_STARTED = "opik_mcp_server_started"
 EVENT_SESSION_INITIALIZED = "opik_mcp_session_initialized"

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -218,6 +218,20 @@ def bucket_seconds(n: float) -> str:
     return ">24h"
 
 
+# ``rejection_reason`` (on ``opik_mcp_auth_rejected``): why a request was
+# rejected before reaching a tool. 401 shapes from BearerAuthMiddleware
+# (missing_header / not_bearer / empty_token) + the SDK transport-security
+# guard's 421 (host) / 403 (origin). Derived from status + header SHAPE only —
+# never the token value.
+AuthRejectionReason = Literal[
+    "missing_header",
+    "not_bearer",
+    "empty_token",
+    "token_rejected",
+    "host_rejected",
+    "origin_rejected",
+]
+
 # ``path_bucket`` (on ``opik_mcp_auth_rejected``): coarse request-path class.
 # Never carries the raw path — the receiver only ever sees these four buckets.
 # ``"other"`` covers OAuth-flow proxy paths (/authorize, /register, /token, …)

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -127,6 +127,12 @@ EVENT_TOOLS_LISTED = "opik_mcp_tools_listed"
 # slice the dark cohort into {pure probe, handshake-failed, healthy-short,
 # healthy-long}.
 EVENT_SERVER_SHUTDOWN = "opik_mcp_server_shutdown"
+# Emitted (HTTP transport only) when an inbound request is rejected before
+# reaching a tool: 401 from BearerAuthMiddleware (missing/malformed bearer) or
+# 421/403 from the SDK transport-security guard (Host/Origin). The key HTTPS
+# health signal — without it auth failures are invisible. See
+# ``AuthRejectionMiddleware`` in server.py.
+EVENT_AUTH_REJECTED = "opik_mcp_auth_rejected"
 
 
 def bucket_tokens(n: int) -> str:
@@ -174,3 +180,35 @@ def bucket_seconds(n: float) -> str:
     if n < 86400:
         return "1-24h"
     return ">24h"
+
+
+# ``path_bucket`` (on ``opik_mcp_auth_rejected``): coarse request-path class.
+# Never carries the raw path — the receiver only ever sees these four buckets.
+# ``"other"`` covers OAuth-flow proxy paths (/authorize, /register, /token, …)
+# and any unknown path. Those proxy paths are unauthenticated pass-throughs, so
+# in practice auth-rejection events carry ``"mcp"`` (our resource-server bearer
+# rejection) or the Host/Origin-guard rejections; ``"other"`` is mostly stray
+# probe traffic.
+PathBucket = Literal["mcp", "health", "well_known", "other"]
+
+
+def bucket_path(path: str, mcp_http_path: str = "/mcp") -> str:
+    """Bucket a request path to a low-cardinality enum. Never emits the raw path.
+
+    ``mcp_http_path`` is the configured MCP transport mount (OPIK_MCP_HTTP_PATH);
+    a request to it (or a subpath) buckets to ``"mcp"``, so the bucketing stays
+    correct when an operator remaps the endpoint behind a path-prefix proxy.
+
+    Matching is exact-or-subpath (``== mount`` or ``mount + "/"`` prefix) rather
+    than a bare ``startswith`` so a sibling like ``/mcpfoo`` or ``/healthz`` does
+    not get mis-bucketed as the real endpoint.
+    """
+    p = path or ""
+    if p.startswith("/.well-known/"):
+        return "well_known"
+    if p == "/health" or p.startswith("/health/"):
+        return "health"
+    mount = mcp_http_path.rstrip("/")
+    if p == mount or p.startswith(mount + "/"):
+        return "mcp"
+    return "other"

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -30,3 +30,25 @@ inbound_authorization: ContextVar[str | None] = ContextVar("inbound_authorizatio
 # verifyWorkspaceHeaderMatchesToken`) and rejects mismatches with 403 before
 # any downstream call. ``None`` means "fall back to settings.comet_workspace".
 inbound_workspace: ContextVar[str | None] = ContextVar("inbound_workspace", default=None)
+
+
+def classify_bearer(auth_header: str) -> tuple[str, str]:
+    """Classify a non-empty inbound ``Authorization`` header for BI analytics.
+
+    Returns ``(auth_mode, oauth_token)``:
+    - ``("oauth", "<opik_at_…>")`` for an OAuth bearer — the token is returned
+      ONLY so the caller can hash it; it is never stored or emitted raw.
+    - ``("api_key", "")`` for any other forwarded credential (the token is NOT
+      returned — api-key-shaped credentials are not hashed here).
+
+    Mirrors ``opik_client.resolve_opik_config``'s OAuth detection
+    (``partition(" ")`` + ``lstrip`` + ``opik_at_`` prefix) so BI's ``auth_mode``
+    / ``token_sha256`` agree with the credential actually forwarded outbound.
+    Single source of truth shared by ``analytics.client._build_event`` and
+    ``server.AuthRejectionMiddleware`` so the two cannot drift.
+    """
+    scheme, _, token_raw = auth_header.partition(" ")
+    token = token_raw.lstrip()
+    if scheme.lower() == "bearer" and token.startswith("opik_at_"):
+        return "oauth", token
+    return "api_key", ""

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -52,3 +52,19 @@ def classify_bearer(auth_header: str) -> tuple[str, str]:
     if scheme.lower() == "bearer" and token.startswith("opik_at_"):
         return "oauth", token
     return "api_key", ""
+
+
+def settings_auth_mode(*, has_api_key: bool, has_as_url: bool) -> str:
+    """Settings-derived ``auth_mode`` when there is no inbound credential.
+
+    The mode an outbound Opik call would use by default: a static ``OPIK_API_KEY``
+    ("api_key") wins; else a configured AS ("oauth"); else "none". Single source
+    of truth shared by ``boot_props.auth_mode_at_boot`` (lifecycle events) and the
+    no-credential fallback in ``client._build_event`` / ``AuthRejectionMiddleware``
+    so per-call and boot events agree for OAuth-only deployments.
+    """
+    if has_api_key:
+        return "api_key"
+    if has_as_url:
+        return "oauth"
+    return "none"

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from typing import Any, ClassVar, Literal
+from urllib.parse import urlparse
 from uuid import UUID
 
 from pydantic import AliasChoices, Field, field_validator
@@ -11,6 +12,13 @@ from opik_mcp.error_kinds import ErrorKind
 # (`OPIK_WORKSPACE_DEFAULT_NAME = "default"`). Lets local/OSS users run without
 # setting a workspace at all; cloud users with named workspaces still set one.
 DEFAULT_WORKSPACE = "default"
+
+# Cloud-Comet hostnames. Strict equality (matching the opik SDK) — ``staging.
+# comet.com`` / ``enterprise.example.com`` count as self-hosted so dashboards
+# don't mix prod-cloud failures with on-prem ones.
+_CLOUD_HOSTS: frozenset[str] = frozenset({"www.comet.com", "comet.com"})
+# Loopback hostnames a developer points at for a docker-compose / local-dev stack.
+_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})
 
 
 class MissingConfigError(RuntimeError):
@@ -215,3 +223,28 @@ def require_ollie_config(settings: Settings) -> tuple[str, str]:
     # Cloud pod discovery for a non-"default" account will surface its own
     # clear error downstream, which beats a hard config failure here.
     return settings.opik_api_key, settings.comet_workspace or DEFAULT_WORKSPACE
+
+
+def installation_type(settings: Settings) -> str:
+    """Classify the Opik destination as ``cloud`` / ``local`` / ``self-hosted``.
+
+    Mirrors the opik SDK's taxonomy (``opik.environment.get_installation_type``)
+    so dashboards across opik-mcp and opik share tag values. Lives here (a leaf
+    module) so both ``error_tracking`` (Sentry tag) and ``analytics.boot_props``
+    (BI) can use it without an import cycle.
+
+    Precedence: ``opik_url`` (explicit Opik base) wins; otherwise derive from
+    ``comet_url_override`` (combined with ``/opik/api`` elsewhere). An empty
+    config falls through to ``self-hosted`` rather than guessing ``cloud`` — a
+    misconfigured install is closer to a custom deploy than to prod-Comet.
+    """
+    raw = settings.opik_url or settings.comet_url_override or ""
+    if not raw:
+        return "self-hosted"
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    host = (parsed.hostname or "").lower()
+    if host in _CLOUD_HOSTS:
+        return "cloud"
+    if host in _LOCAL_HOSTS:
+        return "local"
+    return "self-hosted"

--- a/src/opik_mcp/error_tracking.py
+++ b/src/opik_mcp/error_tracking.py
@@ -34,22 +34,14 @@ import sys
 import threading
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlparse
 
 import sentry_sdk
 from sentry_sdk.types import Event, Hint
 
+# ``installation_type`` lives in ``config`` (a leaf module) so both this Sentry
+# path and ``analytics.boot_props`` (BI) share one source without an import cycle.
 from opik_mcp.analytics.identity import OPIK_MCP_VERSION, get_install_id
-from opik_mcp.config import Settings
-
-# Cloud-Comet hostnames. Matching opik SDK's strict equality semantics —
-# ``staging.comet.com`` or ``enterprise.example.com`` count as self-hosted
-# so dashboards don't mix prod-cloud failures with on-prem ones.
-_CLOUD_HOSTS: frozenset[str] = frozenset({"www.comet.com", "comet.com"})
-
-# Loopback hostnames a developer is most likely to point at when running
-# Opik against a docker-compose / local-dev stack.
-_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})
+from opik_mcp.config import Settings, installation_type
 
 logger = logging.getLogger("opik_mcp.error_tracking")
 
@@ -59,30 +51,6 @@ logger = logging.getLogger("opik_mcp.error_tracking")
 # Sentry level — fatal floods are worse to swallow than error floods, and
 # we don't emit non-error events in this codebase anyway.
 _MAX_EVENTS: int = 30
-
-
-def _installation_type(settings: Settings) -> str:
-    """Classify the Opik destination as ``cloud`` / ``local`` / ``self-hosted``.
-
-    Mirrors the opik SDK's taxonomy (``opik.environment.get_installation_type``)
-    so dashboards across opik-mcp and opik can use the same tag values.
-
-    Precedence: ``opik_url`` (explicit Opik base) wins; otherwise we derive
-    from ``comet_url_override`` (which the rest of the codebase combines
-    with ``/opik/api`` to talk to Opik). An empty config falls through to
-    ``self-hosted`` rather than guessing ``cloud`` — a misconfigured install
-    is closer to a custom deploy than to prod-Comet.
-    """
-    raw = settings.opik_url or settings.comet_url_override or ""
-    if not raw:
-        return "self-hosted"
-    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
-    host = (parsed.hostname or "").lower()
-    if host in _CLOUD_HOSTS:
-        return "cloud"
-    if host in _LOCAL_HOSTS:
-        return "local"
-    return "self-hosted"
 
 
 def _in_pytest() -> bool:
@@ -183,8 +151,8 @@ def _bind_scope(settings: Settings) -> None:
     )
     sentry_sdk.set_tag("transport", settings.opik_mcp_transport)
     # Mirrors opik SDK's classification so Sentry filters stay portable
-    # between products. See ``_installation_type`` for the URL precedence.
-    sentry_sdk.set_tag("installation_type", _installation_type(settings))
+    # between products. See ``config.installation_type`` for the URL precedence.
+    sentry_sdk.set_tag("installation_type", installation_type(settings))
     sentry_sdk.set_tag("github_actions", str(bool(os.getenv("GITHUB_ACTIONS"))).lower())
     if settings.opik_mcp_analytics_source:
         sentry_sdk.set_tag("source", settings.opik_mcp_analytics_source)

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -1,4 +1,8 @@
+import asyncio
+import contextlib
 import logging
+import time
+from collections.abc import AsyncIterator
 from typing import Annotated, Any
 from urllib.parse import urlparse
 
@@ -14,6 +18,14 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 from starlette.types import ASGIApp
 
+from opik_mcp.analytics import (
+    EVENT_SERVER_SHUTDOWN,
+    EVENT_SERVER_STARTED,
+    boot_props,
+    get_analytics,
+    track_event,
+)
+from opik_mcp.analytics.environment import collect_environment_fingerprint
 from opik_mcp.analytics.events import bucket_count
 from opik_mcp.analytics.wrappers import install_tools_listed_emitter, instrument_tool
 from opik_mcp.ask_ollie import AskOllieResult, run_ask_ollie
@@ -803,6 +815,82 @@ async def _not_found_json(scope: Any, receive: Any, send: Any) -> None:
     await response(scope, receive, send)
 
 
+# Shutdown drain budget for the lifespan path. Mirrors __main__'s deadline: the
+# daemon worker is about to be torn down, so block briefly to land the POST.
+_LIFESPAN_FLUSH_DEADLINE_S = 3.5
+
+
+def _make_composed_lifespan(
+    inner_lifespan: Any,
+    settings: Settings,
+    fingerprint_props: dict[str, str],
+) -> Any:
+    """Wrap FastMCP's session-manager lifespan with analytics lifecycle emits.
+
+    Closes GAP#1: the hosted entrypoint runs ``uvicorn ... build_app --factory``,
+    which calls ``build_app()`` directly and never runs ``__main__.main()``, so
+    the boot funnel was 100% dark. This emits server_started/shutdown from the
+    lifespan instead — UNLESS ``main()`` owns lifecycle (the sentinel), in which
+    case it just runs the inner lifespan and emits nothing (no double-count).
+
+    ``inner_lifespan`` MUST be captured from ``app.router.lifespan_context``
+    BEFORE it is overwritten — it starts the ``StreamableHTTPSessionManager``,
+    without which every MCP request hangs.
+    """
+
+    @contextlib.asynccontextmanager
+    async def _composed(app: Any) -> AsyncIterator[Any]:
+        if boot_props.lifecycle_owned_by_main():
+            # main() emits the lifecycle events; just run the session manager.
+            async with inner_lifespan(app) as state:
+                yield state
+            return
+
+        # Anchor at lifespan enter (when serving actually starts), not at
+        # build_app() time — keeps lifespan_seconds_bucket free of uvicorn's
+        # startup/bind latency.
+        started_monotonic = time.monotonic()
+        try:
+            track_event(
+                EVENT_SERVER_STARTED,
+                boot_props.server_started_props(
+                    settings, fingerprint_props=fingerprint_props, lifecycle_source="lifespan"
+                ),
+            )
+        except Exception:
+            logger.debug("lifespan server_started emit failed", exc_info=True)
+
+        reason = "clean_exit"
+        try:
+            async with inner_lifespan(app) as state:
+                yield state
+        except BaseException:
+            reason = "transport_error"
+            raise
+        finally:
+            try:
+                elapsed = time.monotonic() - started_monotonic
+                track_event(
+                    EVENT_SERVER_SHUTDOWN,
+                    boot_props.server_shutdown_props(
+                        reason=reason, elapsed_seconds=elapsed, lifecycle_source="lifespan"
+                    ),
+                )
+                # flush() blocks on threading.Event.wait — never block the event
+                # loop; offload the drain to the default executor.
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(
+                    None, lambda: get_analytics().flush(deadline_s=_LIFESPAN_FLUSH_DEADLINE_S)
+                )
+            except BaseException:
+                # Mirror __main__._emit_server_shutdown: a telemetry-side failure
+                # (incl. CancelledError from the executor during loop teardown)
+                # must NEVER mask the real shutdown reason or leak out of finally.
+                logger.debug("lifespan server_shutdown emit failed", exc_info=True)
+
+    return _composed
+
+
 def build_app() -> Starlette:
     install_tools_listed_emitter(mcp)
     s = get_settings()
@@ -843,4 +931,15 @@ def build_app() -> Starlette:
         BearerAuthMiddleware,
         resource_metadata_url=_resource_metadata_url(s),
     )
+
+    # GAP#1: emit lifecycle events from the lifespan so the hosted --factory
+    # entrypoint (which bypasses __main__.main()) is no longer dark. Capture the
+    # session-manager lifespan BEFORE overwriting it. Compute the fingerprint
+    # synchronously here (it shells out on macOS — must not run in the async
+    # lifespan) and only when this process will actually emit: a main()-owned
+    # boot skips the emit, so skip the cost too.
+    will_emit = not boot_props.lifecycle_owned_by_main()
+    fingerprint_props = collect_environment_fingerprint() if will_emit else {}
+    inner_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _make_composed_lifespan(inner_lifespan, s, fingerprint_props)
     return app

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -11,7 +11,6 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import Field
-from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -19,17 +18,18 @@ from starlette.routing import Route
 from starlette.types import ASGIApp
 
 from opik_mcp.analytics import (
+    EVENT_AUTH_REJECTED,
     EVENT_SERVER_SHUTDOWN,
     EVENT_SERVER_STARTED,
     boot_props,
     get_analytics,
     track_event,
 )
-from opik_mcp.analytics.environment import collect_environment_fingerprint
-from opik_mcp.analytics.events import bucket_count
+from opik_mcp.analytics.environment import cached_call_context_env, collect_environment_fingerprint
+from opik_mcp.analytics.events import bucket_count, bucket_path
 from opik_mcp.analytics.wrappers import install_tools_listed_emitter, instrument_tool
 from opik_mcp.ask_ollie import AskOllieResult, run_ask_ollie
-from opik_mcp.auth_context import inbound_authorization, inbound_workspace
+from opik_mcp.auth_context import classify_bearer, inbound_authorization, inbound_workspace
 from opik_mcp.config import MissingConfigError, Settings, get_settings
 from opik_mcp.instructions import render_instructions
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
@@ -642,6 +642,119 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         return JSONResponse({"error": "unauthorized"}, status_code=401, headers=headers)
 
 
+def _has_absolute_resource_metadata_url(settings: Settings) -> bool:
+    """True only when ``OPIK_MCP_RESOURCE_URI`` is an absolute URL (scheme+netloc).
+
+    ``_resource_metadata_url()`` returns a non-empty *relative* path even when the
+    URI is unset, so ``bool()`` on it is always True. This answers the real
+    question for BI: could a host actually bootstrap OAuth discovery from the
+    ``WWW-Authenticate`` hint this rejection carried?
+    """
+    uri = settings.opik_mcp_resource_uri
+    if not uri:
+        return False
+    parsed = urlparse(uri)
+    return bool(parsed.scheme and parsed.netloc)
+
+
+def _classify_rejection_reason(status_code: int, auth_header: str) -> str:
+    """Map (status, Authorization-header shape) to a ``rejection_reason`` bucket.
+
+    PRIVACY: inspects only the scheme keyword and whether a token is present —
+    never stores or returns any part of the token value.
+    """
+    if status_code == 421:
+        return "host_rejected"
+    if status_code == 403:
+        return "origin_rejected"
+    # 401 — classify by header shape (mirrors BearerAuthMiddleware's checks).
+    if not auth_header:
+        return "missing_header"
+    if not auth_header.lower().startswith("bearer "):
+        return "not_bearer"
+    if not auth_header[len("bearer ") :].strip():
+        return "empty_token"
+    # A well-formed bearer that still got a 401 — BearerAuthMiddleware forwards
+    # those onward, so today this only arises if a downstream layer 401s a valid
+    # shape. Its own bucket (never echoes the token) so BI doesn't conflate it
+    # with genuinely-missing-header rejections.
+    return "token_rejected"
+
+
+class AuthRejectionMiddleware:
+    """Outermost ASGI wrapper: emit ``opik_mcp_auth_rejected`` for 401/421/403
+    responses on authenticated paths (GAP#3).
+
+    Pure ASGI (NOT ``BaseHTTPMiddleware``) so streaming SSE responses flow
+    through unbuffered — it reads only the response status line. ``_UNAUTH_PATHS``
+    (health, OAuth-proxy, discovery) are skipped: a 401 proxied from the AS
+    during the OAuth dance is not opik-mcp's resource-server rejection, and
+    counting it would pollute the auth-rejection chart. Non-http scopes
+    (``lifespan``/``websocket``) pass straight through.
+    """
+
+    def __init__(self, app: ASGIApp, *, settings: Settings) -> None:
+        self.app = app
+        self._settings = settings
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        status_holder: list[int] = []
+
+        async def _capture(message: Any) -> None:
+            # Record the FIRST response status only (ASGI spec sends exactly one
+            # http.response.start; guard against a misbehaving app sending more).
+            if message["type"] == "http.response.start" and not status_holder:
+                status_holder.append(message["status"])
+            await send(message)
+
+        await self.app(scope, receive, _capture)
+
+        if status_holder and status_holder[0] in (401, 403, 421):
+            try:
+                self._emit_rejection(scope, status_holder[0])
+            except Exception:
+                # Telemetry must never affect the (already-sent) response.
+                logger.debug("auth_rejected emit failed", exc_info=True)
+
+    def _emit_rejection(self, scope: dict[str, Any], status_code: int) -> None:
+        path = scope.get("path", "")
+        if (
+            path in _UNAUTH_PATHS
+            or path.startswith("/.well-known/")
+            or path.startswith("/mcp/.well-known/")
+        ):
+            return
+        auth_header = ""
+        for name, value in scope.get("headers", []):
+            if name == b"authorization":
+                auth_header = value.decode("latin-1", "replace")
+                break
+        # auth_mode must be derived HERE from the header: this runs after
+        # BearerAuthMiddleware reset the inbound-auth ContextVar, so
+        # _build_event's per-request fallback would otherwise always be the
+        # settings value (never the rejected bearer). Shape-only — no token kept.
+        if auth_header:
+            auth_mode, _token = classify_bearer(auth_header)
+        else:
+            auth_mode = "api_key" if self._settings.opik_api_key else "none"
+        props = {
+            "rejection_reason": _classify_rejection_reason(status_code, auth_header),
+            "auth_mode": auth_mode,
+            "path_bucket": bucket_path(path, self._settings.opik_mcp_http_path),
+            "oauth_configured": boot_props.oauth_configured(self._settings),
+            "resource_metadata_url_present": str(
+                _has_absolute_resource_metadata_url(self._settings)
+            ).lower(),
+            # Env cohort so BI can separate CI/probe noise from real misconfigs.
+            **cached_call_context_env(),
+        }
+        track_event(EVENT_AUTH_REJECTED, props)
+
+
 # --- health endpoints ---------------------------------------------------- #
 
 
@@ -891,7 +1004,7 @@ def _make_composed_lifespan(
     return _composed
 
 
-def build_app() -> Starlette:
+def build_app() -> ASGIApp:
     install_tools_listed_emitter(mcp)
     s = get_settings()
     # Serve the transport at the configured path so it matches the advertised
@@ -942,4 +1055,8 @@ def build_app() -> Starlette:
     fingerprint_props = collect_environment_fingerprint() if will_emit else {}
     inner_lifespan = app.router.lifespan_context
     app.router.lifespan_context = _make_composed_lifespan(inner_lifespan, s, fingerprint_props)
-    return app
+
+    # Outermost wrapper: observe 401/421/403 and emit auth_rejected (GAP#3). Pure
+    # ASGI so streaming SSE is never buffered; the "lifespan" scope passes through
+    # to the Starlette app so the composed lifespan above still runs.
+    return AuthRejectionMiddleware(app, settings=s)

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -29,7 +29,12 @@ from opik_mcp.analytics.environment import cached_call_context_env, collect_envi
 from opik_mcp.analytics.events import bucket_count, bucket_path
 from opik_mcp.analytics.wrappers import install_tools_listed_emitter, instrument_tool
 from opik_mcp.ask_ollie import AskOllieResult, run_ask_ollie
-from opik_mcp.auth_context import classify_bearer, inbound_authorization, inbound_workspace
+from opik_mcp.auth_context import (
+    classify_bearer,
+    inbound_authorization,
+    inbound_workspace,
+    settings_auth_mode,
+)
 from opik_mcp.config import MissingConfigError, Settings, get_settings
 from opik_mcp.instructions import render_instructions
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
@@ -557,6 +562,21 @@ _UNAUTH_PATHS = (
     | frozenset(_PROXIED_OAUTH_PATHS.keys())
 )
 
+
+def _is_unauth_path(path: str) -> bool:
+    """Paths that bypass bearer auth: health, protected-resource metadata, the
+    OAuth-flow proxy paths, and the path-prefixed ``.well-known`` variants some
+    SDKs probe. Shared by ``BearerAuthMiddleware`` (skip the 401) and
+    ``AuthRejectionMiddleware`` (don't attribute a proxied-AS 401 as our
+    rejection) so the two can't drift.
+    """
+    return (
+        path in _UNAUTH_PATHS
+        or path.startswith("/.well-known/")
+        or path.startswith("/mcp/.well-known/")
+    )
+
+
 # Bounded total budget for the upstream reachability check used by
 # /health/ready. Probes run every 5-10s; a hung upstream must not stall the
 # probe past the probe's own timeout, or readiness flips to "unknown" instead
@@ -601,11 +621,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         # break the host's discovery chain; many SDKs probe path-prefixed
         # variants too (``/.well-known/foo/mcp``, ``/mcp/.well-known/foo``),
         # so we accept the whole prefix.
-        if (
-            path in _UNAUTH_PATHS
-            or path.startswith("/.well-known/")
-            or path.startswith("/mcp/.well-known/")
-        ):
+        if _is_unauth_path(path):
             return await call_next(request)
 
         auth = request.headers.get("authorization", "")
@@ -722,11 +738,7 @@ class AuthRejectionMiddleware:
 
     def _emit_rejection(self, scope: dict[str, Any], status_code: int) -> None:
         path = scope.get("path", "")
-        if (
-            path in _UNAUTH_PATHS
-            or path.startswith("/.well-known/")
-            or path.startswith("/mcp/.well-known/")
-        ):
+        if _is_unauth_path(path):
             return
         auth_header = ""
         for name, value in scope.get("headers", []):
@@ -740,7 +752,12 @@ class AuthRejectionMiddleware:
         if auth_header:
             auth_mode, _token = classify_bearer(auth_header)
         else:
-            auth_mode = "api_key" if self._settings.opik_api_key else "none"
+            # No credential: settings-derived mode (shared with auth_mode_at_boot
+            # so an OAuth-only deploy reports "oauth", not "none").
+            auth_mode = settings_auth_mode(
+                has_api_key=bool(self._settings.opik_api_key),
+                has_as_url=bool(self._settings.opik_mcp_as_url),
+            )
         props = {
             "rejection_reason": _classify_rejection_reason(status_code, auth_header),
             "auth_mode": auth_mode,
@@ -990,10 +1007,13 @@ def _make_composed_lifespan(
                     ),
                 )
                 # flush() blocks on threading.Event.wait — never block the event
-                # loop; offload the drain to the default executor.
+                # loop; offload the drain to the default executor. Capture the
+                # client now (not inside the thread) so a concurrent singleton
+                # swap can't redirect the flush to a different/closed client.
+                client = get_analytics()
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(
-                    None, lambda: get_analytics().flush(deadline_s=_LIFESPAN_FLUSH_DEADLINE_S)
+                    None, lambda: client.flush(deadline_s=_LIFESPAN_FLUSH_DEADLINE_S)
                 )
             except BaseException:
                 # Mirror __main__._emit_server_shutdown: a telemetry-side failure

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     break assertions keyed on ``route.calls.last``.
     """
     from opik_mcp.analytics import reset_analytics_for_tests, transport_probe
+    from opik_mcp.analytics.boot_props import LIFECYCLE_SENTINEL
     from opik_mcp.analytics.wrappers import (
         _reset_seen_sessions_for_tests,
         _reset_seen_tools_listed_for_tests,
@@ -47,11 +48,16 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     _reset_seen_sessions_for_tests()
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()
+    # main() sets this sentinel so the build_app() lifespan skips its own emit.
+    # Clear it between tests or a test that calls main() leaves the build_app()
+    # lifespan (e.g. the session http_client fixture) permanently muted.
+    os.environ.pop(LIFECYCLE_SENTINEL, None)
     yield
     reset_analytics_for_tests()
     _reset_seen_sessions_for_tests()
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()
+    os.environ.pop(LIFECYCLE_SENTINEL, None)
 
 
 # Session-scoped HTTP client over the real ASGI app. Shared across test

--- a/tests/test_analytics_auth_rejected.py
+++ b/tests/test_analytics_auth_rejected.py
@@ -29,7 +29,9 @@ class _Recorder:
 
 
 def _settings(**kwargs: object) -> Settings:
-    return Settings(opik_mcp_analytics_enabled=False, _env_file=None, **kwargs)  # type: ignore[arg-type]
+    base: dict[str, object] = {"opik_mcp_analytics_enabled": False, "_env_file": None}
+    base.update(kwargs)
+    return Settings(**base)  # type: ignore[arg-type]
 
 
 def _app_returning(status: int) -> Any:

--- a/tests/test_analytics_auth_rejected.py
+++ b/tests/test_analytics_auth_rejected.py
@@ -1,0 +1,227 @@
+"""Tests for AuthRejectionMiddleware — the opik_mcp_auth_rejected event (GAP#3).
+
+The middleware is pure ASGI (not BaseHTTPMiddleware) so it never buffers
+streaming SSE responses. It observes the response status and, for 401/421/403
+on AUTHENTICATED paths, emits an analytics event whose reason is derived from
+the Authorization header SHAPE only (never the token value).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from opik_mcp.config import Settings
+
+# Unique bearer token canary — must never appear raw in the emitted event.
+RAW_TOKEN_CANARY = "opik_at_AUTHREJECT-CANARY-TOKEN-3f9a2b1c"
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, str]]] = []
+
+    def track_event(self, et: str, props: dict[str, str]) -> None:
+        self.events.append((et, props))
+
+
+def _settings(**kwargs: object) -> Settings:
+    return Settings(opik_mcp_analytics_enabled=False, _env_file=None, **kwargs)  # type: ignore[arg-type]
+
+
+def _app_returning(status: int) -> Any:
+    async def app(scope: Any, receive: Any, send: Any) -> None:
+        await send({"type": "http.response.start", "status": status, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    return app
+
+
+def _drive(mw: Any, *, path: str = "/mcp", auth: bytes | None = None) -> None:
+    headers: list[tuple[bytes, bytes]] = []
+    if auth is not None:
+        headers.append((b"authorization", auth))
+    scope = {"type": "http", "path": path, "headers": headers}
+
+    async def receive() -> Any:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_msg: Any) -> None:
+        return None
+
+    asyncio.run(mw(scope, receive, send))
+
+
+def _make(
+    monkeypatch: pytest.MonkeyPatch, status: int, settings: Settings | None = None
+) -> tuple[_Recorder, Any]:
+    from opik_mcp import server
+
+    recorder = _Recorder()
+    monkeypatch.setattr("opik_mcp.server.track_event", lambda et, p: recorder.track_event(et, p))
+    mw = server.AuthRejectionMiddleware(_app_returning(status), settings=settings or _settings())
+    return recorder, mw
+
+
+def _only(recorder: _Recorder) -> dict[str, str]:
+    rejected = [p for et, p in recorder.events if et == "opik_mcp_auth_rejected"]
+    assert rejected, f"expected an auth_rejected event, got {recorder.events!r}"
+    return rejected[0]
+
+
+def test_missing_auth_header_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 401)
+    _drive(mw, path="/mcp", auth=None)
+    assert _only(recorder)["rejection_reason"] == "missing_header"
+
+
+def test_non_bearer_scheme_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 401)
+    _drive(mw, path="/mcp", auth=b"Basic dXNlcjpwYXNz")
+    assert _only(recorder)["rejection_reason"] == "not_bearer"
+
+
+def test_empty_bearer_token_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 401)
+    _drive(mw, path="/mcp", auth=b"Bearer    ")
+    assert _only(recorder)["rejection_reason"] == "empty_token"
+
+
+def test_421_is_host_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 421)
+    _drive(mw, path="/mcp", auth=b"Bearer opik_at_x")
+    assert _only(recorder)["rejection_reason"] == "host_rejected"
+
+
+def test_403_is_origin_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 403)
+    _drive(mw, path="/mcp", auth=b"Bearer opik_at_x")
+    assert _only(recorder)["rejection_reason"] == "origin_rejected"
+
+
+def test_success_emits_no_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 200)
+    _drive(mw, path="/mcp", auth=b"Bearer opik_at_x")
+    assert not [p for et, p in recorder.events if et == "opik_mcp_auth_rejected"]
+
+
+def test_unauth_path_rejection_is_not_ours(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A 401 proxied back from the AS during the OAuth dance (/authorize is an
+    # _UNAUTH_PATHS proxy path) is NOT opik-mcp's resource-server rejection —
+    # attributing it would pollute the auth-rejection chart.
+    recorder, mw = _make(monkeypatch, 401)
+    _drive(mw, path="/authorize", auth=None)
+    assert not [p for et, p in recorder.events if et == "opik_mcp_auth_rejected"]
+
+
+def test_health_path_rejection_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 403)
+    _drive(mw, path="/health", auth=None)
+    assert not [p for et, p in recorder.events if et == "opik_mcp_auth_rejected"]
+
+
+def test_raw_token_never_in_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 401)
+    _drive(mw, path="/mcp", auth=f"Bearer {RAW_TOKEN_CANARY}".encode())
+    props = _only(recorder)
+    assert RAW_TOKEN_CANARY not in json.dumps(props)
+    # A non-empty non-... wait: a valid-looking bearer that still 401s is an
+    # unexpected shape; reason falls back to missing_header (never leaks token).
+    assert props["rejection_reason"] in {
+        "missing_header",
+        "not_bearer",
+        "empty_token",
+        "token_rejected",
+        "host_rejected",
+        "origin_rejected",
+    }
+
+
+def test_path_bucket_and_allowlisted_props(monkeypatch: pytest.MonkeyPatch) -> None:
+    from typing import get_args
+
+    from opik_mcp.analytics.events import AuthRejectionReason, PathBucket
+
+    recorder, mw = _make(monkeypatch, 401)
+    _drive(mw, path="/mcp", auth=None)
+    props = _only(recorder)
+    assert props["path_bucket"] in get_args(PathBucket)
+    assert props["path_bucket"] == "mcp"
+    assert props["rejection_reason"] in get_args(AuthRejectionReason)
+    assert props["oauth_configured"] in {"true", "false"}
+    assert props["resource_metadata_url_present"] in {"true", "false"}
+
+
+def test_resource_metadata_url_present_reflects_absolute_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(opik_mcp_resource_uri="https://www.comet.com/api/v1/mcp")
+    recorder, mw = _make(monkeypatch, 401, settings=settings)
+    _drive(mw, path="/mcp", auth=None)
+    assert _only(recorder)["resource_metadata_url_present"] == "true"
+
+
+def test_resource_metadata_url_absent_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder, mw = _make(monkeypatch, 401, settings=_settings(opik_mcp_resource_uri=None))
+    _drive(mw, path="/mcp", auth=None)
+    assert _only(recorder)["resource_metadata_url_present"] == "false"
+
+
+def test_auth_mode_reflects_rejected_oauth_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A valid OAuth bearer rejected by the Host guard (421) must still report
+    # auth_mode="oauth" — derived from the header, NOT the already-reset
+    # ContextVar (which would yield the settings fallback).
+    recorder, mw = _make(monkeypatch, 421)
+    _drive(mw, path="/mcp", auth=b"Bearer opik_at_valid-token")
+    props = _only(recorder)
+    assert props["rejection_reason"] == "host_rejected"
+    assert props["auth_mode"] == "oauth"
+
+
+def test_app_exception_propagates_without_emitting(monkeypatch: pytest.MonkeyPatch) -> None:
+    # If the inner app raises before sending a response, the exception must
+    # propagate and no auth_rejected event is emitted.
+    from opik_mcp import server
+
+    recorder = _Recorder()
+    monkeypatch.setattr("opik_mcp.server.track_event", lambda et, p: recorder.track_event(et, p))
+
+    async def _boom(scope: Any, receive: Any, send: Any) -> None:
+        raise RuntimeError("inner app blew up")
+
+    mw = server.AuthRejectionMiddleware(_boom, settings=_settings())
+    with pytest.raises(RuntimeError):
+        _drive(mw, path="/mcp", auth=None)
+    assert not recorder.events
+
+
+def test_path_bucket_honours_custom_http_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The configured MCP mount must be threaded through to bucket_path.
+    recorder, mw = _make(monkeypatch, 401, settings=_settings(opik_mcp_http_path="/api/v1/mcp"))
+    _drive(mw, path="/api/v1/mcp", auth=None)
+    assert _only(recorder)["path_bucket"] == "mcp"
+
+
+def test_lifespan_scope_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Non-http scopes (lifespan/websocket) must pass straight through so the
+    # composed lifespan still runs when AuthRejectionMiddleware is outermost.
+    from opik_mcp import server
+
+    seen: list[str] = []
+
+    async def inner(scope: Any, receive: Any, send: Any) -> None:
+        seen.append(scope["type"])
+
+    mw = server.AuthRejectionMiddleware(inner, settings=_settings())
+
+    async def receive() -> Any:
+        return {"type": "lifespan.startup"}
+
+    async def send(_msg: Any) -> None:
+        return None
+
+    asyncio.run(mw({"type": "lifespan"}, receive, send))
+    assert seen == ["lifespan"]

--- a/tests/test_analytics_auth_rejected.py
+++ b/tests/test_analytics_auth_rejected.py
@@ -183,6 +183,17 @@ def test_auth_mode_reflects_rejected_oauth_bearer(monkeypatch: pytest.MonkeyPatc
     assert props["auth_mode"] == "oauth"
 
 
+def test_oauth_only_deploy_missing_header_reports_oauth(monkeypatch: pytest.MonkeyPatch) -> None:
+    # OAuth-only deploy (AS configured, no static key): a no-credential rejection
+    # reports auth_mode="oauth" (settings-derived), consistent with boot/per-call.
+    settings = _settings(opik_api_key=None, opik_mcp_as_url="https://as.example.com")
+    recorder, mw = _make(monkeypatch, 401, settings=settings)
+    _drive(mw, path="/mcp", auth=None)
+    props = _only(recorder)
+    assert props["rejection_reason"] == "missing_header"
+    assert props["auth_mode"] == "oauth"
+
+
 def test_app_exception_propagates_without_emitting(monkeypatch: pytest.MonkeyPatch) -> None:
     # If the inner app raises before sending a response, the exception must
     # propagate and no auth_rejected event is emitted.

--- a/tests/test_analytics_boot_props.py
+++ b/tests/test_analytics_boot_props.py
@@ -121,23 +121,31 @@ def test_collect_boot_props_keys_and_literal_membership() -> None:
         opik_mcp_resource_uri="https://www.comet.com/api/v1/mcp",
     )
     props = boot_props.collect_boot_props(s)
+    # installation_type is intentionally NOT here — _build_event's common block
+    # is its single source of truth (stamped on every event).
     assert set(props) == {
-        "installation_type",
         "oauth_configured",
         "resource_uri_scheme",
         "dns_rebinding_protection",
         "allowed_hosts_is_default",
         "auth_mode",
     }
-    assert props["installation_type"] in get_args(InstallationType)
     assert props["auth_mode"] in get_args(AuthMode)
     assert props["resource_uri_scheme"] in get_args(ResourceUriScheme)
     for key in ("oauth_configured", "dns_rebinding_protection", "allowed_hosts_is_default"):
         assert props[key] in {"true", "false"}
 
 
-def test_collect_boot_props_self_hosted_hyphen_end_to_end() -> None:
-    # The hyphen-vs-underscore contract is the highest-stakes invariant here;
-    # pin it end-to-end through collect_boot_props (not just installation_type).
-    props = boot_props.collect_boot_props(_settings(opik_url="https://opik.acme.internal"))
-    assert props["installation_type"] == "self-hosted"
+def test_installation_type_self_hosted_hyphen() -> None:
+    # The hyphen-vs-underscore contract is the highest-stakes invariant here.
+    result = boot_props.installation_type(_settings(opik_url="https://opik.acme.internal"))
+    assert result == "self-hosted"
+    assert result in get_args(InstallationType)
+
+
+def test_lifecycle_sentinel_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Pins the contract the build_app() lifespan (Phase 4) depends on.
+    monkeypatch.delenv(boot_props.LIFECYCLE_SENTINEL, raising=False)
+    assert boot_props.lifecycle_owned_by_main() is False
+    boot_props.mark_lifecycle_owned_by_main()
+    assert boot_props.lifecycle_owned_by_main() is True

--- a/tests/test_analytics_boot_props.py
+++ b/tests/test_analytics_boot_props.py
@@ -1,0 +1,143 @@
+"""Unit tests for analytics/boot_props.py — settings-derived boot properties.
+
+Pure functions over a ``Settings`` instance: deterministic because init kwargs
+win over env in pydantic-settings, and ``_env_file=None`` disables dotenv. The
+single source of truth for the new server_started / startup_error / auth_rejected
+properties, called identically from __main__.main() and the build_app() lifespan.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from opik_mcp.analytics import boot_props
+from opik_mcp.analytics.events import AuthMode, InstallationType, ResourceUriScheme
+from opik_mcp.config import Settings
+
+
+def _settings(**kwargs: object) -> Settings:
+    # _env_file=None: ignore any developer .env so these stay deterministic.
+    return Settings(_env_file=None, **kwargs)  # type: ignore[call-arg]
+
+
+def test_default_allowed_hosts_schema_parity() -> None:
+    # Read the schema default (NOT Settings() — that would pick up env overrides
+    # and make the constant track a live instance instead of the declared default).
+    assert (
+        Settings.model_fields["opik_mcp_allowed_hosts"].default
+        == boot_props._DEFAULT_ALLOWED_HOSTS
+    )
+
+
+def test_installation_type_self_hosted_uses_hyphen() -> None:
+    result = boot_props.installation_type(_settings(opik_url="https://opik.acme.internal"))
+    # Canonical value is "self-hosted" (hyphen) to match error_tracking; an
+    # underscore here would silently break BI filters built against the Sentry tag.
+    assert result == "self-hosted"
+    assert "_" not in result
+
+
+def test_installation_type_cloud() -> None:
+    s = _settings(opik_url=None, comet_url_override="https://www.comet.com")
+    assert boot_props.installation_type(s) == "cloud"
+
+
+def test_installation_type_local() -> None:
+    assert boot_props.installation_type(_settings(opik_url="http://localhost:5173")) == "local"
+
+
+@pytest.mark.parametrize(
+    "uri, expected",
+    [
+        ("https://www.comet.com/api/v1/mcp", "https"),
+        ("http://localhost:8080/mcp", "http"),
+        (None, "none"),
+        ("", "none"),
+        ("ftp://example.com", "none"),
+        # Scheme-less value: TLS is assumed for a public ingress, so it reports https.
+        ("www.comet.com/api/v1/mcp", "https"),
+    ],
+)
+def test_resource_uri_scheme(uri: str | None, expected: str) -> None:
+    assert boot_props.resource_uri_scheme(_settings(opik_mcp_resource_uri=uri)) == expected
+
+
+def test_auth_mode_at_boot_api_key_wins_over_oauth() -> None:
+    s = _settings(opik_api_key="sk-x", opik_mcp_as_url="https://as.example.com")
+    assert boot_props.auth_mode_at_boot(s) == "api_key"
+
+
+def test_auth_mode_at_boot_oauth_when_only_as_url() -> None:
+    s = _settings(opik_api_key=None, opik_mcp_as_url="https://as.example.com")
+    assert boot_props.auth_mode_at_boot(s) == "oauth"
+
+
+def test_auth_mode_at_boot_none_when_neither() -> None:
+    s = _settings(opik_api_key=None, opik_mcp_as_url=None)
+    assert boot_props.auth_mode_at_boot(s) == "none"
+
+
+def test_allowed_hosts_is_default_true_for_shipped_default() -> None:
+    assert boot_props.allowed_hosts_is_default(_settings()) == "true"
+
+
+def test_allowed_hosts_is_default_false_for_custom() -> None:
+    s = _settings(opik_mcp_allowed_hosts="www.comet.com,www.comet.com:*")
+    assert boot_props.allowed_hosts_is_default(s) == "false"
+
+
+def test_allowed_hosts_is_default_tolerates_spaces() -> None:
+    # Whitespace around entries is cosmetic; an operator who pasted the default
+    # with spaces still counts as "default" (not a deliberate hardening).
+    s = _settings(opik_mcp_allowed_hosts="127.0.0.1:* , localhost:* , [::1]:*")
+    assert boot_props.allowed_hosts_is_default(s) == "true"
+
+
+def test_oauth_configured_bool_strings() -> None:
+    assert boot_props.oauth_configured(_settings(opik_mcp_as_url="https://as")) == "true"
+    assert boot_props.oauth_configured(_settings(opik_mcp_as_url=None)) == "false"
+
+
+def test_dns_rebinding_protection_bool_string() -> None:
+    on = _settings(opik_mcp_dns_rebinding_protection=True)
+    off = _settings(opik_mcp_dns_rebinding_protection=False)
+    assert boot_props.dns_rebinding_protection(on) == "true"
+    assert boot_props.dns_rebinding_protection(off) == "false"
+
+
+def test_oauth_configured_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPIK_MCP_AS_URL", raising=False)
+    assert boot_props.oauth_configured_from_env() == "false"
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://as.example.com")
+    assert boot_props.oauth_configured_from_env() == "true"
+
+
+def test_collect_boot_props_keys_and_literal_membership() -> None:
+    s = _settings(
+        opik_api_key="sk",
+        opik_mcp_as_url="https://as",
+        opik_mcp_resource_uri="https://www.comet.com/api/v1/mcp",
+    )
+    props = boot_props.collect_boot_props(s)
+    assert set(props) == {
+        "installation_type",
+        "oauth_configured",
+        "resource_uri_scheme",
+        "dns_rebinding_protection",
+        "allowed_hosts_is_default",
+        "auth_mode",
+    }
+    assert props["installation_type"] in get_args(InstallationType)
+    assert props["auth_mode"] in get_args(AuthMode)
+    assert props["resource_uri_scheme"] in get_args(ResourceUriScheme)
+    for key in ("oauth_configured", "dns_rebinding_protection", "allowed_hosts_is_default"):
+        assert props[key] in {"true", "false"}
+
+
+def test_collect_boot_props_self_hosted_hyphen_end_to_end() -> None:
+    # The hyphen-vs-underscore contract is the highest-stakes invariant here;
+    # pin it end-to-end through collect_boot_props (not just installation_type).
+    props = boot_props.collect_boot_props(_settings(opik_url="https://opik.acme.internal"))
+    assert props["installation_type"] == "self-hosted"

--- a/tests/test_analytics_boot_props.py
+++ b/tests/test_analytics_boot_props.py
@@ -19,15 +19,16 @@ from opik_mcp.config import Settings
 
 def _settings(**kwargs: object) -> Settings:
     # _env_file=None: ignore any developer .env so these stay deterministic.
-    return Settings(_env_file=None, **kwargs)  # type: ignore[call-arg]
+    base: dict[str, object] = {"_env_file": None}
+    base.update(kwargs)
+    return Settings(**base)  # type: ignore[arg-type]
 
 
 def test_default_allowed_hosts_schema_parity() -> None:
     # Read the schema default (NOT Settings() — that would pick up env overrides
     # and make the constant track a live instance instead of the declared default).
     assert (
-        Settings.model_fields["opik_mcp_allowed_hosts"].default
-        == boot_props._DEFAULT_ALLOWED_HOSTS
+        Settings.model_fields["opik_mcp_allowed_hosts"].default == boot_props._DEFAULT_ALLOWED_HOSTS
     )
 
 

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -160,3 +160,19 @@ def test_installation_type_in_common_block(make_client: Any) -> None:
     client = make_client()
     props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
     assert props["installation_type"] in get_args(InstallationType)
+
+
+def test_oauth_only_deploy_reports_oauth_when_no_inbound_credential(make_client: Any) -> None:
+    # OAuth-only deploy (AS configured, no static key): a per-call event with no
+    # inbound bearer must report auth_mode="oauth" (settings-derived), matching
+    # auth_mode_at_boot — NOT the old 2-way "none" fallback.
+    client = make_client(opik_api_key=None, opik_mcp_as_url="https://as.example.com")
+    props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    assert props["auth_mode"] == "oauth"
+
+
+def test_transport_lowercased_in_common_block(make_client: Any) -> None:
+    # A mixed-case OPIK_MCP_TRANSPORT must still emit a canonical lowercase value.
+    client = make_client(opik_mcp_transport="HTTP")
+    props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    assert props["transport"] == "http"

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -1,0 +1,162 @@
+"""Direct unit tests for AnalyticsClient._build_event() per-request enrichment.
+
+These call ``_build_event`` directly on a real (analytics-disabled, no worker)
+client. This is the ONLY layer that can catch a raw-value leak INSIDE
+``_build_event`` — the recorder-based tests in test_analytics_privacy.py
+intercept at ``track_event`` and never see what ``_build_event`` builds.
+
+``_build_event`` runs synchronously in the calling task (track_event builds then
+enqueues), so the auth_context ContextVars are live at build time — that is what
+lets per-request OAuth identity reach BI in hosted mode.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+from collections.abc import Iterator
+from typing import Any, get_args
+
+import pytest
+
+from opik_mcp.analytics.client import AnalyticsClient
+from opik_mcp.auth_context import inbound_authorization, inbound_workspace
+from opik_mcp.config import Settings
+
+# Canaries: unique, greppable values that must never appear raw in an event.
+RAW_OAUTH_TOKEN = "opik_at_BEARER-CANARY-TOKEN-UNIQUE-7a3b2c1d"
+RAW_WORKSPACE = "WORKSPACE-CANARY-NAME-MUST-NOT-LEAK-9f4e5a6b"
+
+
+@pytest.fixture
+def make_client() -> Iterator[Any]:
+    created: list[AnalyticsClient] = []
+
+    def _make(**kwargs: object) -> AnalyticsClient:
+        # Pin auth-relevant fields to deterministic defaults (init kwargs win over
+        # the developer's OPIK_API_KEY/OPIK_MCP_AS_URL env); a test overrides them
+        # explicitly when it needs a key/AS set. analytics_enabled=False => no
+        # worker thread; _build_event is pure.
+        base: dict[str, object] = {
+            "opik_mcp_analytics_enabled": False,
+            "opik_api_key": None,
+            "opik_mcp_as_url": None,
+            "_env_file": None,
+        }
+        base.update(kwargs)
+        client = AnalyticsClient(Settings(**base))  # type: ignore[arg-type]
+        created.append(client)
+        return client
+
+    yield _make
+    for client in created:
+        client.close()
+
+
+@contextlib.contextmanager
+def _inbound(*, auth: str | None = None, workspace: str | None = None) -> Iterator[None]:
+    a = inbound_authorization.set(auth)
+    w = inbound_workspace.set(workspace)
+    try:
+        yield
+    finally:
+        inbound_authorization.reset(a)
+        inbound_workspace.reset(w)
+
+
+def test_oauth_token_sha256_hashed_not_raw(make_client: Any) -> None:
+    client = make_client()
+    with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}"):
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    props = event["event_properties"]
+    assert RAW_OAUTH_TOKEN not in json.dumps(event)  # raw token never leaves the process
+    assert props["auth_mode"] == "oauth"
+    assert props["token_sha256"] == hashlib.sha256(RAW_OAUTH_TOKEN.encode("utf-8")).hexdigest()
+
+
+def test_non_oauth_bearer_is_api_key_mode_without_token_hash(make_client: Any) -> None:
+    client = make_client()
+    with _inbound(auth="Bearer some-non-oauth-static-key"):
+        props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    assert props["auth_mode"] == "api_key"
+    assert "token_sha256" not in props  # only opik_at_ bearers are hashed
+
+
+def test_request_workspace_plaintext_present(make_client: Any) -> None:
+    client = make_client()
+    with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}", workspace=RAW_WORKSPACE):
+        props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    # Plaintext by design — matches the existing settings `workspace` posture
+    # (workspace names are used as user_id in resolve_anonymous_id).
+    assert props["request_workspace"] == RAW_WORKSPACE
+
+
+def test_three_tier_merge_properties_wins_over_per_request(make_client: Any) -> None:
+    client = make_client()
+    with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}"):
+        # A caller that supplies auth_mode in `properties` (e.g. server_started
+        # spreading collect_boot_props in Phase 3) must win over the
+        # contextvar-derived value, while token_sha256 (only in
+        # _per_request_props) still rides along.
+        props = client._build_event(
+            "opik_mcp_server_started", {"auth_mode": "api_key"}
+        )["event_properties"]
+    assert props["auth_mode"] == "api_key"
+    assert props["token_sha256"] == hashlib.sha256(RAW_OAUTH_TOKEN.encode("utf-8")).hexdigest()
+
+
+def test_common_block_still_wins_over_per_request(make_client: Any) -> None:
+    # The common block is authoritative for its keys; a stray per-request key
+    # must never shadow it. transport is a common key.
+    client = make_client(opik_mcp_transport="http")
+    with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}"):
+        props = client._build_event("opik_mcp_tool_called", {"transport": "stdio"})[
+            "event_properties"
+        ]
+    assert props["transport"] == "http"  # common wins over caller properties
+
+
+def test_no_per_request_fields_outside_request_context(make_client: Any) -> None:
+    client = make_client()
+    props = client._build_event("opik_mcp_server_started", {})["event_properties"]
+    assert "token_sha256" not in props
+    assert "request_workspace" not in props
+    assert props["auth_mode"] == "none"  # settings-derived fallback, no env key
+
+
+def test_stdio_auth_mode_api_key_when_env_key_set(make_client: Any) -> None:
+    client = make_client(opik_api_key="sk-test")
+    props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    assert props["auth_mode"] == "api_key"
+    assert "token_sha256" not in props  # env key is hashed as api_key_sha256, not token
+
+
+def test_empty_bearer_is_api_key_without_token_hash(make_client: Any) -> None:
+    # An inbound bearer with an empty token is a (malformed) forwarded
+    # credential -> api_key, never hashed. (In production BearerAuthMiddleware
+    # 401s this before a tool runs; this just pins the enrichment is safe.)
+    client = make_client()
+    with _inbound(auth="Bearer    "):  # whitespace-only token
+        props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    assert props["auth_mode"] == "api_key"
+    assert "token_sha256" not in props
+
+
+def test_oauth_token_extraction_matches_resolve_opik_config(make_client: Any) -> None:
+    # Odd whitespace between scheme and token must still hash the same token
+    # resolve_opik_config identifies (partition(" ") + lstrip), so token_sha256
+    # stays a consistent BI join key.
+    client = make_client()
+    with _inbound(auth=f"Bearer  {RAW_OAUTH_TOKEN}"):  # two spaces
+        props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    assert props["auth_mode"] == "oauth"
+    assert props["token_sha256"] == hashlib.sha256(RAW_OAUTH_TOKEN.encode("utf-8")).hexdigest()
+
+
+def test_installation_type_in_common_block(make_client: Any) -> None:
+    from opik_mcp.analytics.events import InstallationType
+
+    client = make_client()
+    props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
+    assert props["installation_type"] in get_args(InstallationType)

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -99,9 +99,9 @@ def test_three_tier_merge_properties_wins_over_per_request(make_client: Any) -> 
         # spreading collect_boot_props in Phase 3) must win over the
         # contextvar-derived value, while token_sha256 (only in
         # _per_request_props) still rides along.
-        props = client._build_event(
-            "opik_mcp_server_started", {"auth_mode": "api_key"}
-        )["event_properties"]
+        props = client._build_event("opik_mcp_server_started", {"auth_mode": "api_key"})[
+            "event_properties"
+        ]
     assert props["auth_mode"] == "api_key"
     assert props["token_sha256"] == hashlib.sha256(RAW_OAUTH_TOKEN.encode("utf-8")).hexdigest()
 

--- a/tests/test_analytics_events.py
+++ b/tests/test_analytics_events.py
@@ -124,3 +124,67 @@ def test_host_llm_family_literal_covers_all_classifier_values() -> None:
     produced.add(classify_host_llm_family("unmapped-bucket"))  # -> "unknown" fallback
     missing = produced - allowed
     assert not missing, f"HostLlmFamily Literal missing classifier values: {sorted(missing)}"
+
+
+# --- auth_rejected event constant + path bucketing (GAP#3 foundation) ----- #
+
+
+def test_auth_rejected_event_name() -> None:
+    # Wire-shape contract: the receiver and dashboards key off this literal
+    # string, so a rename is a breaking BI change. Imported via the package
+    # surface to also pin that it's exported from analytics/__init__.
+    from opik_mcp.analytics import EVENT_AUTH_REJECTED
+
+    assert EVENT_AUTH_REJECTED == "opik_mcp_auth_rejected"
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("/mcp", "mcp"),
+        ("/mcp/", "mcp"),
+        ("/mcp/messages", "mcp"),
+        ("/health", "health"),
+        ("/health/ready", "health"),
+        ("/.well-known/oauth-protected-resource", "well_known"),
+        ("/.well-known/oauth-authorization-server", "well_known"),
+        ("/authorize", "other"),
+        ("/register", "other"),
+        ("/", "other"),
+        ("", "other"),
+        # Sibling paths must NOT collide with the real endpoints (exact-or-subpath).
+        ("/mcpfoo", "other"),
+        ("/healthz", "other"),
+        ("/.well-knownfoo", "other"),
+    ],
+)
+def test_bucket_path(path: str, expected: str) -> None:
+    from opik_mcp.analytics.events import bucket_path
+
+    assert bucket_path(path) == expected
+
+
+def test_bucket_path_respects_custom_mcp_path() -> None:
+    # The MCP transport path is configurable (OPIK_MCP_HTTP_PATH). A request to
+    # the configured path buckets to "mcp"; the hardcoded "/mcp" default must
+    # NOT match when the operator has remapped it.
+    from opik_mcp.analytics.events import bucket_path
+
+    assert bucket_path("/api/v1/mcp", mcp_http_path="/api/v1/mcp") == "mcp"
+    assert bucket_path("/mcp", mcp_http_path="/api/v1/mcp") == "other"
+
+
+def test_path_bucket_literal_matches_bucket_path_outputs() -> None:
+    # bucket_path never emits a raw path — only these four buckets — and the
+    # PathBucket Literal must declare exactly them (privacy + BI contract).
+    from typing import get_args
+
+    from opik_mcp.analytics.events import PathBucket, bucket_path
+
+    allowed = set(get_args(PathBucket))
+    assert allowed == {"mcp", "health", "well_known", "other"}
+    # Samples chosen to exercise every bucket, so this is a bidirectional check:
+    # the Literal declares exactly what bucket_path can produce (no dead buckets,
+    # no undeclared outputs).
+    samples = ["/mcp", "/health", "/.well-known/x", "/anything-else", ""]
+    assert {bucket_path(p) for p in samples} == allowed

--- a/tests/test_analytics_events.py
+++ b/tests/test_analytics_events.py
@@ -78,3 +78,49 @@ def test_bucket_seconds(elapsed: float, expected: str) -> None:
     from opik_mcp.analytics.events import bucket_seconds
 
     assert bucket_seconds(elapsed) == expected
+
+
+# --- allowlist <-> classifier sync (privacy contract, events.py:7-19) ----- #
+
+
+def test_mcp_host_literal_covers_all_classifier_buckets() -> None:
+    """Every value ``classify_mcp_host`` can return must be a declared McpHost.
+
+    events.py promises the allowlist stays in sync with the classifier in
+    mcp_client_info.py. Drift means a real bucket value (e.g. ``"codex"``)
+    ships in BI without being declared in the privacy allowlist.
+
+    Drives the classifier FUNCTION (not just the pattern table) so the test
+    also pins the hardcoded ``"other"`` fallback — renaming it without updating
+    the Literal would otherwise pass silently.
+    """
+    from typing import get_args
+
+    from opik_mcp.analytics.events import McpHost
+    from opik_mcp.analytics.mcp_client_info import _MCP_HOST_PATTERNS, classify_mcp_host
+
+    allowed = set(get_args(McpHost))
+    produced = {classify_mcp_host(pattern) for pattern, _bucket in _MCP_HOST_PATTERNS}
+    produced.add(classify_mcp_host(""))  # empty clientInfo.name -> fallback
+    produced.add(classify_mcp_host("totally-unrecognized-host"))  # no match -> fallback
+    missing = produced - allowed
+    assert not missing, f"McpHost Literal missing classifier values: {sorted(missing)}"
+
+
+def test_host_llm_family_literal_covers_all_classifier_values() -> None:
+    """Every value ``classify_host_llm_family`` can return must be a declared
+    HostLlmFamily value (same sync contract as McpHost).
+
+    The classifier's only inputs are McpHost buckets, so we drive it over every
+    declared McpHost value plus an unmapped one to pin the ``"unknown"`` fallback.
+    """
+    from typing import get_args
+
+    from opik_mcp.analytics.events import HostLlmFamily, McpHost
+    from opik_mcp.analytics.mcp_client_info import classify_host_llm_family
+
+    allowed = set(get_args(HostLlmFamily))
+    produced = {classify_host_llm_family(host) for host in get_args(McpHost)}
+    produced.add(classify_host_llm_family("unmapped-bucket"))  # -> "unknown" fallback
+    missing = produced - allowed
+    assert not missing, f"HostLlmFamily Literal missing classifier values: {sorted(missing)}"

--- a/tests/test_analytics_lifespan.py
+++ b/tests/test_analytics_lifespan.py
@@ -128,6 +128,106 @@ def test_transport_crash_emits_shutdown_with_reason_transport_error(
     assert props["reason"] == "transport_error"
 
 
+# Boot props that __main__ spreads explicitly into server_started's properties
+# dict (so they appear in the recorder, which bypasses _build_event). Note:
+# installation_type is NOT here — it comes from _build_event's common block,
+# which the recorder bypasses; its on-every-event presence is covered by
+# tests/test_analytics_client_build_event.py::test_installation_type_in_common_block.
+_BOOT_PROP_KEYS = (
+    "oauth_configured",
+    "resource_uri_scheme",
+    "dns_rebinding_protection",
+    "allowed_hosts_is_default",
+    "auth_mode",
+)
+
+
+def test_server_started_carries_lifecycle_source_main_and_boot_props(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from typing import get_args
+
+    from opik_mcp.analytics.events import AuthMode, ResourceUriScheme
+
+    recorder = _install_recorder(monkeypatch)
+
+    class _StubMcp:
+        def run(self, *, transport: str) -> None:
+            return None
+
+    monkeypatch.setattr("opik_mcp.server.mcp", _StubMcp())
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+
+    main_mod.main()
+
+    started = next(p for et, p in recorder.events if et == EVENT_SERVER_STARTED)
+    assert started["lifecycle_source"] == "main"
+    for key in _BOOT_PROP_KEYS:
+        assert key in started, f"server_started missing boot prop {key!r}"
+    assert started["auth_mode"] in get_args(AuthMode)
+    assert started["resource_uri_scheme"] in get_args(ResourceUriScheme)
+
+
+def test_server_shutdown_carries_lifecycle_source_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _install_recorder(monkeypatch)
+
+    class _StubMcp:
+        def run(self, *, transport: str) -> None:
+            return None
+
+    monkeypatch.setattr("opik_mcp.server.mcp", _StubMcp())
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+
+    main_mod.main()
+
+    props = next(p for et, p in recorder.events if et == EVENT_SERVER_SHUTDOWN)
+    assert props["lifecycle_source"] == "main"
+
+
+def test_server_started_pure_oauth_reports_auth_mode_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pure-OAuth deployment (AS configured, no static key): server_started must
+    report auth_mode='oauth' from collect_boot_props — NOT the contextvar
+    fallback 'none' (there is no request in flight at boot)."""
+    recorder = _install_recorder(monkeypatch)
+
+    class _StubMcp:
+        def run(self, *, transport: str) -> None:
+            return None
+
+    monkeypatch.setattr("opik_mcp.server.mcp", _StubMcp())
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+    monkeypatch.delenv("OPIK_API_KEY", raising=False)
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://as.example.com")
+
+    main_mod.main()
+
+    started = next(p for et, p in recorder.events if et == EVENT_SERVER_STARTED)
+    assert started["auth_mode"] == "oauth"
+
+
+def test_transport_crash_startup_error_carries_oauth_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = _install_recorder(monkeypatch)
+
+    class _BoomMcp:
+        def run(self, *, transport: str) -> None:
+            raise OSError("address already in use")
+
+    monkeypatch.setattr("opik_mcp.server.mcp", _BoomMcp())
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "stdio")
+
+    with pytest.raises(OSError):
+        main_mod.main()
+
+    props = next(p for et, p in recorder.events if et == EVENT_STARTUP_ERROR)
+    # oauth_configured is passed explicitly (recorder bypasses common);
+    # installation_type rides on the common block (see _build_event tests).
+    assert props["oauth_configured"] in {"true", "false"}
+
+
 def test_sys_exit_emits_shutdown_with_reason_sys_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     """sys.exit() inside the transport path must still record shutdown.
 

--- a/tests/test_analytics_lifespan.py
+++ b/tests/test_analytics_lifespan.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
 
 import pytest
 
@@ -13,6 +16,23 @@ from opik_mcp.analytics import (
     EVENT_STARTUP_ERROR,
     transport_probe,
 )
+
+
+@contextlib.asynccontextmanager
+async def _noop_inner(app: Any) -> AsyncIterator[None]:
+    """Stand-in for FastMCP's session_manager.run() — never touches the
+    process-wide StreamableHTTPSessionManager singleton (which may only run once),
+    so these tests must NOT call build_app()."""
+    yield
+
+
+def _install_server_recorder(monkeypatch: pytest.MonkeyPatch) -> _RecorderClient:
+    """Redirect the analytics calls the build_app() lifespan makes (it uses the
+    module-level track_event / get_analytics in opik_mcp.server)."""
+    r = _RecorderClient()
+    monkeypatch.setattr("opik_mcp.server.track_event", lambda et, p: r.track_event(et, p))
+    monkeypatch.setattr("opik_mcp.server.get_analytics", lambda: r)
+    return r
 
 
 class _RecorderClient:
@@ -251,3 +271,113 @@ def test_sys_exit_emits_shutdown_with_reason_sys_exit(monkeypatch: pytest.Monkey
     assert props["reason"] == "sys_exit"
     # SystemExit is a deliberate exit, not a crash — startup_error must not fire.
     assert EVENT_STARTUP_ERROR not in [et for et, _ in recorder.events]
+
+
+# --- build_app() composed lifespan (GAP#1: hosted --factory boot) --------- #
+
+
+def test_lifespan_emits_started_and_shutdown_when_not_owned_by_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+
+    from opik_mcp import server
+    from opik_mcp.analytics.boot_props import LIFECYCLE_SENTINEL
+    from opik_mcp.config import get_settings
+
+    monkeypatch.delenv(LIFECYCLE_SENTINEL, raising=False)
+    recorder = _install_server_recorder(monkeypatch)
+    settings = get_settings()
+
+    composed = server._make_composed_lifespan(_noop_inner, settings, {})
+
+    async def _drive() -> None:
+        async with composed(None):
+            pass
+
+    asyncio.run(_drive())
+
+    ets = [et for et, _ in recorder.events]
+    assert EVENT_SERVER_STARTED in ets
+    assert EVENT_SERVER_SHUTDOWN in ets
+    started = next(p for et, p in recorder.events if et == EVENT_SERVER_STARTED)
+    assert started["lifecycle_source"] == "lifespan"
+    shut = next(p for et, p in recorder.events if et == EVENT_SERVER_SHUTDOWN)
+    assert shut["lifecycle_source"] == "lifespan"
+    assert shut["reason"] == "clean_exit"
+    # flush must be drained off the event loop on shutdown.
+    assert recorder.flush_calls
+
+
+def test_lifespan_skips_emit_when_owned_by_main(monkeypatch: pytest.MonkeyPatch) -> None:
+
+    from opik_mcp import server
+    from opik_mcp.analytics.boot_props import LIFECYCLE_SENTINEL
+    from opik_mcp.config import get_settings
+
+    monkeypatch.setenv(LIFECYCLE_SENTINEL, "1")
+    recorder = _install_server_recorder(monkeypatch)
+    settings = get_settings()
+
+    composed = server._make_composed_lifespan(_noop_inner, settings, {})
+
+    async def _drive() -> None:
+        async with composed(None):
+            pass
+
+    asyncio.run(_drive())
+
+    ets = [et for et, _ in recorder.events]
+    assert EVENT_SERVER_STARTED not in ets
+    assert EVENT_SERVER_SHUTDOWN not in ets
+
+
+def test_lifespan_shutdown_reason_transport_error_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+
+    from opik_mcp import server
+    from opik_mcp.analytics.boot_props import LIFECYCLE_SENTINEL
+    from opik_mcp.config import get_settings
+
+    monkeypatch.delenv(LIFECYCLE_SENTINEL, raising=False)
+    recorder = _install_server_recorder(monkeypatch)
+    settings = get_settings()
+
+    composed = server._make_composed_lifespan(_noop_inner, settings, {})
+
+    async def _drive() -> None:
+        async with composed(None):
+            raise RuntimeError("simulated transport crash")
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(_drive())
+
+    shut = next(p for et, p in recorder.events if et == EVENT_SERVER_SHUTDOWN)
+    assert shut["reason"] == "transport_error"
+    assert shut["lifecycle_source"] == "lifespan"
+
+
+def test_lifespan_started_pure_oauth_reports_auth_mode_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+
+    from opik_mcp import server
+    from opik_mcp.analytics.boot_props import LIFECYCLE_SENTINEL
+    from opik_mcp.config import get_settings
+
+    monkeypatch.delenv(LIFECYCLE_SENTINEL, raising=False)
+    monkeypatch.delenv("OPIK_API_KEY", raising=False)
+    monkeypatch.setenv("OPIK_MCP_AS_URL", "https://as.example.com")
+    recorder = _install_server_recorder(monkeypatch)
+    settings = get_settings()
+
+    composed = server._make_composed_lifespan(_noop_inner, settings, {})
+
+    async def _drive() -> None:
+        async with composed(None):
+            pass
+
+    asyncio.run(_drive())
+
+    started = next(p for et, p in recorder.events if et == EVENT_SERVER_STARTED)
+    assert started["auth_mode"] == "oauth"

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -48,6 +48,9 @@ FORBIDDEN = [
     "FORBIDDEN-CANARY-socket-hostname-9d3e5f4a",
     "FORBIDDEN-CANARY-uname-nodename-1b2c3d4e",
     "FORBIDDEN-CANARY-home-path-5e6f7a8b",
+    # OAuth bearer token canary — auth_rejected derives its reason from the
+    # header SHAPE only; the raw token must never reach the event.
+    "opik_at_FORBIDDEN-CANARY-oauth-token-2f8e1d3c",
 ]
 
 
@@ -749,6 +752,7 @@ async def _noop_coroutine_result(result: Any) -> Any:
         "opik_mcp_session_initialized",
         "opik_mcp_tools_listed",
         "opik_mcp_server_shutdown",
+        "opik_mcp_auth_rejected",
     ],
 )
 def test_new_events_carry_no_forbidden_substring(
@@ -861,6 +865,28 @@ def test_new_events_carry_no_forbidden_substring(
                 "session_reached": str(transport_probe.session_reached()).lower(),
             },
         )
+
+    elif event_name == "opik_mcp_auth_rejected":
+        from opik_mcp import server
+        from opik_mcp.config import Settings
+
+        monkeypatch.setattr(
+            "opik_mcp.server.track_event", lambda et, p: recorder.track_event(et, p)
+        )
+        mw = server.AuthRejectionMiddleware(
+            None,  # type: ignore[arg-type]  # app unused by _emit_rejection
+            settings=Settings(opik_mcp_analytics_enabled=False, _env_file=None),  # type: ignore[call-arg]
+        )
+        # Drive the emit path directly with a canary-laden bearer token; the
+        # event must carry only the bucketed reason/auth_mode, never the token.
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [
+                (b"authorization", b"Bearer opik_at_FORBIDDEN-CANARY-oauth-token-2f8e1d3c"),
+            ],
+        }
+        mw._emit_rejection(scope, 401)
 
     # An empty recorder would let the canary check pass vacuously, hiding the
     # case where the emit path silently no-ops (e.g. a future regression that

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -510,3 +510,35 @@ def test_http_main_owns_lifecycle_and_disables_access_log(
     started = next(p for et, p in recorder.events if et == EVENT_SERVER_STARTED)
     assert started["lifecycle_source"] == "main"
     assert started["transport"] == "http"
+
+
+def test_reload_http_disables_access_log(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dev --reload HTTP must also disable access logging — OAuth-flow query
+    strings (code/token) must never hit stdout, same as the non-reload path."""
+    _install_recorder(monkeypatch)
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("OPIK_MCP_RELOAD", "true")
+    monkeypatch.delenv("OPIK_MCP_AS_URL", raising=False)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(main_mod, "_preflight_bind_check", lambda host, port: None)
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: captured.update(kwargs=k))
+
+    main_mod.main()
+
+    assert captured["kwargs"].get("reload") is True
+    assert captured["kwargs"].get("access_log") is False
+
+
+def test_fallback_client_installation_type_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On the config-fail path the fallback client must still classify the Opik
+    destination from env (model_construct ignores it), so a self-hosted install's
+    startup_error isn't mislabelled 'cloud'."""
+    monkeypatch.setenv("COMET_URL_OVERRIDE", "https://opik.acme.internal")
+    monkeypatch.delenv("OPIK_URL", raising=False)
+
+    client = main_mod._build_fallback_analytics_client()
+    try:
+        assert client._installation_type == "self-hosted"
+    finally:
+        client.close()

--- a/tests/test_analytics_server_startup.py
+++ b/tests/test_analytics_server_startup.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import httpx
 import pytest
@@ -462,3 +463,50 @@ def test_no_startup_error_when_resource_uri_set(monkeypatch: pytest.MonkeyPatch)
     error_props = [p for et, p in recorder.events if et == EVENT_STARTUP_ERROR]
     assert error_props == [], "guard must not fire when resource URI is set"
     assert EVENT_SERVER_STARTED in [e[0] for e in recorder.events]
+
+
+def test_http_main_owns_lifecycle_and_disables_access_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hosted entrypoint runs main() (python -m opik_mcp), so ALL events fire in
+    HTTP mode just like stdio. The sentinel must be set BEFORE build_app() so the
+    composed lifespan skips its emit (no double-count), and main() emits the
+    lifecycle events itself. Access logging is disabled (parity with the old
+    --no-access-log; avoids logging OAuth tokens in query strings)."""
+    from opik_mcp.analytics import boot_props
+
+    recorder = _install_recorder(monkeypatch)
+    monkeypatch.setenv("OPIK_MCP_TRANSPORT", "http")
+    monkeypatch.delenv("OPIK_MCP_AS_URL", raising=False)
+    monkeypatch.delenv("OPIK_MCP_RESOURCE_URI", raising=False)
+    monkeypatch.delenv("OPIK_MCP_RELOAD", raising=False)
+
+    captured: dict[str, Any] = {}
+    built_app = object()
+
+    def _fake_build_app() -> object:
+        # The composed lifespan reads the sentinel at runtime; main() must have
+        # set it before reaching build_app() so the lifespan defers to main().
+        captured["owned_at_build"] = boot_props.lifecycle_owned_by_main()
+        return built_app
+
+    def _fake_uvicorn_run(app: object, **kwargs: Any) -> None:
+        captured["app"] = app
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(main_mod, "_preflight_bind_check", lambda host, port: None)
+    monkeypatch.setattr("opik_mcp.server.build_app", _fake_build_app)
+    monkeypatch.setattr("uvicorn.run", _fake_uvicorn_run)
+
+    main_mod.main()
+
+    assert captured["owned_at_build"] is True, "sentinel must be set before build_app()"
+    assert captured["kwargs"].get("access_log") is False
+    # The app built once in main() is the exact object handed to uvicorn.run.
+    assert captured["app"] is built_app
+
+    event_types = [e[0] for e in recorder.events]
+    assert EVENT_SERVER_STARTED in event_types
+    started = next(p for et, p in recorder.events if et == EVENT_SERVER_STARTED)
+    assert started["lifecycle_source"] == "main"
+    assert started["transport"] == "http"

--- a/tests/test_error_tracking.py
+++ b/tests/test_error_tracking.py
@@ -8,7 +8,7 @@ import pytest
 import sentry_sdk
 
 from opik_mcp import error_tracking
-from opik_mcp.config import Settings
+from opik_mcp.config import Settings, installation_type
 
 # --- before_send filter --------------------------------------------------- #
 
@@ -207,8 +207,10 @@ def test_setup_sentry_initializes_and_binds_scope(monkeypatch: pytest.MonkeyPatc
     ],
 )
 def test_installation_type_taxonomy(comet_url: str, opik_url: str | None, expected: str) -> None:
+    # The classifier lives in config (leaf module) so error_tracking + boot_props
+    # share it without an import cycle; this pins the taxonomy at its source.
     settings = _settings(comet_url_override=comet_url, opik_url=opik_url)
-    assert error_tracking._installation_type(settings) == expected
+    assert installation_type(settings) == expected
 
 
 def test_setup_sentry_stamps_installation_type_and_workspace(


### PR DESCRIPTION
## Summary

Extends opik-mcp's BI/analytics so the **hosted HTTP/OAuth deployment** is no longer dark and every event carries the metadata needed for the most useful usage charts. Closes three gaps in the analytics layer relative to the recently-added OAuth resource-server + transport-security work.

**GAP#1 — lifecycle events were dark in hosted mode.** `server_started`/`server_shutdown`/`startup_error` were only emitted from `__main__.main()`, but the Docker/Helm entrypoint runs `uvicorn opik_mcp.server:build_app --factory`, which bypasses `main()`. `build_app()` now composes an analytics lifespan around FastMCP's session-manager lifespan and emits them itself — guarded by an env-var sentinel so a `main()`-driven HTTP boot is never double-counted (verified inherited by `--reload` spawn workers).

**GAP#2 — per-request OAuth identity never reached BI.** `_build_event()` runs synchronously in the request task, so the `auth_context` ContextVars are live: events now carry per-request `auth_mode`, `token_sha256` (hash of the `opik_at_` bearer — raw token never stored), `request_workspace`, and `installation_type`. Extraction mirrors `resolve_opik_config` exactly so BI agrees with the outbound credential.

**GAP#3 — auth failures were invisible.** New `opik_mcp_auth_rejected` event from a pure-ASGI `AuthRejectionMiddleware` (never buffers SSE) for 401/421/403 on authenticated paths, with bucketed `rejection_reason`, `auth_mode`, `path_bucket`, `oauth_configured`, `resource_metadata_url_present`. OAuth-proxy/discovery paths are skipped (a proxied-AS 401 isn't our rejection).

Also fixes a **pre-existing privacy-contract bug**: the `McpHost`/`HostLlmFamily` `Literal` allowlists were out of sync with the classifiers (`codex`/`gemini-cli`/`openai`/`google` were shipping undeclared).

### Per-event additions
- `server_started`: `installation_type`, `oauth_configured`, `resource_uri_scheme`, `dns_rebinding_protection`, `allowed_hosts_is_default`, `auth_mode`, `lifecycle_source`
- `server_shutdown`: `lifecycle_source`; `startup_error`: `oauth_configured` (+ `installation_type` via common)
- `tool_called` / `session_initialized` / `ask_ollie_completed`: `auth_mode`, `token_sha256`, `request_workspace`, `installation_type`
- new `opik_mcp_auth_rejected` event

### Notes
- New `boot_props` module is the single source of truth shared by `main()` and the lifespan so the two boot paths cannot drift. The pure `installation_type` classifier moved to `config` (leaf) to break an import cycle.
- **Cross-team dependency:** `token_sha256` is only a useful BI join key once the backend exposes an `opik_at_ → user` mapping; until then dashboards should treat `auth_mode='oauth'` rows as `identity_pending`.
- Privacy contract upheld: every new property is a bool-string / allowlisted `Literal` / bucket, or a SHA-256 identity hash; raw tokens, paths, and user prose never leave the process. Enforced by direct `_build_event` tests + the cross-event canary sweep.
- Design/plan doc lives at `docs/bi-events-https-plan.md` (gitignored, local).

## Test Plan
- [x] `uv run pytest` — 1061 passed, 2 skipped (clean env)
- [x] `uv run ruff check .` + `ruff format --check .` — clean
- [x] `uv run mypy` — clean (107 files)
- [x] Each change developed test-first (red → green) and code-reviewed; findings fixed
- [ ] Staging: confirm `server_started` (`lifecycle_source=lifespan`) fires within minutes of a Docker `--factory` boot, and `auth_rejected` fires on an unauthenticated request
- [ ] Backend: confirm the `opik_at_ → user` mapping is BI-queryable before relying on `token_sha256`

🤖 Generated with [Claude Code](https://claude.com/claude-code)