### PR TITLE
[DO NOT MERGE] [OPIK-7649] Scaffold: /explain skill

### DIFF
--- a/src/opik_mcp/skills/explain/SKILL.md
+++ b/src/opik_mcp/skills/explain/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: explain
+description: Root-cause a specific trace or behavior — what went wrong and why. Reasons against your code by default (SDK); escalates to Ollie for workspace-wide investigation when the hosted MCP is connected.
+last_updated: "2026-07-30"
+source_commit: "TODO"
+---
+
+# Explain — root-cause a specific trace   <!-- SCAFFOLD (OPIK-7649) -->
+
+> **Scaffold — not yet implemented.** Behavior is specified below; the steps are TODO.
+
+## Intent
+Given a trace (often from `/find`), produce a grounded root-cause: what went wrong, why, and a suggested next step, citing the relevant spans.
+
+## Transport — two paths, one output
+- **SDK (default):** fetch the trace + spans; the coding agent reasons **against your code**. No MCP required.
+- **MCP / Ollie (when connected on Opik Cloud):** escalate to `ask_ollie` for workspace-wide investigation. `ask_ollie` is the only MCP-only capability.
+
+Same output shape either way (root cause + evidence spans + next step).
+
+## Definition of done
+- [ ] Grounded root-cause over the SDK path with no MCP required.
+- [ ] Escalates to Ollie when available; identical output shape.
+
+## Open question
+Validate whether Ollie out-root-causes the coding agent for a single trace (Ollie lacks repo context) before calling the Ollie path "recommended."

--- a/src/opik_mcp/skills/explain/SKILL.md
+++ b/src/opik_mcp/skills/explain/SKILL.md
@@ -12,11 +12,8 @@ source_commit: "TODO"
 ## Intent
 Given a trace (often from `/find`), produce a grounded root-cause: what went wrong, why, and a suggested next step, citing the relevant spans.
 
-## Transport — two paths, one output
-- **SDK (default):** fetch the trace + spans; the coding agent reasons **against your code**. No MCP required.
-- **MCP / Ollie (when connected on Opik Cloud):** escalate to `ask_ollie` for workspace-wide investigation. `ask_ollie` is the only MCP-only capability.
-
-Same output shape either way (root cause + evidence spans + next step).
+## Transport
+The agent runs the investigation itself over data it fetches via the SDK — a single trace, or a broader set (via `list` / `agent_insights`) for a pattern. **No MCP required.** When the hosted MCP is connected, it can optionally hand off to `ask_ollie` as an *alternative* reasoner — a convenience, not a gate. Output shape is the same either way (root cause + evidence spans + next step).
 
 ## Definition of done
 - [ ] Grounded root-cause over the SDK path with no MCP required.


### PR DESCRIPTION
Scaffold for the `/explain` task skill (OPIK-7649) — skeleton `SKILL.md` with intent, transport, and definition of done; implementation steps are TODO. **Stacked on #154** (shared-skills move); base retargets to `main` when #154 merges. Part of the "Opik for Agents" epic (OPIK-7623). **DO NOT MERGE** until authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)