### PR TITLE
[DO NOT MERGE] [OPIK-7592] Add `opik-mcp skills` install CLI (non-MCP front door)

### DIFF
--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -238,6 +238,14 @@ def _emit_server_shutdown(
 
 
 def main() -> None:
+    # `opik-mcp skills ...` is a local, offline file-copy subcommand — it must
+    # short-circuit before any settings load, analytics, or server startup.
+    argv = sys.argv[1:]
+    if argv and argv[0] == "skills":
+        from opik_mcp.skills_install import run as run_skills
+
+        raise SystemExit(run_skills(argv[1:]))
+
     try:
         settings = get_settings()
     except ValidationError as e:

--- a/src/opik_mcp/skills_install.py
+++ b/src/opik_mcp/skills_install.py
@@ -1,0 +1,130 @@
+"""``opik-mcp skills`` — install the bundled skills onto disk (OPIK-7592).
+
+The skills served over MCP by ``read_skill`` also ship inside the wheel (see
+``skills/``). This subcommand copies them to a local skills directory so a
+coding agent can use them **without** connecting the MCP — the non-MCP front
+door, in code form. No server, no auth: a plain file copy from the installed
+package.
+
+Usage::
+
+    opik-mcp skills list
+    opik-mcp skills install [--dir DIR] [--force] [SKILL ...]
+
+``--dir`` defaults to ``.claude/skills`` under the current directory. Pass
+specific skill names to install a subset; omit them to install all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from importlib.resources import as_file, files
+from importlib.resources.abc import Traversable
+from pathlib import Path
+
+_DEFAULT_DIR = Path(".claude") / "skills"
+
+# Block scalar indicators a YAML frontmatter ``description:`` may use instead of
+# an inline value ("description: >"); when seen, the real text is on the
+# following indented lines.
+_BLOCK_SCALARS = frozenset({"", ">", "|", ">-", "|-", ">+", "|+"})
+
+
+def _skills_root() -> Traversable:
+    return files("opik_mcp") / "skills"
+
+
+def _available() -> list[str]:
+    """Skill names = immediate sub-directories of ``skills/`` (skips files)."""
+    return sorted(p.name for p in _skills_root().iterdir() if p.is_dir())
+
+
+def _describe(name: str) -> str:
+    """First line of a skill's ``description:`` frontmatter, best-effort."""
+    try:
+        text = (_skills_root() / name / "SKILL.md").read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return ""
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("description:"):
+            continue
+        value = stripped[len("description:") :].strip()
+        if value not in _BLOCK_SCALARS:
+            return value.strip('"').strip("'")
+        # Folded/literal block scalar — gather the following indented lines.
+        collected: list[str] = []
+        for nxt in lines[i + 1 :]:
+            if nxt.strip() == "" or not nxt.startswith((" ", "\t")):
+                break
+            collected.append(nxt.strip())
+            if sum(len(c) for c in collected) > 90:
+                break
+        return " ".join(collected)
+    return ""
+
+
+def _cmd_list() -> int:
+    for name in _available():
+        desc = _describe(name)
+        print(f"{name:<14}  {desc[:88]}" if desc else name)
+    return 0
+
+
+def _cmd_install(dest: Path, only: list[str], force: bool) -> int:
+    available = _available()
+    picks = only or available
+    unknown = [s for s in picks if s not in available]
+    if unknown:
+        print(f"unknown skill(s): {', '.join(unknown)}", file=sys.stderr)
+        print(f"available: {', '.join(available)}", file=sys.stderr)
+        return 2
+
+    dest.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with as_file(_skills_root()) as root:  # concrete path even from a zip import
+        for name in picks:
+            target = dest / name
+            if target.exists() and not force:
+                print(f"skip {name} — already exists (use --force to overwrite)")
+                continue
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(Path(root) / name, target)
+            print(f"installed {name} -> {target}")
+            written += 1
+    print(f"\nDone. {written} skill(s) written to {dest}.")
+    return 0
+
+
+def run(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="opik-mcp skills",
+        description="Install the Opik coding-agent skills onto disk (no MCP required).",
+    )
+    sub = parser.add_subparsers(dest="action")
+    sub.add_parser("list", help="list the bundled skills and their descriptions")
+    inst = sub.add_parser("install", help="copy skills into a local directory")
+    inst.add_argument(
+        "--dir",
+        type=Path,
+        default=_DEFAULT_DIR,
+        help="target skills directory (default: .claude/skills)",
+    )
+    inst.add_argument(
+        "--force", action="store_true", help="overwrite existing skill directories"
+    )
+    inst.add_argument(
+        "skills", nargs="*", help="specific skills to install (default: all)"
+    )
+
+    args = parser.parse_args(argv)
+    if args.action == "list":
+        return _cmd_list()
+    if args.action == "install":
+        return _cmd_install(args.dir, args.skills, args.force)
+    parser.print_help()
+    return 1

--- a/tests/test_skills_install.py
+++ b/tests/test_skills_install.py
@@ -13,7 +13,7 @@ import pytest
 
 from opik_mcp.skills_install import _available, run
 
-SHARED_SKILLS = ("opik", "agent-ops", "opik-sdk", "evaluation")
+SHARED_SKILLS = ("opik", "agent-ops", "evaluation")
 
 
 def test_available_lists_the_shared_skills() -> None:

--- a/tests/test_skills_install.py
+++ b/tests/test_skills_install.py
@@ -13,7 +13,7 @@ import pytest
 
 from opik_mcp.skills_install import _available, run
 
-SHARED_SKILLS = ("opik", "agent-ops", "evaluation")
+SHARED_SKILLS = ("opik", "evaluate")
 
 
 def test_available_lists_the_shared_skills() -> None:
@@ -44,7 +44,7 @@ def test_install_subset(tmp_path: Path) -> None:
     dest = tmp_path / "skills"
     assert run(["install", "--dir", str(dest), "opik"]) == 0
     assert (dest / "opik" / "SKILL.md").is_file()
-    assert not (dest / "agent-ops").exists()
+    assert not (dest / "evaluate").exists()
 
 
 def test_install_unknown_skill_errors(tmp_path: Path) -> None:

--- a/tests/test_skills_install.py
+++ b/tests/test_skills_install.py
@@ -1,0 +1,67 @@
+"""`opik-mcp skills` CLI — list + install onto disk without the MCP (OPIK-7592).
+
+Exercises the offline front-door: `list` names the bundled skills, `install`
+copies them into a target dir, unknown names are rejected, and an existing
+skill is skipped unless `--force` is given.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opik_mcp.skills_install import _available, run
+
+SHARED_SKILLS = ("opik", "agent-ops", "opik-sdk", "evaluation")
+
+
+def test_available_lists_the_shared_skills() -> None:
+    available = _available()
+    for skill in SHARED_SKILLS:
+        assert skill in available
+    # the folder README is a file, not a skill directory
+    assert "README" not in available and "README.md" not in available
+
+
+def test_list_prints_skill_names(capsys: pytest.CaptureFixture[str]) -> None:
+    assert run(["list"]) == 0
+    out = capsys.readouterr().out
+    for skill in SHARED_SKILLS:
+        assert skill in out
+
+
+def test_install_all_copies_skill_trees(tmp_path: Path) -> None:
+    dest = tmp_path / "skills"
+    assert run(["install", "--dir", str(dest)]) == 0
+    for skill in SHARED_SKILLS:
+        assert (dest / skill / "SKILL.md").is_file()
+    # references travel with the skill
+    assert (dest / "opik" / "references").is_dir()
+
+
+def test_install_subset(tmp_path: Path) -> None:
+    dest = tmp_path / "skills"
+    assert run(["install", "--dir", str(dest), "opik"]) == 0
+    assert (dest / "opik" / "SKILL.md").is_file()
+    assert not (dest / "agent-ops").exists()
+
+
+def test_install_unknown_skill_errors(tmp_path: Path) -> None:
+    assert run(["install", "--dir", str(tmp_path / "s"), "does-not-exist"]) == 2
+
+
+def test_install_skips_existing_without_force(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dest = tmp_path / "skills"
+    run(["install", "--dir", str(dest), "opik"])
+    marker = dest / "opik" / "MARKER.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    assert run(["install", "--dir", str(dest), "opik"]) == 0
+    assert "skip opik" in capsys.readouterr().out
+    assert marker.exists()  # untouched — directory was not overwritten
+
+    assert run(["install", "--dir", str(dest), "--force", "opik"]) == 0
+    assert not marker.exists()  # --force replaced the tree


### PR DESCRIPTION
Adds `opik-mcp skills list` / `opik-mcp skills install [--dir] [--force]` to export the bundled skills to disk — a convenience alongside the primary `npx skills add comet-ml/opik-skills` path.

Mirrors the shared set from #154 (`/opik`, `/evaluate`). **Stacked on #154** — rebase once it merges so the CLI exports the final folded set. OPIK-7592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
