### PR TITLE
feat: full thread support in the MCP (read, list, lifecycle, annotate) — OPIK-7443

### DIFF
--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -37,8 +37,11 @@ Tool selection:
 - read / list: use for any "show me X" or "what is Y" — these are the cheapest \
 reads. read takes (entity_type, id_or_name_or_uri); list takes (entity_type, \
 optional name filter, page, size). Readable entity types include trace, span, \
-project, experiment, prompt, test_suite. Composite reads (trace, prompt) inline \
-their child collections so one call usually gets the full picture.
+project, experiment, prompt, test_suite, thread. Composite reads (trace, prompt, \
+thread) inline their child collections so one call usually gets the full picture. \
+For a thread, pass the thread link/URI or a project_id — read('thread', …) \
+returns the messages list, and list('thread', project_id=…) enumerates a \
+project's threads.
 - Direct writes — use when the user's intent is concrete and well-defined \
 ("score this trace 0.8 on helpfulness", "comment 'retry with temperature=0' \
 on span X"). Skip ask_ollie for these — narrower tools are faster and more \

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -115,6 +115,16 @@ class OpikListClient(Protocol):
         *,
         project_id: str | None = None,
         project_name: str | None = None,
+        filters: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]: ...
+
+    async def list_threads(
+        self,
+        *,
+        project_id: str | None = None,
+        project_name: str | None = None,
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]: ...
@@ -169,6 +179,16 @@ class OpikReadClient(OpikListClient, Protocol):
     async def get_experiment(self, experiment_id: str, /) -> dict[str, Any]: ...
 
     async def get_prompt(self, prompt_id: str, /) -> dict[str, Any]: ...
+
+    async def get_thread(
+        self,
+        thread_id: str,
+        /,
+        *,
+        project_id: str | None = None,
+        project_name: str | None = None,
+        truncate: bool = False,
+    ) -> dict[str, Any]: ...
 
 
 # --- client --------------------------------------------------------------- #
@@ -317,10 +337,17 @@ class OpikClient:
         *,
         project_id: str | None = None,
         project_name: str | None = None,
+        filters: str | None = None,
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]:
-        """``GET /v1/private/traces`` — requires ``project_id`` or ``project_name``."""
+        """``GET /v1/private/traces`` — requires ``project_id`` or ``project_name``.
+
+        ``filters`` is the backend's JSON-encoded filter array (query param),
+        e.g. ``[{"field":"thread_id","operator":"=","value":"<id>"}]`` — used
+        by the thread read to pull a thread's messages. Forwarded only when set;
+        the ``list`` tool never passes it.
+        """
         if project_id is None and project_name is None:
             raise ValueError("list_traces requires project_id or project_name")
         params: dict[str, Any] = {"page": page, "size": size}
@@ -328,6 +355,8 @@ class OpikClient:
             params["project_id"] = project_id
         if project_name is not None:
             params["project_name"] = project_name
+        if filters is not None:
+            params["filters"] = filters
         return await self._get_json("/v1/private/traces", params=params, entity_hint="traces")
 
     async def get_trace(self, trace_id: str) -> dict[str, Any]:
@@ -336,6 +365,62 @@ class OpikClient:
             f"/v1/private/traces/{trace_id}",
             params=None,
             entity_hint=f"trace {trace_id!r}",
+        )
+
+    async def list_threads(
+        self,
+        *,
+        project_id: str | None = None,
+        project_name: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]:
+        """``GET /v1/private/traces/threads`` — project-scoped page of threads.
+
+        A thread groups traces by ``thread_id`` within one project, so listing
+        requires ``project_id`` or ``project_name`` (like ``list_traces``).
+        Returns a Spring Page envelope ``{content, page, size, total}``.
+        """
+        if project_id is None and project_name is None:
+            raise ValueError("list_threads requires project_id or project_name")
+        params: dict[str, Any] = {"page": page, "size": size}
+        if project_id is not None:
+            params["project_id"] = project_id
+        if project_name is not None:
+            params["project_name"] = project_name
+        return await self._get_json(
+            "/v1/private/traces/threads",
+            params=params,
+            entity_hint="threads",
+        )
+
+    async def get_thread(
+        self,
+        thread_id: str,
+        *,
+        project_id: str | None = None,
+        project_name: str | None = None,
+        truncate: bool = False,
+    ) -> dict[str, Any]:
+        """``POST /v1/private/traces/threads/retrieve`` — one thread's metadata.
+
+        A thread is keyed by ``thread_id`` within a single project, so the
+        backend has no ``GET /{id}`` route — it takes a ``TraceThreadIdentifier``
+        body and requires ``project_id`` or ``project_name`` (raise ``ValueError``
+        if neither is given, mirroring ``list_traces``). ``truncate=False`` keeps
+        full first/last-message payloads; compression manages the token budget.
+        """
+        if project_id is None and project_name is None:
+            raise ValueError("get_thread requires project_id or project_name")
+        body: dict[str, Any] = {"thread_id": thread_id, "truncate": truncate}
+        if project_id is not None:
+            body["project_id"] = project_id
+        if project_name is not None:
+            body["project_name"] = project_name
+        return await self._post_json(
+            "/v1/private/traces/threads/retrieve",
+            json=body,
+            entity_hint=f"thread {thread_id!r}",
         )
 
     async def list_spans(
@@ -561,6 +646,40 @@ class OpikClient:
         if not isinstance(body, dict):
             raise OpikServerError(
                 f"Opik returned non-object JSON for GET {path}: {type(body).__name__}"
+            )
+        return body
+
+    async def _post_json(
+        self,
+        path: str,
+        *,
+        json: dict[str, Any],
+        entity_hint: str,
+    ) -> dict[str, Any]:
+        """POST a JSON body, expect 200, return the parsed object.
+
+        Read-side sibling of ``_get_json`` for endpoints the backend models as
+        POST-with-body rather than ``GET /{id}`` (thread ``retrieve``). Same
+        typed error mapping via ``_raise_for_status`` so callers don't translate.
+        """
+        url = f"{self._base_url}{path}"
+        content = _json.dumps(json, separators=(",", ":")).encode()
+        async with self._http() as http:
+            resp = await http.request("POST", url, content=content, headers=self._headers())
+        _raise_for_status(resp, entity_hint)
+        if resp.status_code != 200:
+            raise OpikServerError(
+                f"Unexpected status {resp.status_code} from POST {path} (expected 200)"
+            )
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise OpikServerError(
+                f"Opik returned non-JSON body for POST {path}: {resp.text[:200]!r}"
+            ) from exc
+        if not isinstance(body, dict):
+            raise OpikServerError(
+                f"Opik returned non-object JSON for POST {path}: {type(body).__name__}"
             )
         return body
 

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -80,9 +80,7 @@ async def run_list(
             # either, so don't force the UUID when a name was given.
             if required == "project_id" and kw.get("project_name"):
                 continue
-            hint = (
-                f"{required} (or project_name)" if required == "project_id" else required
-            )
+            hint = f"{required} (or project_name)" if required == "project_id" else required
             err = EntityArgValidationError(
                 f"list({entity_type!r}) requires {hint}. "
                 f"E.g. list({entity_type!r}, {required}='<uuid>', …)."

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -42,6 +42,7 @@ async def run_list(
     page: int = 1,
     size: int = 25,
     project_id: str | None = None,
+    project_name: str | None = None,
     test_suite_id: str | None = None,
     prompt_id: str | None = None,
     settings: Settings | None = None,
@@ -62,6 +63,11 @@ async def run_list(
         kw["name"] = name
     if project_id is not None:
         kw["project_id"] = project_id
+    # Only project-scoped lists (trace, thread) take project_name; forwarding it
+    # to a workspace-wide list_fn (projects/experiments/…) would be an unexpected
+    # kwarg. Gate on the same signal the required-check uses.
+    if project_name is not None and "project_id" in handler.list_required_kwargs:
+        kw["project_name"] = project_name
     if test_suite_id is not None:
         kw["test_suite_id"] = test_suite_id
     if prompt_id is not None:
@@ -69,8 +75,16 @@ async def run_list(
 
     for required in handler.list_required_kwargs:
         if kw.get(required) is None:
+            # project_name is an accepted alternative to project_id for the
+            # project-scoped lists (trace, thread) — the client methods take
+            # either, so don't force the UUID when a name was given.
+            if required == "project_id" and kw.get("project_name"):
+                continue
+            hint = (
+                f"{required} (or project_name)" if required == "project_id" else required
+            )
             err = EntityArgValidationError(
-                f"list({entity_type!r}) requires {required}. "
+                f"list({entity_type!r}) requires {hint}. "
                 f"E.g. list({entity_type!r}, {required}='<uuid>', …)."
             )
             raise ToolError(str(err)) from err

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -36,7 +36,7 @@ from opik_mcp.read_list.registry import (
     EntityHandler,
     compress_for,
 )
-from opik_mcp.read_list.uri import InvalidURI, looks_like_uri
+from opik_mcp.read_list.uri import InvalidURI, looks_like_thread_url, looks_like_uri
 from opik_mcp.read_list.uri import parse as parse_uri
 
 logger = logging.getLogger("opik_mcp.read_list.read")
@@ -103,25 +103,33 @@ async def run_read(
     id: str,
     *,
     max_tokens: int | None = None,
+    project_id: str | None = None,
+    project_name: str | None = None,
     settings: Settings | None = None,
     client: OpikReadClient | None = None,
 ) -> str:
     """Read tool entrypoint. See ``server.py`` for the registered tool.
 
-    Dispatch order: URI parse → registry lookup → UUID-vs-name branch →
-    fetch → compress. Each branch surfaces errors as ``ToolError`` so the
-    host LLM gets the structured guidance.
+    Dispatch order: URI parse → registry lookup → project gate → UUID-vs-name
+    branch → fetch → compress. Each branch surfaces errors as ``ToolError`` so
+    the host LLM gets the structured guidance.
     """
-    # Accept ``opik://…`` URIs as id input (D1 mitigation). When the URI
-    # encodes its own entity_type we trust it and override the explicit
-    # argument — that way the agent can paste a URI into either slot.
-    if looks_like_uri(id):
+    # Accept ``opik://…`` URIs and pasted web thread links as id input. When the
+    # URI encodes its own entity_type we trust it and override the explicit
+    # argument — that way the agent can paste a URI into either slot. A parsed
+    # thread URI/link also carries the project, which overrides the explicit arg.
+    if looks_like_uri(id) or looks_like_thread_url(id):
         try:
             parsed = parse_uri(id)
         except InvalidURI as e:
             raise ToolError(str(e)) from e
         entity_type = parsed.entity_type
         id = parsed.entity_id
+        if parsed.project_id is not None:
+            # The URI is the source of truth for the project — clear any
+            # explicit project_name so we don't send a conflicting pair.
+            project_id = parsed.project_id
+            project_name = None
 
     if entity_type not in READABLE_TYPES:
         if entity_type in ENTITY_REGISTRY:
@@ -138,8 +146,18 @@ async def run_read(
 
     handler = ENTITY_REGISTRY[entity_type]
 
+    if handler.needs_project and project_id is None and project_name is None:
+        err = EntityArgValidationError(
+            f"read({entity_type!r}) requires project scope. Pass the full thread "
+            f"link/URI, or a project_id — e.g. "
+            f"read('{entity_type}', '<{entity_type}_id>', project_id='<uuid>')."
+        )
+        raise ToolError(str(err)) from err
+
     opik = client if client is not None else make_opik_client(settings or get_settings())
-    data = await _fetch_with_name_lookup(handler, opik, id)
+    data = await _fetch_with_name_lookup(
+        handler, opik, id, project_id=project_id, project_name=project_name
+    )
 
     compressed_text, tier = compress_for(handler, data, max_tokens)
     full_json = compact_json(data)
@@ -153,6 +171,9 @@ async def _fetch_with_name_lookup(
     handler: EntityHandler,
     client: OpikReadClient,
     entity_id: str,
+    *,
+    project_id: str | None = None,
+    project_name: str | None = None,
 ) -> dict[str, Any]:
     """Resolve name → id when the input doesn't look like a UUID.
 
@@ -182,6 +203,10 @@ async def _fetch_with_name_lookup(
         # will 404 with a clear message if it really doesn't exist.
 
     try:
+        if handler.needs_project:
+            return await handler.fetch_fn(
+                client, entity_id, project_id=project_id, project_name=project_name
+            )
         return await handler.fetch_fn(client, entity_id)
     except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as e:
         raise ToolError(_format_client_error(handler.entity_type, entity_id, e)) from e

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -22,6 +22,7 @@ plug into the existing dispatchers without further code changes.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -43,8 +44,13 @@ from opik_mcp.read_list.compression import (
 # constants so cache shapes stay stable for any in-flight integration.
 SPANS_INLINE_LIMIT = 200
 VERSIONS_INLINE_LIMIT = 100
+MESSAGES_INLINE_LIMIT = 200
 
-FetchFn = Callable[[OpikReadClient, str], Awaitable[dict[str, Any]]]
+# ``FetchFn`` is widened to ``...`` so project-scoped fetchers (only ``thread``
+# today) can accept ``project_id`` / ``project_name`` kwargs. Every other
+# fetcher is still ``(client, id)`` and is called positionally; only the
+# ``needs_project`` branch in ``read_tool`` passes the extra kwargs.
+FetchFn = Callable[..., Awaitable[dict[str, Any]]]
 SearchByNameFn = Callable[[OpikReadClient, str], Awaitable[list[dict[str, Any]]]]
 ListFn = Callable[..., Awaitable[dict[str, Any]]]
 CompressFn = Callable[[dict[str, Any], int | None], tuple[str, CompressionTier]]
@@ -65,6 +71,15 @@ class EntityHandler:
 
     The ``read`` tool uses this to skip the name-lookup branch entirely —
     saves one round-trip on every non-UUID input for traces/spans/etc.
+    """
+    needs_project: bool = False
+    """True if ``fetch_fn`` needs project scope (thread only).
+
+    A thread id is unique only within a project, so ``read`` must pass
+    ``project_id`` / ``project_name`` into the fetcher. The read tool branches
+    on this flag: when set it calls ``fetch_fn(client, id, project_id=…,
+    project_name=…)`` and requires one of them; otherwise it calls
+    ``fetch_fn(client, id)`` exactly as before. Orthogonal to ``id_only``.
     """
 
 
@@ -159,6 +174,80 @@ async def _fetch_prompt(client: OpikReadClient, entity_id: str) -> dict[str, Any
     return {"prompt": prompt, "versions": versions, "versionsTruncated": truncated}
 
 
+def _thread_messages(traces: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Project each trace to one conversation turn, sorted by ``start_time`` asc.
+
+    Ascending order is conversation order. Each turn keeps a ``trace_id`` so the
+    agent can ``read('trace', id)`` to drill into spans/metadata.
+    """
+    ordered = sorted(traces, key=lambda t: t.get("start_time") or "")
+    messages: list[dict[str, Any]] = []
+    for t in ordered:
+        msg: dict[str, Any] = {
+            "trace_id": t.get("id"),
+            "name": t.get("name"),
+            "input": t.get("input"),
+            "output": t.get("output"),
+            "start_time": t.get("start_time"),
+            "end_time": t.get("end_time"),
+            "duration": t.get("duration"),
+            "usage": t.get("usage"),
+            "total_estimated_cost": t.get("total_estimated_cost"),
+            "feedback_scores": t.get("feedback_scores"),
+        }
+        error_info = t.get("error_info")
+        if error_info is not None:
+            msg["error_info"] = error_info
+        messages.append(msg)
+    return messages
+
+
+async def _fetch_thread(
+    client: OpikReadClient,
+    entity_id: str,
+    *,
+    project_id: str | None = None,
+    project_name: str | None = None,
+) -> dict[str, Any]:
+    """Thread metadata + its messages (traces filtered by ``thread_id``).
+
+    Two project-scoped calls reproduce the UI's Thread panel: ``get_thread``
+    for metadata, then ``list_traces`` filtered by ``thread_id`` for the turns.
+    Mirrors ``_fetch_trace``'s defensive inline: if the messages call fails,
+    return the metadata with an empty messages list rather than failing the
+    whole read.
+    """
+    thread = await client.get_thread(
+        entity_id, project_id=project_id, project_name=project_name
+    )
+    filters = json.dumps([{"field": "thread_id", "operator": "=", "value": entity_id}])
+    try:
+        traces_page = await client.list_traces(
+            project_id=project_id,
+            project_name=project_name,
+            filters=filters,
+            page=1,
+            size=MESSAGES_INLINE_LIMIT,
+        )
+    except Exception:
+        # Unlike a trace's spans (secondary), messages ARE a thread's primary
+        # payload — so an empty list here must NOT read as "no messages" when
+        # the metadata says otherwise. Signal the load failure explicitly.
+        return {
+            "thread": thread,
+            "messages": [],
+            "messagesTruncated": False,
+            "messagesError": "Failed to load thread messages; retry or read the traces directly.",
+        }
+    traces = _content(traces_page)
+    truncated = _is_truncated(traces_page, inlined=len(traces), limit=MESSAGES_INLINE_LIMIT)
+    return {
+        "thread": thread,
+        "messages": _thread_messages(traces),
+        "messagesTruncated": truncated,
+    }
+
+
 async def _unsupported_fetch(_client: OpikReadClient, _entity_id: str) -> dict[str, Any]:
     """Sentinel for list-only entities. The read tool raises before calling this."""
     raise NotImplementedError(
@@ -230,6 +319,14 @@ async def _list_prompt_versions(client: OpikListClient, **kw: Any) -> dict[str, 
     return await client.list_prompt_versions(prompt_id, **kw)
 
 
+async def _list_threads(client: OpikListClient, **kw: Any) -> dict[str, Any]:
+    # Thread listing is project-scoped — the ``list`` tool enforces project_id
+    # via ``list_required_kwargs``. ``name`` filtering on threads isn't
+    # supported by opik-backend; drop it if passed.
+    kw.pop("name", None)
+    return await client.list_threads(**kw)
+
+
 # --- trace skeleton compression ------------------------------------------ #
 
 
@@ -262,6 +359,47 @@ def _compress_trace(data: dict[str, Any], max_tokens: int | None) -> tuple[str, 
         ],
         "spansTruncated": data.get("spansTruncated", False),
         "note": "SKELETON compression: payloads omitted. Use read('span', id) for details.",
+    }
+    return compact_json(skeleton), CompressionTier.SKELETON
+
+
+def _compress_thread(data: dict[str, Any], max_tokens: int | None) -> tuple[str, CompressionTier]:
+    """Thread+messages: FULL → MEDIUM (truncated strings) → SKELETON (turn list only).
+
+    Mirrors ``_compress_trace``: SKELETON drops the message payloads but keeps
+    the turn list so the LLM can drill into a specific turn via
+    ``read('trace', trace_id)``.
+    """
+    full_json = compact_json(data)
+    full_tokens = estimate_tokens(full_json)
+
+    budget = max_tokens if max_tokens is not None else TOKEN_FULL_THRESHOLD
+    if full_tokens <= budget:
+        return full_json, CompressionTier.FULL
+
+    if full_tokens < TOKEN_SKELETON_THRESHOLD:
+        truncated = truncate_strings(data, ".thread")
+        return compact_json(truncated), CompressionTier.MEDIUM
+
+    thread = data.get("thread") or {}
+    messages = data.get("messages") or []
+    skeleton = {
+        "thread": {"id": thread.get("id"), "status": thread.get("status")},
+        "messages": [
+            {
+                "trace_id": m.get("trace_id"),
+                "name": m.get("name"),
+                "start_time": m.get("start_time"),
+                "feedback_scores": m.get("feedback_scores"),
+            }
+            for m in messages
+            if isinstance(m, dict)
+        ],
+        "messagesTruncated": data.get("messagesTruncated", False),
+        "note": (
+            "SKELETON compression: message payloads omitted. "
+            "Use read('trace', trace_id) for details."
+        ),
     }
     return compact_json(skeleton), CompressionTier.SKELETON
 
@@ -348,6 +486,23 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         description=(
             "Prompt version. Currently list-only — pass prompt_id to enumerate. "
             "Use read('prompt', id) to get the prompt + all versions in one call."
+        ),
+    ),
+    "thread": EntityHandler(
+        entity_type="thread",
+        fetch_fn=_fetch_thread,
+        list_fn=_list_threads,
+        list_extra_fields=("status", "number_of_messages", "last_updated_at"),
+        list_required_kwargs=("project_id",),
+        compress_fn=_compress_thread,
+        id_only=True,
+        needs_project=True,
+        description=(
+            "Conversation thread: metadata + messages list (each turn's trace "
+            "input/output, up to 200 inlined). Returns {thread, messages, "
+            "messagesTruncated}. Requires project scope — pass a thread link/URI "
+            "or project_id. list('thread', project_id=…) enumerates a project's "
+            "threads."
         ),
     ),
 }

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -217,9 +217,7 @@ async def _fetch_thread(
     return the metadata with an empty messages list rather than failing the
     whole read.
     """
-    thread = await client.get_thread(
-        entity_id, project_id=project_id, project_name=project_name
-    )
+    thread = await client.get_thread(entity_id, project_id=project_id, project_name=project_name)
     filters = json.dumps([{"field": "thread_id", "operator": "=", "value": entity_id}])
     try:
         traces_page = await client.list_traces(

--- a/src/opik_mcp/read_list/uri.py
+++ b/src/opik_mcp/read_list/uri.py
@@ -12,6 +12,11 @@ Recognized shapes (matching the deleted ``resources.py`` URI templates):
 - ``opik://test-suites/{id}``               → ("test_suite", id)
 - ``opik://experiments/{id}``               → ("experiment", id)
 - ``opik://prompts/{id}``                   → ("prompt", id)
+- ``opik://projects/{pid}/threads/{tid}``   → ("thread", tid, project_id=pid)
+
+A pasted Opik web thread link (``https://…/projects/{pid}/…?thread={tid}``) is
+also recognized via ``looks_like_thread_url`` + ``parse`` so a user can drop a
+URL straight from the UI.
 
 List-shaped URIs (``opik://projects``, ``opik://projects/{id}/traces``,
 ``opik://test-suites/{id}/items``) are accepted only as best-effort hints
@@ -22,6 +27,7 @@ from __future__ import annotations
 
 import re
 from typing import ClassVar, NamedTuple
+from urllib.parse import unquote
 
 from opik_mcp.error_kinds import ErrorKind
 
@@ -39,6 +45,10 @@ class InvalidURI(ValueError):
 class ParsedURI(NamedTuple):
     entity_type: str
     entity_id: str
+    project_id: str | None = None
+    """Set only for threads — a thread id is unique only within a project, so
+    the parser extracts the project from the URI/link and the read tool uses it
+    to scope the fetch. ``None`` for every other entity (globally-unique ids)."""
 
 
 # Canonical singleton URI patterns. test-suites is hyphenated in the URI
@@ -53,9 +63,35 @@ _PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^opik://prompts/([^/?#]+)$"), "prompt"),
 ]
 
+# Threads carry a project id AND a thread id, so they need two capture groups —
+# handled ahead of the single-id ``_PATTERNS`` in ``parse``.
+_THREAD_URI_RE = re.compile(r"^opik://projects/([^/?#]+)/threads/([^/?#]+)$")
+# A pasted Opik web thread link: /projects/<projectId>/... with ?thread=<threadId>.
+_WEB_PROJECT_RE = re.compile(r"/projects/([^/?#]+)")
+_WEB_THREAD_QS_RE = re.compile(r"[?&]thread=([^&#]+)")
+
 
 def looks_like_uri(s: str) -> bool:
     return s.startswith("opik://")
+
+
+def looks_like_thread_url(s: str) -> bool:
+    """A pasted http(s) Opik thread link — has a project path and a ``thread`` qs.
+
+    ``looks_like_uri`` only matches ``opik://``; a user usually pastes the web
+    URL from the Opik UI instead. The read tool routes anything matching this
+    through ``parse`` so the project + thread id are extracted; a plain http URL
+    that isn't a thread link fails this check and falls through to raw-id handling.
+
+    The gate uses the SAME regexes ``parse`` extracts with, so a match here
+    guarantees extraction succeeds — a stray ``?other_thread=x`` (substring of
+    ``thread=``) or a project-less path won't pass the gate only to fail parsing.
+    """
+    return (
+        s.startswith(("http://", "https://"))
+        and _WEB_PROJECT_RE.search(s) is not None
+        and _WEB_THREAD_QS_RE.search(s) is not None
+    )
 
 
 def parse(uri: str) -> ParsedURI:
@@ -65,11 +101,27 @@ def parse(uri: str) -> ParsedURI:
     way callers can distinguish "user passed a UUID" (no prefix, no error)
     from "user passed a malformed URI" (prefix but unrecognized).
     """
+    # Threads first — both the canonical opik:// shape and a pasted web link
+    # carry a project id alongside the thread id.
+    tm = _THREAD_URI_RE.match(uri)
+    if tm is not None:
+        return ParsedURI(entity_type="thread", entity_id=tm.group(2), project_id=tm.group(1))
+    if looks_like_thread_url(uri):
+        pm = _WEB_PROJECT_RE.search(uri)
+        qm = _WEB_THREAD_QS_RE.search(uri)
+        if pm is not None and qm is not None:
+            return ParsedURI(
+                entity_type="thread",
+                entity_id=unquote(qm.group(1)),
+                project_id=pm.group(1),
+            )
+
     for pattern, entity_type in _PATTERNS:
         m = pattern.match(uri)
         if m is not None:
             return ParsedURI(entity_type=entity_type, entity_id=m.group(1))
     raise InvalidURI(
         f"URI {uri!r} starts with opik:// but matches no known entity shape. "
-        "Expected e.g. opik://traces/<uuid> or opik://projects/<uuid>."
+        "Expected e.g. opik://traces/<uuid>, opik://projects/<uuid>, or "
+        "opik://projects/<projectId>/threads/<threadId>."
     )

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -266,7 +266,22 @@ async def list_entities(
     ] = 25,
     project_id: Annotated[
         str | None,
-        Field(description="Required when listing traces. UUID of the parent project."),
+        Field(
+            description=(
+                "Parent project UUID for project-scoped lists (trace, thread). "
+                "Pass this OR project_name."
+            )
+        ),
+    ] = None,
+    project_name: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Parent project name — alternative to project_id for trace/thread "
+                "lists, so you don't need to resolve the UUID first."
+            ),
+            max_length=200,
+        ),
     ] = None,
     test_suite_id: Annotated[
         str | None,
@@ -284,8 +299,9 @@ async def list_entities(
     columns, plus a pagination footer when more pages exist. Use read() to
     get full details on any specific item.
 
-    Project-scoped types require their parent id:
-    - trace: project_id
+    Project-scoped types require their parent:
+    - trace: project_id or project_name
+    - thread: project_id or project_name
     - test_suite_item: test_suite_id
     - prompt_version: prompt_id
 
@@ -300,6 +316,7 @@ async def list_entities(
         page=page,
         size=size,
         project_id=project_id,
+        project_name=project_name,
         test_suite_id=test_suite_id,
         prompt_id=prompt_id,
     )

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -42,6 +42,7 @@ from opik_mcp.oauth_identity import resolve_workspace_name
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
 from opik_mcp.read_list import run_list, run_read
 from opik_mcp.read_list.registry import LISTABLE_TYPES, READABLE_TYPES
+from opik_mcp.read_list.uri import looks_like_thread_url
 from opik_mcp.run_experiment import run_experiment_impl
 from opik_mcp.run_experiment_models import RunExperimentConfig, RunExperimentResult
 from opik_mcp.writes import (
@@ -71,12 +72,13 @@ def _looks_like_uuid(s: str) -> bool:
 
 
 def _read_props(_result: Any, kwargs: dict[str, Any]) -> dict[str, str]:
-    raw_id = kwargs.get("id", "")
-    id_kind = (
-        "uri"
-        if str(raw_id).startswith("opik://")
-        else ("uuid" if _looks_like_uuid(str(raw_id)) else "name")
-    )
+    raw_id = str(kwargs.get("id", ""))
+    if raw_id.startswith("opik://") or looks_like_thread_url(raw_id):
+        id_kind = "uri"
+    elif _looks_like_uuid(raw_id):
+        id_kind = "uuid"
+    else:
+        id_kind = "name"
     return {
         "entity_type": kwargs.get("entity_type", ""),
         "id_kind": id_kind,
@@ -163,12 +165,13 @@ async def read(
         str,
         Field(
             description=(
-                "UUID, entity name (for nameable types), or full opik:// URI "
-                "(e.g. opik://traces/<uuid>). When a URI is passed, entity_type "
-                "is overridden from the URI."
+                "UUID, entity name (for nameable types), full opik:// URI "
+                "(e.g. opik://traces/<uuid>), or a pasted Opik thread link. When "
+                "a URI/link is passed, entity_type (and, for threads, the project) "
+                "is overridden from it."
             ),
             min_length=1,
-            max_length=512,
+            max_length=2048,
         ),
     ],
     max_tokens: Annotated[
@@ -184,6 +187,23 @@ async def read(
             le=200_000,
         ),
     ] = None,
+    project_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Project UUID. Required for entity_type='thread' unless the id is "
+                "a full thread URL/URI (which carries the project). Ignored for "
+                "globally-unique entities like trace/span."
+            ),
+        ),
+    ] = None,
+    project_name: Annotated[
+        str | None,
+        Field(
+            description="Project name — alternative to project_id for thread reads.",
+            max_length=200,
+        ),
+    ] = None,
     ctx: Context[ServerSession, None] | None = None,
 ) -> str:
     """Read any Opik entity by ID, name, or opik:// URI, with adaptive compression.
@@ -197,6 +217,9 @@ async def read(
     Special shapes:
     - trace: returns {trace, spans, spansTruncated} with up to 200 spans inlined.
     - prompt: returns {prompt, versions, versionsTruncated} with up to 100 versions.
+    - thread: returns {thread, messages, messagesTruncated} — each message is one
+      turn's trace input/output + a trace_id to read('trace', id). Needs project
+      scope: pass a thread link/URI, or project_id/project_name.
     - All others: the flat record from /v1/private/{entity}/{id}.
 
     Output is a one-line `[read: …]` header (entity_type, id, compression
@@ -204,7 +227,13 @@ async def read(
     """
     if ctx is not None:
         await ctx.info(f"read.called entity_type={entity_type} id={id}")
-    return await run_read(entity_type=entity_type, id=id, max_tokens=max_tokens)
+    return await run_read(
+        entity_type=entity_type,
+        id=id,
+        max_tokens=max_tokens,
+        project_id=project_id,
+        project_name=project_name,
+    )
 
 
 @mcp.tool(name="list")

--- a/src/opik_mcp/writes/dispatch.py
+++ b/src/opik_mcp/writes/dispatch.py
@@ -30,7 +30,14 @@ import httpx
 from pydantic import BaseModel, ValidationError
 
 from opik_mcp.config import Settings, get_settings
-from opik_mcp.opik_client import OpikClient, make_opik_client
+from opik_mcp.opik_client import (
+    OpikAuthError,
+    OpikClient,
+    OpikNotFoundError,
+    OpikServerError,
+    OpikValidationError,
+    make_opik_client,
+)
 from opik_mcp.writes.errors import (
     AuthorizationDeniedError,
     BackendError,
@@ -80,27 +87,109 @@ async def run_write(
 
     effective_idem = _resolve_idempotency_key(idempotency_key, items)
 
+    # Live path only: build the client and resolve any identifiers the wire
+    # needs but the caller doesn't carry (thread comments target the BE by the
+    # thread's model UUID; the caller passes the thread_id string). dry_run stays
+    # pure — no client, no backend calls — so it never depends on config/network.
+    http_client: OpikClient | None = None
+    if not dry_run:
+        http_client = client if client is not None else make_opik_client(settings or get_settings())
+        await _resolve_thread_comment_target(op, items, http_client)
+
     method, path, body = _build_request_with_method(op, items, is_batch=is_batch)
 
     if dry_run:
-        return {
-            "dry_run": True,
-            "would_call": {
-                "method": method,
-                "path": path,
-                "body_size": len(json.dumps(body)),
-                "batch": is_batch,
-                "item_count": len(items),
-                # Echoing the body lets the caller verify wire translations
-                # (e.g. ``test_suite_*`` → ``dataset_*``, items wrapped in
-                # ``{source, data: …}``) before committing the live call.
-                "body": body,
-            },
+        would_call: dict[str, Any] = {
+            "method": method,
+            "path": path,
+            "body_size": len(json.dumps(body)),
+            "batch": is_batch,
+            "item_count": len(items),
+            # Echoing the body lets the caller verify wire translations
+            # (e.g. ``test_suite_*`` → ``dataset_*``, items wrapped in
+            # ``{source, data: …}``) before committing the live call.
+            "body": body,
         }
+        # dry_run skips the live resolve, so a thread comment's previewed path
+        # still shows the thread_id string; the real call resolves it to the
+        # thread's model UUID. Say so rather than imply the preview is exact.
+        if op.name == "comment.create" and getattr(items[0], "target", None) == "thread":
+            would_call["note"] = (
+                "thread comments resolve the thread_id string to the thread's model "
+                "UUID at execution; the live path will use /threads/{model_uuid}/comments."
+            )
+        return {"dry_run": True, "would_call": would_call}
 
-    http_client = client if client is not None else make_opik_client(settings or get_settings())
+    assert http_client is not None  # set above whenever not dry_run
     resp = await http_client.write_json(method, path, body, idempotency_key=effective_idem)
     return _stage4_finalize(op, resp, items, is_batch=is_batch, method=method, path=path)
+
+
+async def _resolve_thread_comment_target(
+    op: WriteOperation, items: list[BaseModel], client: OpikClient
+) -> None:
+    """Swap a thread-comment's ``thread_id`` string for the thread's model UUID.
+
+    The BE's ``POST /threads/{id}/comments`` takes the thread *model* UUID as
+    the path id, but the caller passes the same ``thread_id`` string used for
+    scoring/reading (uniform contract). Resolve it via ``get_thread`` so the
+    asymmetry never surfaces. No-op for non-thread comments and every other op.
+    """
+    if op.name != "comment.create":
+        return
+    from opik_mcp.writes.models import CommentCreate
+
+    model = items[0]
+    if not isinstance(model, CommentCreate) or model.target != "thread":
+        return
+    try:
+        # truncate=True — we only need the model id, not the full messages.
+        thread = await client.get_thread(
+            model.target_id,
+            project_id=str(model.project_id) if model.project_id else None,
+            project_name=model.project_name,
+            truncate=True,
+        )
+    except OpikNotFoundError as e:
+        raise ValidationFailedError.build(
+            op.name,
+            [
+                ValidationIssue(
+                    "target_id",
+                    f"thread {model.target_id!r} not found in the given project — "
+                    "check the thread_id and project_name/project_id.",
+                    "thread_not_found",
+                )
+            ],
+            expected_schema=op.pydantic_model.model_json_schema(),
+            example=op.example,
+        ) from e
+    except (OpikAuthError, OpikValidationError, OpikServerError) as e:
+        # Mirror the live write path: a non-404 backend failure during the
+        # resolve becomes a structured BackendError, not a raw OpikError that
+        # would bypass the write tool's JSON-envelope contract.
+        raise BackendError.build(
+            op.name,
+            e.http_status or 502,
+            str(e),
+            method="POST",
+            path="/v1/private/traces/threads/retrieve",
+        ) from e
+    # ``id`` on a TraceThread is the string thread_id, NOT a UUID — the comment
+    # path needs the model UUID, so there is no valid fallback to ``id`` here.
+    model_id = thread.get("thread_model_id")
+    if not isinstance(model_id, str) or not model_id:
+        raise ValidationFailedError.build(
+            op.name,
+            [
+                ValidationIssue(
+                    "target_id", "thread has no resolvable model id.", "thread_not_found"
+                )
+            ],
+            expected_schema=op.pydantic_model.model_json_schema(),
+            example=op.example,
+        )
+    items[0] = model.model_copy(update={"target_id": model_id})
 
 
 # --- Stage 1 ------------------------------------------------------------- #
@@ -195,14 +284,16 @@ def _stage2_validate(op: WriteOperation, data: Any) -> tuple[list[BaseModel], bo
         assert isinstance(model, ScoreCreate)
         thread_example: dict[str, Any] = {
             "target": "thread",
-            "target_id": str(model.target_id),
+            "target_id": model.target_id,
             "name": model.name,
             "value": model.value,
         }
-        if model.reason is not None:
-            thread_example["reason"] = model.reason
         if model.project_name is not None:
             thread_example["project_name"] = model.project_name
+        if model.project_id is not None:
+            thread_example["project_id"] = str(model.project_id)
+        if model.reason is not None:
+            thread_example["reason"] = model.reason
         if model.category_name is not None:
             thread_example["category_name"] = model.category_name
         raise ValidationFailedError.build(
@@ -349,11 +440,13 @@ def _build_request(
         single = _dump(first)
         target_id = single.pop("target_id")
         single.pop("target", None)
-        # ``project_name`` is only consulted by the thread route; the spec
-        # leaves the single-trace/span routes free to ignore it but we
-        # strip it here to keep the body minimal.
+        # ``project_name``/``project_id`` are only consulted by the thread
+        # route; the single-trace/span routes ignore them, so strip them to
+        # keep the body minimal. (Thread scores always take the batch path, so
+        # this branch is trace/span only in practice.)
         if target != "thread":
             single.pop("project_name", None)
+            single.pop("project_id", None)
         return f"/v1/private/{target_path}/{target_id}/feedback-scores", single
 
     if name == "comment.create":
@@ -479,6 +572,7 @@ def _score_batch_item(item: dict[str, Any], target: str) -> dict[str, Any]:
     else:
         item["id"] = target_id
         item.pop("project_name", None)
+        item.pop("project_id", None)
     return item
 
 

--- a/src/opik_mcp/writes/dispatch.py
+++ b/src/opik_mcp/writes/dispatch.py
@@ -414,6 +414,13 @@ def _build_request(
                 item["dataset_item_id"] = item.pop("test_suite_item_id")
         return op.endpoint, body
 
+    if name in ("thread.close", "thread.open"):
+        # Fixed endpoint + generic body. The model is exactly
+        # {thread_id, project_name?, project_id?} with no ``target`` field, so
+        # the exclude_none dump IS the wire body (TraceThreadIdentifier).
+        # supports_batch=False, so items[0] is the only item.
+        return op.endpoint, _dump(items[0])
+
     # Belt-and-braces — every registry entry is matched above. If a new
     # operation lands without a branch here, fail loudly.
     raise RuntimeError(f"dispatch: unhandled operation {name!r}")  # pragma: no cover

--- a/src/opik_mcp/writes/models.py
+++ b/src/opik_mcp/writes/models.py
@@ -184,41 +184,80 @@ class SpanCreate(_StrictBase, _ClientIdMixin, _TagsMixin, _ProjectMixin):
     usage: dict[str, Any] | None = Field(default=None)
 
 
-# --- 4. score.create ------------------------------------------------------ #
+# --- 4 & 5. shared annotation target (score.create / comment.create) ----- #
+
+_TARGET_ID_DESC = (
+    "Identifier of the thing being annotated. For target='trace'/'span': the "
+    "entity UUID. For target='thread': the thread_id STRING — the value shown "
+    "as `id` in list('thread', project_id=…) and read('thread', …). Threads are "
+    "keyed by that string, not a UUID."
+)
 
 
-class ScoreCreate(_StrictBase):
-    """``PUT /v1/private/{target_path}/{target_id}/feedback-scores`` —
-    attaches a numeric score to a trace, span, or thread.
+class _AnnotationTarget(_StrictBase):
+    """Shared target fields + per-target id validation for score/comment.
 
-    ``target`` selects which BE route the dispatcher hits. For ``thread``,
-    the BE has no single-item endpoint, so the dispatcher rewrites this
-    payload into a batch envelope; that constraint is captured by the
-    ``target='thread'`` branch in ``dispatch.py`` rather than here so the
-    model stays uniform across targets.
+    One uniform contract for the LLM: ``target_id`` is a UUID for trace/span
+    and the ``thread_id`` string for thread. Thread annotations also need a
+    project (a thread_id is unique only within a project); trace/span ignore it
+    (their ids are globally unique). The dispatcher turns the string thread_id
+    into whatever each BE route needs (score sends it as-is; comment resolves it
+    to the thread's model UUID), so callers never juggle two identifiers.
     """
 
-    target: ScoreTarget = Field(description="What the score is attached to.")
-    target_id: UUID = Field(description="UUID of the trace, span, or thread.")
+    target: ScoreTarget = Field(description="What the annotation attaches to.")
+    target_id: str = Field(min_length=1, max_length=200, description=_TARGET_ID_DESC)
+    project_name: str | None = Field(default=None, max_length=200)
+    project_id: UUID | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> _AnnotationTarget:
+        if self.target in ("trace", "span"):
+            try:
+                # Normalize to canonical dashed form: Python's UUID() also
+                # accepts braces / urn: / dashless hex, but the Java BE's
+                # `UUID.fromString` path param does not — canonicalize so a
+                # locally-valid id is always BE-valid on the wire.
+                self.target_id = str(UUID(self.target_id))
+            except ValueError:
+                raise ValueError(
+                    f"target_id_not_uuid: target={self.target!r} needs a UUID "
+                    f"target_id; got {self.target_id!r}."
+                ) from None
+        else:  # thread — keyed by the thread_id string, scoped to a project
+            if self.project_name is None and self.project_id is None:
+                raise ValueError(
+                    "thread_project_missing: annotating a thread needs "
+                    "project_name or project_id (a thread_id is unique only "
+                    "within a project)."
+                )
+        return self
+
+
+class ScoreCreate(_AnnotationTarget):
+    """Attach a numeric feedback score to a trace, span, or thread.
+
+    trace/span -> ``PUT /v1/private/{traces|spans}/{id}/feedback-scores``.
+    thread -> ``PUT /v1/private/traces/threads/feedback-scores`` (batch-only on
+    the BE, so the dispatcher requires the array form for target='thread').
+    """
+
     name: str = Field(min_length=1, max_length=200)
     value: float = Field(ge=-1e9, le=1e9)
     source: Literal["sdk", "ui", "online_scoring"] = "sdk"
     category_name: str | None = Field(default=None, max_length=200)
     reason: str | None = Field(default=None, max_length=2000)
-    # ``thread`` writes optionally scope by project name so the BE can
-    # disambiguate threads that exist in multiple projects; ignored for
-    # trace/span writes (entity id is globally unique there).
-    project_name: str | None = Field(default=None, max_length=200)
 
 
-# --- 5. comment.create ---------------------------------------------------- #
+class CommentCreate(_AnnotationTarget):
+    """Attach a free-text comment to a trace, span, or thread.
 
+    trace/span -> ``POST /v1/private/{traces|spans}/{id}/comments``.
+    thread -> ``POST /v1/private/traces/threads/{thread_model_id}/comments``;
+    the dispatcher resolves the thread_id string to the model UUID first, so the
+    caller passes the same thread_id string used everywhere else.
+    """
 
-class CommentCreate(_StrictBase):
-    """``POST /v1/private/{target_path}/{target_id}/comments`` — free-text."""
-
-    target: ScoreTarget = Field(description="What the comment is attached to.")
-    target_id: UUID = Field(description="UUID of the trace, span, or thread.")
     text: str = Field(min_length=1, max_length=10_000)
 
 

--- a/src/opik_mcp/writes/models.py
+++ b/src/opik_mcp/writes/models.py
@@ -378,6 +378,45 @@ class ExperimentItemCreate(_StrictBase):
     experiment_items: list[ExperimentItem] = Field(min_length=1, max_length=1000)
 
 
+# --- 11/12. thread.close / thread.open ----------------------------------- #
+
+
+class _ThreadLifecycle(_StrictBase):
+    """Shared shape for thread status changes (close/open).
+
+    A thread is keyed by ``thread_id`` within a project, so the BE's
+    ``TraceThreadIdentifier`` body takes the id plus project scope. Project is
+    optional (the BE resolves within the default project) but passing one
+    disambiguates threads that exist in multiple projects — same contract as the
+    thread score/comment path. The model carries no ``target`` field, so the
+    dispatcher's ``exclude_none`` dump is the wire body verbatim.
+    """
+
+    thread_id: str = Field(min_length=1, max_length=200)
+    project_name: str | None = Field(default=None, max_length=200)
+    project_id: UUID | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _require_project(self) -> _ThreadLifecycle:
+        # The BE's TraceThreadIdentifier validator rejects a request with
+        # neither project field (400). Catch it locally with a recovery code so
+        # the LLM adds a project instead of round-tripping a confusing 400.
+        if self.project_name is None and self.project_id is None:
+            raise ValueError(
+                "thread_project_missing: pass `project_name` or `project_id` "
+                "to identify the thread's project."
+            )
+        return self
+
+
+class ThreadClose(_ThreadLifecycle):
+    """``POST /v1/private/traces/threads/close`` — mark a thread inactive/done."""
+
+
+class ThreadOpen(_ThreadLifecycle):
+    """``POST /v1/private/traces/threads/open`` — reopen a thread (→ active)."""
+
+
 # --- examples (used by registry + validation errors) --------------------- #
 #
 # One validated example per operation. These are the source of truth for the
@@ -459,6 +498,8 @@ EXAMPLES: dict[str, dict[str, Any]] = {
             }
         ]
     },
+    "thread.close": {"thread_id": "conversation-42", "project_name": "demo"},
+    "thread.open": {"thread_id": "conversation-42", "project_name": "demo"},
 }
 
 
@@ -475,6 +516,8 @@ MODELS: dict[str, type[BaseModel]] = {
     "test_suite_item.upsert": TestSuiteItemUpsert,
     "experiment.create": ExperimentCreate,
     "experiment_item.create": ExperimentItemCreate,
+    "thread.close": ThreadClose,
+    "thread.open": ThreadOpen,
 }
 
 
@@ -497,6 +540,8 @@ __all__ = [
     "TestSuiteCreate",
     "TestSuiteItem",
     "TestSuiteItemUpsert",
+    "ThreadClose",
+    "ThreadOpen",
     "TraceCreate",
     "TraceUpdate",
 ]

--- a/src/opik_mcp/writes/registry.py
+++ b/src/opik_mcp/writes/registry.py
@@ -192,6 +192,34 @@ _REGISTRY: dict[str, WriteOperation] = {
         description="Attach trace + dataset_item rows to an experiment. Always the array envelope.",
         example=EXAMPLES["experiment_item.create"],
     ),
+    "thread.close": WriteOperation(
+        name="thread.close",
+        pydantic_model=MODELS["thread.close"],
+        endpoint="/v1/private/traces/threads/close",
+        method="PUT",
+        oauth_scope=SCOPE_TRACE_SPAN_THREAD_LOG,
+        supports_batch=False,
+        description=(
+            "Close a thread (mark it inactive/done). Pass thread_id + project "
+            "(project_name or project_id)."
+        ),
+        example=EXAMPLES["thread.close"],
+        failure_modes=("thread_project_missing",),
+    ),
+    "thread.open": WriteOperation(
+        name="thread.open",
+        pydantic_model=MODELS["thread.open"],
+        endpoint="/v1/private/traces/threads/open",
+        method="PUT",
+        oauth_scope=SCOPE_TRACE_SPAN_THREAD_LOG,
+        supports_batch=False,
+        description=(
+            "Reopen a previously closed thread (mark it active). Pass thread_id "
+            "+ project (project_name or project_id)."
+        ),
+        example=EXAMPLES["thread.open"],
+        failure_modes=("thread_project_missing",),
+    ),
 }
 
 

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -47,8 +47,22 @@
         }
       ],
       "default": null,
-      "description": "Required when listing traces. UUID of the parent project.",
+      "description": "Parent project UUID for project-scoped lists (trace, thread). Pass this OR project_name.",
       "title": "Project Id"
+    },
+    "project_name": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Parent project name \u2014 alternative to project_id for trace/thread lists, so you don't need to resolve the UUID first.",
+      "title": "Project Name"
     },
     "prompt_id": {
       "anyOf": [

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "entity_type": {
-      "description": "One of: experiment, project, prompt, prompt_version, test_suite, test_suite_item, trace.",
+      "description": "One of: experiment, project, prompt, prompt_version, test_suite, test_suite_item, thread, trace.",
       "enum": [
         "experiment",
         "project",
@@ -9,6 +9,7 @@
         "prompt_version",
         "test_suite",
         "test_suite_item",
+        "thread",
         "trace"
       ],
       "title": "Entity Type",

--- a/tests/conformance/snapshots/read.json
+++ b/tests/conformance/snapshots/read.json
@@ -1,21 +1,22 @@
 {
   "properties": {
     "entity_type": {
-      "description": "One of: experiment, project, prompt, span, test_suite, trace.",
+      "description": "One of: experiment, project, prompt, span, test_suite, thread, trace.",
       "enum": [
         "experiment",
         "project",
         "prompt",
         "span",
         "test_suite",
+        "thread",
         "trace"
       ],
       "title": "Entity Type",
       "type": "string"
     },
     "id": {
-      "description": "UUID, entity name (for nameable types), or full opik:// URI (e.g. opik://traces/<uuid>). When a URI is passed, entity_type is overridden from the URI.",
-      "maxLength": 512,
+      "description": "UUID, entity name (for nameable types), full opik:// URI (e.g. opik://traces/<uuid>), or a pasted Opik thread link. When a URI/link is passed, entity_type (and, for threads, the project) is overridden from it.",
+      "maxLength": 2048,
       "minLength": 1,
       "title": "Id",
       "type": "string"
@@ -34,6 +35,33 @@
       "default": null,
       "description": "Optional token budget. If the entity is under the budget, it's returned in full; otherwise compressed to MEDIUM (long strings truncated with path hints) or SKELETON (structure only). Default ~8k tokens.",
       "title": "Max Tokens"
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Project UUID. Required for entity_type='thread' unless the id is a full thread URL/URI (which carries the project). Ignored for globally-unique entities like trace/span.",
+      "title": "Project Id"
+    },
+    "project_name": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Project name \u2014 alternative to project_id for thread reads.",
+      "title": "Project Name"
     }
   },
   "required": [

--- a/tests/conformance/snapshots/schema.json
+++ b/tests/conformance/snapshots/schema.json
@@ -12,7 +12,9 @@
         "test_suite.create",
         "test_suite_item.upsert",
         "experiment.create",
-        "experiment_item.create"
+        "experiment_item.create",
+        "thread.close",
+        "thread.open"
       ],
       "title": "Operation",
       "type": "string"

--- a/tests/conformance/snapshots/write.json
+++ b/tests/conformance/snapshots/write.json
@@ -46,7 +46,9 @@
         "test_suite.create",
         "test_suite_item.upsert",
         "experiment.create",
-        "experiment_item.create"
+        "experiment_item.create",
+        "thread.close",
+        "thread.open"
       ],
       "title": "Operation",
       "type": "string"

--- a/tests/integration/test_llm_recovery.py
+++ b/tests/integration/test_llm_recovery.py
@@ -134,6 +134,7 @@ async def test_score_thread_error_proposes_array_form_for_retry(
                     "target_id": thread_id,
                     "name": "helpfulness",
                     "value": 0.5,
+                    "project_name": "demo",
                 },
             },
         )

--- a/tests/test_opik_client_read.py
+++ b/tests/test_opik_client_read.py
@@ -6,6 +6,8 @@ envelope is passed through verbatim — normalization to MCP's canonical
 ``{items,nextCursor?,total?}`` shape lives in ``resources.py``.
 """
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -102,6 +104,70 @@ async def test_get_trace_hits_singleton_path() -> None:
         )
         body = await _client().get_trace("tr-1")
     assert body["id"] == "tr-1"
+
+
+@pytest.mark.anyio
+async def test_list_traces_forwards_filters_only_when_set() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get("/v1/private/traces").mock(
+            return_value=httpx.Response(200, json=_page([])),
+        )
+        await _client().list_traces(project_id="p-1")  # no filters
+        assert "filters" not in dict(route.calls.last.request.url.params)
+
+        filt = '[{"field":"thread_id","operator":"=","value":"th-1"}]'
+        await _client().list_traces(project_id="p-1", filters=filt)
+    assert dict(route.calls.last.request.url.params).get("filters") == filt
+
+
+# --- threads -------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_list_threads_requires_project() -> None:
+    with pytest.raises(ValueError, match="project_id or project_name"):
+        await _client().list_threads()
+
+
+@pytest.mark.anyio
+async def test_list_threads_hits_project_scoped_path() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get("/v1/private/traces/threads").mock(
+            return_value=httpx.Response(200, json=_page([{"id": "th-1"}], total=1)),
+        )
+        body = await _client().list_threads(project_id="p-1", page=1, size=25)
+    params = dict(route.calls.last.request.url.params)
+    assert params == {"project_id": "p-1", "page": "1", "size": "25"}
+    assert body["content"][0]["id"] == "th-1"
+
+
+@pytest.mark.anyio
+async def test_get_thread_requires_project() -> None:
+    with pytest.raises(ValueError, match="project_id or project_name"):
+        await _client().get_thread("th-1")
+
+
+@pytest.mark.anyio
+async def test_get_thread_posts_retrieve_body() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.post("/v1/private/traces/threads/retrieve").mock(
+            return_value=httpx.Response(200, json={"id": "th-1", "status": "active"}),
+        )
+        body = await _client().get_thread("th-1", project_name="demo")
+    req = route.calls.last.request
+    sent = json.loads(req.content)
+    assert sent == {"thread_id": "th-1", "truncate": False, "project_name": "demo"}
+    assert body["id"] == "th-1"
+
+
+@pytest.mark.anyio
+async def test_get_thread_maps_404_to_not_found() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.post("/v1/private/traces/threads/retrieve").mock(
+            return_value=httpx.Response(404, json={"message": "nope"}),
+        )
+        with pytest.raises(OpikNotFoundError):
+            await _client().get_thread("th-1", project_id="p-1")
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -159,6 +159,37 @@ async def test_list_threads_requires_project_id() -> None:
 
 
 @pytest.mark.anyio
+async def test_list_threads_accepts_project_name_alternative() -> None:
+    """project_name satisfies the project requirement (no UUID round-trip)."""
+    fake = FakeOpikClient(threads={"content": [{"id": "th-1", "status": "active"}], "total": 1})
+    out = await run_list("thread", project_name="support-bot", client=fake)
+    assert fake.last_kwargs.get("project_name") == "support-bot"
+    assert "project_id" not in fake.last_kwargs
+    assert "th-1" in out
+
+
+@pytest.mark.anyio
+async def test_list_traces_accepts_project_name_alternative() -> None:
+    fake = FakeOpikClient(traces={"content": [], "total": 0})
+    await run_list("trace", project_name="support-bot", client=fake)
+    assert fake.last_kwargs.get("project_name") == "support-bot"
+
+
+@pytest.mark.anyio
+async def test_list_thread_missing_project_error_mentions_name() -> None:
+    with pytest.raises(ToolError, match=r"project_id \(or project_name\)"):
+        await run_list("thread", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_list_project_name_not_forwarded_to_workspace_wide_list() -> None:
+    """project_name must not leak into a non-project-scoped list_fn as a kwarg."""
+    fake = FakeOpikClient(experiments={"content": [], "total": 0})
+    await run_list("experiment", project_name="ignored", client=fake)
+    assert "project_name" not in fake.last_kwargs
+
+
+@pytest.mark.anyio
 async def test_list_threads_renders_thread_columns() -> None:
     fake = FakeOpikClient(
         threads={

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -28,6 +28,7 @@ class FakeOpikClient:
     traces: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
     test_suite_items: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
     prompt_versions: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
+    threads: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
 
     last_kwargs: dict[str, Any] = field(default_factory=dict)
 
@@ -50,6 +51,10 @@ class FakeOpikClient:
     async def list_traces(self, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = kw
         return self.traces
+
+    async def list_threads(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.threads
 
     async def list_test_suite_items(self, test_suite_id: str, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = {"test_suite_id": test_suite_id, **kw}
@@ -145,6 +150,36 @@ async def test_list_test_suite_items_requires_test_suite_id() -> None:
 async def test_list_prompt_versions_requires_prompt_id() -> None:
     with pytest.raises(ToolError, match="requires prompt_id"):
         await run_list("prompt_version", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_list_threads_requires_project_id() -> None:
+    with pytest.raises(ToolError, match="requires project_id"):
+        await run_list("thread", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_list_threads_renders_thread_columns() -> None:
+    fake = FakeOpikClient(
+        threads={
+            "content": [
+                {
+                    "id": "conv-1",
+                    "status": "active",
+                    "number_of_messages": 4,
+                    "last_updated_at": "2026-01-02",
+                }
+            ],
+            "total": 1,
+        }
+    )
+    out = await run_list("thread", project_id="p-1", client=fake)
+    assert fake.last_kwargs.get("project_id") == "p-1"
+    # id column carries the thread identifier; extras render status + counts.
+    assert "conv-1" in out
+    assert "status" in out
+    assert "number_of_messages" in out
+    assert "4" in out
 
 
 # --- entity-type validation ---------------------------------------------- #

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -6,13 +6,14 @@ fetcher functions without spinning up httpx mocks.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
-from opik_mcp.opik_client import OpikNotFoundError
+from opik_mcp.opik_client import OpikNotFoundError, OpikServerError
 from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.read_tool import run_read
 
@@ -36,6 +37,9 @@ class FakeOpikClient:
     test_suites_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     prompts_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     prompt_versions: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    threads_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
+    thread_messages: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    fail_list_traces: bool = False
 
     async def get_project(self, project_id: str) -> dict[str, Any]:
         if project_id not in self.projects_by_id:
@@ -107,9 +111,45 @@ class FakeOpikClient:
     async def list_prompts(self, **_: Any) -> dict[str, Any]:
         return {"content": [], "page": 1, "size": 0, "total": 0}
 
+    async def get_thread(
+        self,
+        thread_id: str,
+        *,
+        project_id: str | None = None,
+        project_name: str | None = None,
+        truncate: bool = False,
+    ) -> dict[str, Any]:
+        if thread_id not in self.threads_by_id:
+            raise OpikNotFoundError(f"thread {thread_id!r} not found (404).")
+        return self.threads_by_id[thread_id]
+
+    async def list_traces(
+        self,
+        *,
+        project_id: str | None = None,
+        project_name: str | None = None,
+        filters: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]:
+        if self.fail_list_traces:
+            raise OpikServerError("boom")
+        # Honor a thread_id filter so the thread fetcher's messages call works.
+        if filters:
+            for f in json.loads(filters):
+                if f.get("field") == "thread_id":
+                    content = self.thread_messages.get(f.get("value"), [])
+                    return {
+                        "content": content,
+                        "page": page,
+                        "size": len(content),
+                        "total": len(content),
+                    }
+        return {"content": [], "page": page, "size": 0, "total": 0}
+
     # OpikListClient surface the read tool doesn't exercise — present so the
     # fake satisfies the Protocol structurally.
-    async def list_traces(self, **_: Any) -> dict[str, Any]:
+    async def list_threads(self, **_: Any) -> dict[str, Any]:
         return {"content": [], "page": 1, "size": 0, "total": 0}
 
     async def list_test_suite_items(self, _test_suite_id: str, **_kw: Any) -> dict[str, Any]:
@@ -223,6 +263,83 @@ async def test_read_accepts_opik_uri_overriding_entity_type() -> None:
 async def test_read_rejects_malformed_uri() -> None:
     with pytest.raises(ToolError, match="opik://"):
         await run_read("trace", "opik://nonsense/x", client=FakeOpikClient())
+
+
+# --- threads -------------------------------------------------------------- #
+
+THREAD = "conv-1"
+_THREAD_META = {"id": THREAD, "status": "active", "project_id": "p-9"}
+
+
+def _thread_fake() -> FakeOpikClient:
+    return FakeOpikClient(
+        threads_by_id={THREAD: _THREAD_META},
+        thread_messages={
+            THREAD: [
+                {"id": "tr-2", "name": "turn2", "input": "b", "start_time": "2026-01-02"},
+                {"id": "tr-1", "name": "turn1", "input": "a", "start_time": "2026-01-01"},
+            ]
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_read_thread_assembles_sorted_messages() -> None:
+    out = await run_read("thread", THREAD, project_id="p-9", client=_thread_fake())
+    assert f"[read: thread {THREAD}" in out
+    assert '"messages"' in out
+    assert '"messagesTruncated": false' in out
+    # ascending by start_time → tr-1 (2026-01-01) precedes tr-2 (2026-01-02)
+    assert out.index("tr-1") < out.index("tr-2")
+    assert '"trace_id"' in out
+
+
+@pytest.mark.anyio
+async def test_read_thread_via_project_name() -> None:
+    out = await run_read("thread", THREAD, project_name="demo", client=_thread_fake())
+    assert f"[read: thread {THREAD}" in out
+
+
+@pytest.mark.anyio
+async def test_read_thread_requires_project() -> None:
+    with pytest.raises(ToolError) as exc:
+        await run_read("thread", THREAD, client=_thread_fake())
+    assert "requires project scope" in str(exc.value)
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_read_thread_via_canonical_uri_carries_project() -> None:
+    # URI supplies the project, so no explicit project arg is needed.
+    out = await run_read("thread", "opik://projects/p-9/threads/conv-1", client=_thread_fake())
+    assert f"[read: thread {THREAD}" in out
+
+
+@pytest.mark.anyio
+async def test_read_thread_via_web_url() -> None:
+    url = "https://app.opik.test/ws/projects/p-9/traces?thread=conv-1"
+    out = await run_read("thread", url, client=_thread_fake())
+    assert f"[read: thread {THREAD}" in out
+
+
+@pytest.mark.anyio
+async def test_read_thread_degrades_on_messages_failure() -> None:
+    fake = _thread_fake()
+    fake.fail_list_traces = True
+    out = await run_read("thread", THREAD, project_id="p-9", client=fake)
+    assert '"messages": []' in out
+    assert '"messagesTruncated": false' in out
+    # the load failure is surfaced, not silently reported as "no messages"
+    assert "messagesError" in out
+    # metadata still present
+    assert '"status"' in out
+
+
+@pytest.mark.anyio
+async def test_read_thread_not_found() -> None:
+    fake = FakeOpikClient()
+    with pytest.raises(ToolError, match="Not found"):
+        await run_read("thread", THREAD, project_id="p-9", client=fake)
 
 
 # --- validation / errors -------------------------------------------------- #

--- a/tests/test_read_list/test_registry.py
+++ b/tests/test_read_list/test_registry.py
@@ -44,3 +44,22 @@ def test_project_scoped_lists_declare_required_kwarg() -> None:
     assert ENTITY_REGISTRY["trace"].list_required_kwargs == ("project_id",)
     assert ENTITY_REGISTRY["test_suite_item"].list_required_kwargs == ("test_suite_id",)
     assert ENTITY_REGISTRY["prompt_version"].list_required_kwargs == ("prompt_id",)
+    assert ENTITY_REGISTRY["thread"].list_required_kwargs == ("project_id",)
+
+
+def test_thread_is_both_readable_and_listable() -> None:
+    assert "thread" in READABLE_TYPES
+    assert "thread" in LISTABLE_TYPES
+
+
+def test_thread_needs_project_and_is_id_only() -> None:
+    handler = ENTITY_REGISTRY["thread"]
+    assert handler.needs_project is True
+    assert handler.id_only is True
+    assert handler.search_by_name_fn is None
+
+
+def test_needs_project_is_thread_only() -> None:
+    """Only thread declares needs_project — every other fetcher is (client, id)."""
+    for entity_type, handler in ENTITY_REGISTRY.items():
+        assert handler.needs_project is (entity_type == "thread")

--- a/tests/test_read_list/test_server_registration.py
+++ b/tests/test_read_list/test_server_registration.py
@@ -46,3 +46,15 @@ async def test_read_tool_schema_advertises_entity_types() -> None:
     # Description should enumerate the readable types
     assert "trace" in et["description"]
     assert "project" in et["description"]
+    # thread is advertised in both the read enum and as a read param surface
+    assert "thread" in et["enum"]
+    assert "project_id" in read_tool.inputSchema["properties"]
+
+
+@pytest.mark.anyio
+async def test_list_tool_schema_advertises_thread() -> None:
+    async with create_connected_server_and_client_session(mcp._mcp_server) as session:
+        await session.initialize()
+        tools = await session.list_tools()
+    list_tool = next(t for t in tools.tools if t.name == "list")
+    assert "thread" in list_tool.inputSchema["properties"]["entity_type"]["enum"]

--- a/tests/test_read_list/test_uri.py
+++ b/tests/test_read_list/test_uri.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from opik_mcp.read_list.uri import InvalidURI, ParsedURI, looks_like_uri, parse
+from opik_mcp.read_list.uri import (
+    InvalidURI,
+    ParsedURI,
+    looks_like_thread_url,
+    looks_like_uri,
+    parse,
+)
 
 
 @pytest.mark.parametrize(
@@ -45,3 +51,37 @@ def test_parse_underscore_form_for_test_suite_rejected() -> None:
     """We canonicalize on hyphens in the URI shape to match the old resources.py."""
     with pytest.raises(InvalidURI):
         parse("opik://test_suites/ds-1")
+
+
+# --- threads -------------------------------------------------------------- #
+
+
+def test_parse_canonical_thread_uri_carries_project() -> None:
+    assert parse("opik://projects/p-9/threads/th-1") == ParsedURI(
+        "thread", "th-1", project_id="p-9"
+    )
+
+
+def test_parse_web_thread_url_extracts_project_and_thread() -> None:
+    url = "https://app.opik.test/my-ws/projects/p-9/traces?page=1&thread=th-1&x=2"
+    assert parse(url) == ParsedURI("thread", "th-1", project_id="p-9")
+
+
+def test_parse_web_thread_url_url_decodes_thread_id() -> None:
+    url = "https://app.opik.test/ws/projects/p-9/traces?thread=conv%2F42"
+    assert parse(url) == ParsedURI("thread", "conv/42", project_id="p-9")
+
+
+def test_looks_like_thread_url() -> None:
+    assert looks_like_thread_url("https://x.test/ws/projects/p/traces?thread=t")
+    assert not looks_like_thread_url("https://x.test/ws/projects/p/traces")  # no thread=
+    assert not looks_like_thread_url("https://x.test/ws/datasets?thread=t")  # no /projects/
+    assert not looks_like_thread_url("opik://projects/p/threads/t")  # not http(s)
+    # 'thread=' is a substring of 'other_thread=' but must NOT be treated as a
+    # thread link — the gate uses the same anchored [?&]thread= regex as parse.
+    assert not looks_like_thread_url("https://x.test/ws/projects/p/traces?other_thread=t")
+
+
+def test_thread_uri_not_confused_with_project_singleton() -> None:
+    # A plain project singleton must still parse as project, not thread.
+    assert parse("opik://projects/p-1") == ParsedURI("project", "p-1")

--- a/tests/test_writes/test_dispatch.py
+++ b/tests/test_writes/test_dispatch.py
@@ -162,6 +162,93 @@ async def test_batch_too_large_rejects_before_be() -> None:
     assert not route.called, "BE was hit despite batch_too_large"
 
 
+# --- thread lifecycle (thread.close / thread.open) ---------------------- #
+
+
+@pytest.mark.anyio
+async def test_thread_close_puts_fixed_endpoint_with_body() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.put("/v1/private/traces/threads/close").mock(
+            return_value=httpx.Response(204)
+        )
+        await run_write(
+            operation="thread.close",
+            data={"thread_id": "conv-1", "project_name": "demo"},
+            client=_client(),
+        )
+    sent = json.loads(route.calls.last.request.content)
+    # exclude_none dump is the wire body verbatim — no target/None fields.
+    assert sent == {"thread_id": "conv-1", "project_name": "demo"}
+
+
+@pytest.mark.anyio
+async def test_thread_open_puts_fixed_endpoint_and_stringifies_uuid() -> None:
+    pid = "00000000-0000-0000-0000-000000000009"
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.put("/v1/private/traces/threads/open").mock(
+            return_value=httpx.Response(204)
+        )
+        await run_write(
+            operation="thread.open",
+            data={"thread_id": "conv-1", "project_id": pid},
+            client=_client(),
+        )
+    sent = json.loads(route.calls.last.request.content)
+    assert sent == {"thread_id": "conv-1", "project_id": pid}
+
+
+@pytest.mark.anyio
+async def test_thread_close_dry_run_reports_fixed_path() -> None:
+    with respx.mock(base_url=OPIK_BASE, assert_all_called=False) as mock:
+        route = mock.route().mock(return_value=httpx.Response(500))
+        result = await run_write(
+            operation="thread.close",
+            data={"thread_id": "conv-1", "project_name": "demo"},
+            dry_run=True,
+            client=_client(),
+        )
+    assert result["would_call"]["method"] == "PUT"
+    assert result["would_call"]["path"] == "/v1/private/traces/threads/close"
+    assert not route.called
+
+
+@pytest.mark.anyio
+async def test_thread_close_requires_log_scope() -> None:
+    with pytest.raises(AuthorizationDeniedError) as exc_info:
+        await run_write(
+            operation="thread.close",
+            data={"thread_id": "conv-1", "project_name": "demo"},
+            scopes=frozenset(),
+            client=_client(),
+        )
+    body = json.loads(exc_info.value.to_json())
+    assert body["required_scope"] == SCOPE_TRACE_SPAN_THREAD_LOG
+
+
+@pytest.mark.anyio
+async def test_thread_close_requires_project() -> None:
+    with pytest.raises(ValidationFailedError) as exc_info:
+        await run_write(
+            operation="thread.close",
+            data={"thread_id": "conv-1"},  # no project
+            client=_client(),
+        )
+    body = json.loads(exc_info.value.to_json())
+    assert any(i.get("code") == "thread_project_missing" for i in body["issues"])
+
+
+@pytest.mark.anyio
+async def test_thread_close_rejects_batch() -> None:
+    with pytest.raises(ValidationFailedError) as exc_info:
+        await run_write(
+            operation="thread.close",
+            data=[{"thread_id": "a"}, {"thread_id": "b"}],
+            client=_client(),
+        )
+    body = json.loads(exc_info.value.to_json())
+    assert any(i.get("code") == "batch_unsupported" for i in body["issues"])
+
+
 # --- OAuth scope rejection ---------------------------------------------- #
 
 

--- a/tests/test_writes/test_dispatch.py
+++ b/tests/test_writes/test_dispatch.py
@@ -287,9 +287,7 @@ async def test_batch_too_large_rejects_before_be() -> None:
 @pytest.mark.anyio
 async def test_thread_close_puts_fixed_endpoint_with_body() -> None:
     with respx.mock(base_url=OPIK_BASE) as mock:
-        route = mock.put("/v1/private/traces/threads/close").mock(
-            return_value=httpx.Response(204)
-        )
+        route = mock.put("/v1/private/traces/threads/close").mock(return_value=httpx.Response(204))
         await run_write(
             operation="thread.close",
             data={"thread_id": "conv-1", "project_name": "demo"},
@@ -304,9 +302,7 @@ async def test_thread_close_puts_fixed_endpoint_with_body() -> None:
 async def test_thread_open_puts_fixed_endpoint_and_stringifies_uuid() -> None:
     pid = "00000000-0000-0000-0000-000000000009"
     with respx.mock(base_url=OPIK_BASE) as mock:
-        route = mock.put("/v1/private/traces/threads/open").mock(
-            return_value=httpx.Response(204)
-        )
+        route = mock.put("/v1/private/traces/threads/open").mock(return_value=httpx.Response(204))
         await run_write(
             operation="thread.open",
             data={"thread_id": "conv-1", "project_id": pid},

--- a/tests/test_writes/test_dispatch.py
+++ b/tests/test_writes/test_dispatch.py
@@ -73,15 +73,17 @@ async def test_score_create_routes_per_target() -> None:
             data={"target": "span", "target_id": target_id, "name": "h", "value": 0.5},
             client=_client(),
         )
-        # Thread requires batch form; pass a one-element array.
+        # Thread requires batch form; thread target_id is the thread_id STRING
+        # and needs a project. Pass a one-element array.
         await run_write(
             operation="score.create",
             data=[
                 {
                     "target": "thread",
-                    "target_id": target_id,
+                    "target_id": "conversation-42",
                     "name": "h",
                     "value": 0.5,
+                    "project_name": "demo",
                 }
             ],
             client=_client(),
@@ -90,10 +92,127 @@ async def test_score_create_routes_per_target() -> None:
     assert trace_route.called
     assert span_route.called
     assert thread_route.called
-    # Verify thread batch body uses thread_id key (not id).
+    # Verify thread batch body uses thread_id key (not id) and carries project.
     body = json.loads(thread_route.calls.last.request.read())
     assert "scores" in body
-    assert body["scores"][0]["thread_id"] == target_id
+    assert body["scores"][0]["thread_id"] == "conversation-42"
+    assert body["scores"][0]["project_name"] == "demo"
+
+
+# --- thread annotation: string thread_id contract ---------------------- #
+
+
+@pytest.mark.anyio
+async def test_score_thread_accepts_string_thread_id() -> None:
+    """A thread score uses the thread_id STRING (not a UUID) as target_id."""
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.put("/v1/private/traces/threads/feedback-scores").mock(
+            return_value=httpx.Response(204)
+        )
+        await run_write(
+            operation="score.create",
+            data=[
+                {
+                    "target": "thread",
+                    "target_id": "support-2026-07-23-alex",
+                    "name": "resolution",
+                    "value": 1,
+                    "project_name": "support-bot",
+                }
+            ],
+            client=_client(),
+        )
+    item = json.loads(route.calls.last.request.read())["scores"][0]
+    assert item["thread_id"] == "support-2026-07-23-alex"
+    assert item["project_name"] == "support-bot"
+    assert "target" not in item and "target_id" not in item
+
+
+@pytest.mark.anyio
+async def test_comment_thread_resolves_model_uuid_for_path() -> None:
+    """comment on a thread: caller passes the thread_id string; the dispatcher
+    resolves it to the thread model UUID the BE's comment path requires."""
+    model_uuid = "019f8eaf-aa13-732d-8157-cb067ea60bed"
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        retrieve = mock.post("/v1/private/traces/threads/retrieve").mock(
+            return_value=httpx.Response(
+                200, json={"id": "support-2026-07-23-alex", "thread_model_id": model_uuid}
+            )
+        )
+        comment = mock.post(f"/v1/private/traces/threads/{model_uuid}/comments").mock(
+            return_value=httpx.Response(201)
+        )
+        await run_write(
+            operation="comment.create",
+            data={
+                "target": "thread",
+                "target_id": "support-2026-07-23-alex",
+                "text": "duplicate refunded",
+                "project_name": "support-bot",
+            },
+            client=_client(),
+        )
+    assert retrieve.called and comment.called
+    rb = json.loads(retrieve.calls.last.request.read())
+    assert rb["thread_id"] == "support-2026-07-23-alex" and rb["project_name"] == "support-bot"
+    assert json.loads(comment.calls.last.request.read())["text"] == "duplicate refunded"
+
+
+@pytest.mark.anyio
+async def test_comment_thread_not_found_surfaces_recovery() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.post("/v1/private/traces/threads/retrieve").mock(
+            return_value=httpx.Response(404, json={"message": "no such thread"})
+        )
+        with pytest.raises(ValidationFailedError) as exc_info:
+            await run_write(
+                operation="comment.create",
+                data={
+                    "target": "thread",
+                    "target_id": "ghost",
+                    "text": "x",
+                    "project_name": "support-bot",
+                },
+                client=_client(),
+            )
+    body = json.loads(exc_info.value.to_json())
+    assert any(i.get("code") == "thread_not_found" for i in body["issues"])
+
+
+@pytest.mark.anyio
+async def test_comment_thread_resolve_backend_error_is_structured() -> None:
+    """A non-404 failure during the resolve surfaces as a structured BackendError,
+    not a raw OpikError that would bypass the write tool's JSON envelope."""
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.post("/v1/private/traces/threads/retrieve").mock(
+            return_value=httpx.Response(403, json={"message": "denied"})
+        )
+        with pytest.raises(BackendError) as exc_info:
+            await run_write(
+                operation="comment.create",
+                data={"target": "thread", "target_id": "t", "text": "x", "project_name": "p"},
+                client=_client(),
+            )
+    body = json.loads(exc_info.value.to_json())
+    assert body["error"] == "backend_error"
+    assert body["backend_error"]["status"] == 403
+
+
+@pytest.mark.anyio
+async def test_score_trace_canonicalizes_non_dashed_uuid() -> None:
+    """A brace/urn/dashless UUID validates locally AND is normalized to the
+    canonical dashed form the Java BE path requires."""
+    canon = "00000000-0000-0000-0000-000000000001"
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.put(f"/v1/private/traces/{canon}/feedback-scores").mock(
+            return_value=httpx.Response(204)
+        )
+        await run_write(
+            operation="score.create",
+            data={"target": "trace", "target_id": f"{{{canon}}}", "name": "h", "value": 0.5},
+            client=_client(),
+        )
+    assert route.called  # matched only if target_id was canonicalized
 
 
 # --- single vs. batch endpoint selection -------------------------------- #

--- a/tests/test_writes/test_models.py
+++ b/tests/test_writes/test_models.py
@@ -89,14 +89,60 @@ async def test_score_thread_single_form_returns_array_example() -> None:
             operation="score.create",
             data={
                 "target": "thread",
-                "target_id": "00000000-0000-0000-0000-000000000001",
+                "target_id": "conversation-42",  # thread_id string
                 "name": "helpfulness",
                 "value": 0.5,
+                "project_name": "demo",
             },
         )
     body = json.loads(exc_info.value.to_json())
     assert any("thread_requires_batch" in i.get("code", "") for i in body["issues"])
     assert isinstance(body["example"], list), "thread error must propose the array form"
+
+
+@pytest.mark.anyio
+async def test_score_trace_non_uuid_target_id_rejected() -> None:
+    """trace/span target_id must be a UUID — a non-UUID gives a clear code."""
+    from opik_mcp.writes.dispatch import run_write
+
+    with pytest.raises(ValidationFailedError) as exc_info:
+        await run_write(
+            operation="score.create",
+            data={"target": "trace", "target_id": "not-a-uuid", "name": "h", "value": 0.5},
+        )
+    body = json.loads(exc_info.value.to_json())
+    assert any(i.get("code") == "target_id_not_uuid" for i in body["issues"])
+
+
+@pytest.mark.anyio
+async def test_score_thread_without_project_rejected() -> None:
+    """thread annotations need a project (thread_id is unique only within one)."""
+    from opik_mcp.writes.dispatch import run_write
+
+    with pytest.raises(ValidationFailedError) as exc_info:
+        await run_write(
+            operation="score.create",
+            data=[{"target": "thread", "target_id": "conv-1", "name": "h", "value": 0.5}],
+        )
+    body = json.loads(exc_info.value.to_json())
+    assert any(i.get("code") == "thread_project_missing" for i in body["issues"])
+
+
+@pytest.mark.anyio
+async def test_comment_thread_accepts_string_id_with_project() -> None:
+    """A thread comment with the thread_id string + project clears validation
+    (Stage 2), reaching Stage 3 authorization under empty scopes."""
+    from opik_mcp.writes.dispatch import run_write
+    from opik_mcp.writes.errors import WriteError
+
+    with pytest.raises(WriteError) as exc_info:
+        await run_write(
+            operation="comment.create",
+            data={"target": "thread", "target_id": "conv-1", "text": "hi", "project_name": "p"},
+            dry_run=True,
+            scopes=frozenset(),
+        )
+    assert exc_info.value.error == "authorization_denied"
 
 
 @pytest.mark.anyio

--- a/tests/test_writes/test_models.py
+++ b/tests/test_writes/test_models.py
@@ -228,6 +228,35 @@ async def test_experiment_item_create_bare_object_returns_envelope_example() -> 
     assert "experiment_items" in body["example"]
 
 
+# --- thread lifecycle negatives ------------------------------------------ #
+
+
+@pytest.mark.anyio
+async def test_thread_close_missing_thread_id() -> None:
+    from opik_mcp.writes.dispatch import run_write
+
+    with pytest.raises(ValidationFailedError) as exc_info:
+        await run_write(operation="thread.close", data={"project_name": "demo"})
+    body = json.loads(exc_info.value.to_json())
+    fields = {i["field"] for i in body["issues"]}
+    assert "thread_id" in fields
+
+
+@pytest.mark.anyio
+async def test_thread_open_forbids_unknown_field() -> None:
+    from opik_mcp.writes.dispatch import run_write
+
+    with pytest.raises(ValidationFailedError) as exc_info:
+        await run_write(
+            operation="thread.open",
+            # 'status' is not a field; project present so only the extra trips.
+            data={"thread_id": "conv-1", "project_name": "demo", "status": "active"},
+        )
+    body = json.loads(exc_info.value.to_json())
+    fields = {i["field"] for i in body["issues"]}
+    assert "status" in fields
+
+
 # --- unknown operation rejected at Stage 1 ------------------------------- #
 
 


### PR DESCRIPTION
## Full thread support in the MCP (OPIK-7443)

Makes `thread` a first-class Opik entity across the MCP tool surface. Before this
PR, threads were only a *write/annotate* target (and even that was broken for real
threads — see the fix below). Now an agent can **read**, **list**, **annotate**,
and **close/reopen** a thread through one uniform, self-documenting contract.

### The contract (why it's good LLM UX)

One rule everywhere: **pass the `thread_id` string you see in `list('thread')` /
`read('thread')`, plus the project (id *or* name)**. The server absorbs every
backend asymmetry so the model never juggles identifiers:

| Surface | Tool call |
|---|---|
| Read a thread as a conversation | `read('thread', <thread_id>, project_id\|project_name)` → `{thread, messages, messagesTruncated}`; each message = one turn's trace input/output + a `trace_id` to `read('trace', …)` |
| List a project's threads | `list('thread', project_id\|project_name)` |
| Score / comment a thread | `write score.create` / `comment.create` with `target="thread"`, `target_id=<thread_id string>` + project |
| Close / reopen | `write thread.close` / `thread.open` with `{thread_id, project}` |

## What's in here (4 commits)

- **`feat(read/list)` — thread as a readable/listable entity.**
  `read('thread', …)` returns metadata + the messages list (traces filtered by
  `thread_id`, up to 200 inlined, sorted ascending). `list('thread', project_id=…)`
  enumerates a project's threads. New client methods `get_thread`
  (`POST …/threads/retrieve`), `list_threads`, `list_traces(filters=…)`, and a
  `_post_json` read helper. URI/link parsing: `opik://projects/<p>/threads/<t>`
  and pasted Opik web thread URLs (`looks_like_thread_url`). `read` gains
  `project_id`/`project_name` (a thread_id is unique only within a project).

- **`feat(write)` — `thread.close` / `thread.open` lifecycle.**
  Two write operations toggling thread status (active ↔ inactive), via the
  universal `write` tool. The dispatcher's `_build_request` is an explicit
  `if name == …` chain (no generic fallthrough — a branchless op would hit a
  `RuntimeError`), so both got a real branch. Verified against opik-backend:
  these are **`PUT`** (not POST) and return 204.

- **`fix(write)` — thread score/comment by `thread_id` string.**
  `score.create`/`comment.create` typed `target_id` as `UUID`, so annotating any
  real thread failed with `uuid_parsing` (thread_ids are user-supplied strings).
  Now a shared `_AnnotationTarget` base validates per target: UUID for
  trace/span (canonicalized), the `thread_id` string for thread, with a required
  project. For `comment`, the dispatcher resolves the string thread_id → the
  thread's model UUID (the BE's `POST /threads/{id}/comments` needs the UUID) so
  the caller never sees the asymmetry.

- **`feat(list)` — `project_name` for trace/thread lists.**
  `list('thread'/'trace')` now accepts `project_name` as an alternative to
  `project_id`, matching every other thread tool and removing a forced
  `list('project')` UUID round-trip.

## Verification

- **Reviewed against opik-backend source** for every endpoint/identifier
  (`TracesResource` `@PUT /threads/{open,close}`, `addThreadComment(@PathParam UUID)`,
  `FeedbackScoreBatchItemThread` project fields, the `thread_id` filter operator).
  Multi-agent adversarial review on each phase caught and fixed real issues
  pre-merge (POST→PUT verb, string-vs-UUID identifiers, a missed `schema.json`
  snapshot, a silent message-load degrade, non-404 resolve errors bypassing the
  write envelope).
- **Live E2E on dev.comet.com** through the built server over MCP stdio:
  create a thread → `list` (by id and by name) → `read` (turns in order) →
  `score` + `comment` by string id (comment resolves to the model-UUID path) →
  read back (both annotations present) → `close` (inactive) → `open` (active).
  All green.
- `ruff` + strict `mypy` (src + tests) clean; **1143 tests** pass; conformance
  snapshots (`read`/`list`/`write`/`schema`) regenerated.

## Notes

- **Not in scope (deliberately):** destructive `thread.delete`, feedback-score
  delete, thread tag updates, thread stats. Clean follow-ups.
- No breaking changes to existing surfaces; trace/span score & comment behavior
  is unchanged (target_id UUID still required and now canonicalized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
