### PR TITLE
feat(analytics): resolve real caller identity for BI events

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,13 @@ curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS / Linux
 You'll need two things from your Opik workspace:
 
 - **`OPIK_API_KEY`** — get it from [`comet.com/api/my/settings/`](https://www.comet.com/api/my/settings/).
-- **`OPIK_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. Optional — defaults to `default` (the Opik SDK convention), which is correct for local/OSS installs; cloud users with a named workspace should set it. `COMET_WORKSPACE` is accepted as a deprecated alias.
-
-> **Pre-release note:** `opik-mcp` (Python) is not yet published to PyPI. Until
-> the first PyPI release lands, replace `uvx opik-mcp` in any snippet below with:
-> `uvx --from git+https://github.com/comet-ml/opik-mcp.git opik-mcp`
+- **`OPIK_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. Optional: leave it unset and cloud installs resolve your account's workspace automatically. Do **not** set it to the literal `default` — that is a placeholder for local/OSS installs, and it is also a real cloud workspace belonging to someone else, so setting it on a cloud install misattributes your usage. `COMET_WORKSPACE` is accepted as a deprecated alias.
 
 > **`OPIK_WORKSPACE` is optional.** Omit the `OPIK_WORKSPACE` line/key in any
-> snippet below and the server uses the `default` workspace (correct for
-> local/OSS installs). Set it only if you connect to a named cloud workspace.
+> snippet below. On a cloud install the server resolves your account's workspace
+> for you; on a local/OSS install it falls back to the `default` placeholder.
+> Set it explicitly only when you work in a named workspace that is not your
+> account default.
 
 ### Claude Code
 
@@ -305,9 +303,9 @@ Every setting is an environment variable. Required ones in **bold**.
 | Variable | Default | Notes |
 |---|---|---|
 | **`OPIK_API_KEY`** | — | Required for `ask_ollie` and any authenticated read/write. |
-| `OPIK_WORKSPACE` | `default` | Workspace name. Optional — falls back to `default` (Opik SDK convention). Cloud users with a named workspace should set it. |
+| `OPIK_WORKSPACE` | _unset_ | Workspace name. Optional — cloud installs resolve the account workspace; local/OSS installs fall back to the `default` placeholder. Set it only for a named workspace that is not your account default, and never to the literal `default` on cloud. |
 | `COMET_WORKSPACE` | — | Deprecated alias for `OPIK_WORKSPACE` (backward compat). `OPIK_WORKSPACE` wins if both are set. |
-| `COMET_WORKSPACE_ID` | — | Optional workspace UUID. Stamped into analytics events when set so BI can join on a stable id rather than the (mutable) workspace name. |
+| `COMET_WORKSPACE_ID` | _unset_ | Optional workspace UUID. Stamped into analytics events when set, and takes precedence over the resolved one. Rarely needed — OAuth installs get the UUID from the token automatically. |
 | `COMET_URL_OVERRIDE` | `https://www.comet.com` | Set to your self-hosted Comet host, or `https://dev.comet.com` for staging. |
 | `OPIK_URL` | derived from `COMET_URL_OVERRIDE` + `/opik/api` | Override only if Opik lives on a different host/path than the Comet UI. |
 | `OPIK_DEFAULT_PROJECT_NAME` | _unset_ | When set, the per-session `instructions` blob tells the LLM to pass this as `project_name` on every tool call unless the user names a different project. |

--- a/src/opik_mcp/account_identity.py
+++ b/src/opik_mcp/account_identity.py
@@ -38,7 +38,7 @@ from urllib.parse import urlparse
 import httpx
 
 from opik_mcp.config import Settings, installation_type
-from opik_mcp.session_identity import (
+from opik_mcp.credential_identity import (
     ResolvedIdentity,
     credential_digest,
     lookup_identity,

--- a/src/opik_mcp/account_identity.py
+++ b/src/opik_mcp/account_identity.py
@@ -1,0 +1,237 @@
+"""Resolve the caller's identity from a Comet API key.
+
+The API-key install — the documented ``uvx`` path — knows nothing about who is
+running it. The login lives on the Comet side, behind the same endpoint the Opik
+Python SDK already uses to validate a key and find its default workspace:
+``GET /api/rest/v2/account-details``, authenticated with the key itself. It
+returns ``userName`` and ``defaultWorkspaceName``.
+
+Three rules shape everything here, and all three exist to keep telemetry from
+ever being felt by a user:
+
+- **Startup never waits.** Boot reads a disk cache and moves on. A miss or a
+  stale entry triggers a refresh on a background daemon thread; the events
+  emitted before it lands are reported anonymously and say so.
+- **Only where it can work.** Cloud deployments only. This endpoint does not
+  exist on a self-hosted Opik, and a self-hosted install must not pay a timeout
+  for an answer it can never get.
+- **Failure is silent.** Unreachable host, non-200, malformed body, unreadable
+  or unwritable cache — every one of them degrades to "we don't know", never to
+  an error and never to a retry storm.
+
+The cache is keyed by a digest of the key, never the key itself, so rotating a
+credential resolves fresh identity instead of reporting the previous user, and
+no new plaintext copy of a secret is written to disk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from opik_mcp.config import Settings, installation_type
+from opik_mcp.session_identity import (
+    ResolvedIdentity,
+    credential_digest,
+    lookup_identity,
+    remember_identity,
+)
+
+logger = logging.getLogger("opik_mcp.account_identity")
+
+# Path of the Comet account-details endpoint, matching the Opik Python SDK
+# (``opik.url_helpers.URL_ACCOUNT_DETAILS_POSTFIX``).
+_ACCOUNT_DETAILS_PATH = "/api/rest/v2/account-details"
+
+# A resolved login is stable for as long as the user does not rename themselves,
+# so a day between refreshes is generous. Short enough that a rename corrects
+# itself without anyone intervening.
+CACHE_TTL_SECONDS = 24 * 60 * 60
+
+# Deliberately tight: this never blocks anything a user waits on, but a hung
+# connection should not keep a daemon thread alive for minutes either.
+_TIMEOUT_SECONDS = 5.0
+
+# One in-flight refresh per credential digest, so a burst of events at startup
+# cannot fan out into a burst of identical HTTP calls.
+_INFLIGHT: set[str] = set()
+_INFLIGHT_LOCK = threading.Lock()
+
+
+def _cache_path() -> Path:
+    return Path.home() / ".opik-mcp" / "identity-cache.json"
+
+
+def _account_details_url(settings: Settings) -> str | None:
+    """The account-details URL for this deployment's Comet host, or ``None``.
+
+    Built from the host only — the Opik REST base carries an ``/opik/api``
+    suffix that this endpoint does not live under.
+    """
+    raw = settings.opik_url or settings.comet_url_override or ""
+    if not raw:
+        return None
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}{_ACCOUNT_DETAILS_PATH}"
+
+
+def _read_cache() -> dict[str, Any]:
+    try:
+        return json.loads(_cache_path().read_text())  # type: ignore[no-any-return]
+    except Exception:
+        # Missing, unreadable or corrupt — all mean "no cached answer".
+        return {}
+
+
+def _write_cache(digest: str, user_name: str | None, workspace_name: str | None) -> None:
+    try:
+        path = _cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        cache = _read_cache()
+        cache[digest] = {
+            "user_name": user_name,
+            "workspace_name": workspace_name,
+            "cached_at": time.time(),
+        }
+        path.write_text(json.dumps(cache))
+        try:
+            path.chmod(0o600)
+        except OSError:
+            logger.debug("could not chmod identity cache", exc_info=True)
+    except Exception:
+        # A read-only or full filesystem costs us the cache, not the feature:
+        # the in-memory store still holds the answer for this process.
+        logger.debug("identity cache not written", exc_info=True)
+
+
+def _entry_is_fresh(entry: dict[str, Any]) -> bool:
+    cached_at = entry.get("cached_at")
+    if not isinstance(cached_at, int | float):
+        return False
+    return (time.time() - cached_at) < CACHE_TTL_SECONDS
+
+
+def _identity_from_entry(entry: dict[str, Any]) -> ResolvedIdentity:
+    return ResolvedIdentity(
+        user_name=entry.get("user_name") or None,
+        workspace_name=entry.get("workspace_name") or None,
+        # This endpoint has never returned a workspace UUID. The OAuth path
+        # supplies one; here the workspace name is the join key.
+        workspace_id=None,
+        source="api_key",
+    )
+
+
+def _fetch(url: str, api_key: str) -> tuple[str | None, str | None] | None:
+    """``(user_name, default_workspace_name)`` from Comet, or ``None`` on any failure."""
+    try:
+        with httpx.Client(timeout=_TIMEOUT_SECONDS) as client:
+            response = client.get(url, headers={"Authorization": api_key})
+        if response.status_code != 200:
+            logger.debug("account-details returned %s", response.status_code)
+            return None
+        body = response.json()
+    except Exception:
+        logger.debug("account-details lookup failed", exc_info=True)
+        return None
+    if not isinstance(body, dict):
+        return None
+    user_name = body.get("userName")
+    workspace_name = body.get("defaultWorkspaceName")
+    return (
+        user_name if isinstance(user_name, str) and user_name else None,
+        workspace_name if isinstance(workspace_name, str) and workspace_name else None,
+    )
+
+
+def _refresh(url: str, api_key: str, digest: str) -> None:
+    """Fetch and store. Runs on a daemon thread; must never raise."""
+    try:
+        fetched = _fetch(url, api_key)
+        if fetched is None:
+            return
+        user_name, workspace_name = fetched
+        if user_name is None and workspace_name is None:
+            return
+        remember_identity(
+            api_key,
+            ResolvedIdentity(
+                user_name=user_name,
+                workspace_name=workspace_name,
+                workspace_id=None,
+                source="api_key",
+            ),
+        )
+        _write_cache(digest, user_name, workspace_name)
+    except Exception:
+        logger.debug("identity refresh failed", exc_info=True)
+    finally:
+        with _INFLIGHT_LOCK:
+            _INFLIGHT.discard(digest)
+
+
+def resolve_api_key_identity(settings: Settings) -> ResolvedIdentity | None:
+    """Identity for this install's API key, if we have one; refresh if we don't.
+
+    Returns immediately, always. The answer comes from memory, then from the
+    disk cache; a miss or a stale entry starts a background refresh whose result
+    lands on a later event.
+    """
+    api_key = settings.opik_api_key
+    if not api_key:
+        return None
+    # Self-hosted and local deployments have no account-details endpoint. Skip
+    # entirely rather than spending a timeout to learn that every time.
+    if installation_type(settings) != "cloud":
+        return None
+
+    known = lookup_identity(api_key)
+    digest = credential_digest(api_key)
+    entry = _read_cache().get(digest)
+
+    if known is None and isinstance(entry, dict):
+        known = _identity_from_entry(entry)
+        remember_identity(api_key, known)
+
+    if isinstance(entry, dict) and _entry_is_fresh(entry):
+        return known
+
+    url = _account_details_url(settings)
+    if url is not None:
+        with _INFLIGHT_LOCK:
+            already_running = digest in _INFLIGHT
+            if not already_running:
+                _INFLIGHT.add(digest)
+        if not already_running:
+            threading.Thread(
+                target=_refresh,
+                args=(url, api_key, digest),
+                name="opik-mcp-identity",
+                daemon=True,
+            ).start()
+
+    # Whatever we have right now — possibly nothing, possibly a stale answer
+    # that is still far better than none.
+    return known
+
+
+def reset_account_identity_for_tests() -> None:
+    """Drop in-flight bookkeeping. Test-only — never call from production."""
+    with _INFLIGHT_LOCK:
+        _INFLIGHT.clear()
+
+
+__all__ = [
+    "CACHE_TTL_SECONDS",
+    "reset_account_identity_for_tests",
+    "resolve_api_key_identity",
+]

--- a/src/opik_mcp/account_identity.py
+++ b/src/opik_mcp/account_identity.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 import time
 from pathlib import Path
@@ -64,6 +65,26 @@ _TIMEOUT_SECONDS = 5.0
 _INFLIGHT: set[str] = set()
 _INFLIGHT_LOCK = threading.Lock()
 
+# Floor between refresh ATTEMPTS for one credential, successful or not. Without
+# it, any condition that stops an answer from being persisted — an unwritable
+# HOME, a read-only container, a key the endpoint rejects — turns every single
+# event into a fresh lookup, which is the retry storm this module promises not
+# to cause.
+_MIN_RETRY_INTERVAL_SECONDS = 300.0
+
+# When the identity currently in memory was obtained, and when we last tried.
+# Both are in-memory only: the disk cache survives restarts, this bookkeeping
+# does not need to.
+_RESOLVED_AT: dict[str, float] = {}
+_LAST_ATTEMPT: dict[str, float] = {}
+_ATTEMPT_LOCK = threading.Lock()
+
+# The disk cache is read ONCE per process. ``_build_event`` runs on whichever
+# thread is emitting, so parsing a JSON file per event would put disk I/O on the
+# caller's path. After the first read, memory is the source of truth.
+_DISK_CACHE: dict[str, Any] | None = None
+_DISK_LOCK = threading.Lock()
+
 
 def _cache_path() -> Path:
     return Path.home() / ".opik-mcp" / "identity-cache.json"
@@ -86,10 +107,20 @@ def _account_details_url(settings: Settings) -> str | None:
 
 def _read_cache() -> dict[str, Any]:
     try:
-        return json.loads(_cache_path().read_text())  # type: ignore[no-any-return]
+        loaded = json.loads(_cache_path().read_text())
     except Exception:
         # Missing, unreadable or corrupt — all mean "no cached answer".
         return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _disk_cache() -> dict[str, Any]:
+    """The on-disk cache, read at most once per process."""
+    global _DISK_CACHE
+    with _DISK_LOCK:
+        if _DISK_CACHE is None:
+            _DISK_CACHE = _read_cache()
+        return _DISK_CACHE
 
 
 def _write_cache(digest: str, user_name: str | None, workspace_name: str | None) -> None:
@@ -102,11 +133,19 @@ def _write_cache(digest: str, user_name: str | None, workspace_name: str | None)
             "workspace_name": workspace_name,
             "cached_at": time.time(),
         }
-        path.write_text(json.dumps(cache))
+        # Write-then-rename: a second opik-mcp process (one per MCP host is
+        # normal) must never observe a half-written file. Last writer wins on
+        # the whole map, which at worst costs the other process one lookup.
+        tmp = path.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(cache))
         try:
-            path.chmod(0o600)
+            tmp.chmod(0o600)
         except OSError:
             logger.debug("could not chmod identity cache", exc_info=True)
+        os.replace(tmp, path)
+        with _DISK_LOCK:
+            global _DISK_CACHE
+            _DISK_CACHE = cache
     except Exception:
         # A read-only or full filesystem costs us the cache, not the feature:
         # the in-memory store still holds the answer for this process.
@@ -127,7 +166,6 @@ def _identity_from_entry(entry: dict[str, Any]) -> ResolvedIdentity:
         # This endpoint has never returned a workspace UUID. The OAuth path
         # supplies one; here the workspace name is the join key.
         workspace_id=None,
-        source="api_key",
     )
 
 
@@ -168,9 +206,9 @@ def _refresh(url: str, api_key: str, digest: str) -> None:
                 user_name=user_name,
                 workspace_name=workspace_name,
                 workspace_id=None,
-                source="api_key",
             ),
         )
+        _RESOLVED_AT[digest] = time.time()
         _write_cache(digest, user_name, workspace_name)
     except Exception:
         logger.debug("identity refresh failed", exc_info=True)
@@ -182,9 +220,9 @@ def _refresh(url: str, api_key: str, digest: str) -> None:
 def resolve_api_key_identity(settings: Settings) -> ResolvedIdentity | None:
     """Identity for this install's API key, if we have one; refresh if we don't.
 
-    Returns immediately, always. The answer comes from memory, then from the
-    disk cache; a miss or a stale entry starts a background refresh whose result
-    lands on a later event.
+    Returns immediately, always. The answer comes from memory (populated from
+    the disk cache on first use); a miss or a stale entry starts a background
+    refresh whose result lands on a later event.
     """
     api_key = settings.opik_api_key
     if not api_key:
@@ -194,40 +232,58 @@ def resolve_api_key_identity(settings: Settings) -> ResolvedIdentity | None:
     if installation_type(settings) != "cloud":
         return None
 
-    known = lookup_identity(api_key)
     digest = credential_digest(api_key)
-    entry = _read_cache().get(digest)
+    known = lookup_identity(api_key)
 
-    if known is None and isinstance(entry, dict):
-        known = _identity_from_entry(entry)
-        remember_identity(api_key, known)
+    if known is None:
+        entry = _disk_cache().get(digest)
+        if isinstance(entry, dict):
+            known = _identity_from_entry(entry)
+            remember_identity(api_key, known)
+            cached_at = entry.get("cached_at")
+            _RESOLVED_AT[digest] = cached_at if isinstance(cached_at, int | float) else 0.0
 
-    if isinstance(entry, dict) and _entry_is_fresh(entry):
+    now = time.time()
+    if known is not None and (now - _RESOLVED_AT.get(digest, 0.0)) < CACHE_TTL_SECONDS:
         return known
 
-    url = _account_details_url(settings)
-    if url is not None:
-        with _INFLIGHT_LOCK:
-            already_running = digest in _INFLIGHT
-            if not already_running:
-                _INFLIGHT.add(digest)
-        if not already_running:
-            threading.Thread(
-                target=_refresh,
-                args=(url, api_key, digest),
-                name="opik-mcp-identity",
-                daemon=True,
-            ).start()
-
+    _maybe_refresh(settings, api_key, digest, now)
     # Whatever we have right now — possibly nothing, possibly a stale answer
     # that is still far better than none.
     return known
 
 
+def _maybe_refresh(settings: Settings, api_key: str, digest: str, now: float) -> None:
+    """Start a background refresh unless one is running or was tried recently."""
+    url = _account_details_url(settings)
+    if url is None:
+        return
+    with _ATTEMPT_LOCK:
+        if (now - _LAST_ATTEMPT.get(digest, 0.0)) < _MIN_RETRY_INTERVAL_SECONDS:
+            return
+        _LAST_ATTEMPT[digest] = now
+    with _INFLIGHT_LOCK:
+        if digest in _INFLIGHT:
+            return
+        _INFLIGHT.add(digest)
+    threading.Thread(
+        target=_refresh,
+        args=(url, api_key, digest),
+        name="opik-mcp-identity",
+        daemon=True,
+    ).start()
+
+
 def reset_account_identity_for_tests() -> None:
-    """Drop in-flight bookkeeping. Test-only — never call from production."""
+    """Drop all bookkeeping and the cached disk read. Test-only."""
+    global _DISK_CACHE
     with _INFLIGHT_LOCK:
         _INFLIGHT.clear()
+    with _ATTEMPT_LOCK:
+        _RESOLVED_AT.clear()
+        _LAST_ATTEMPT.clear()
+    with _DISK_LOCK:
+        _DISK_CACHE = None
 
 
 __all__ = [

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -18,11 +18,11 @@ from typing import Any
 
 import httpx
 
+from opik_mcp.account_identity import resolve_api_key_identity
 from opik_mcp.analytics.identity import (
     OPIK_MCP_VERSION,
     api_key_sha256,
     get_install_id,
-    resolve_anonymous_id,
 )
 from opik_mcp.auth_context import (
     classify_bearer,
@@ -30,7 +30,8 @@ from opik_mcp.auth_context import (
     inbound_workspace,
     settings_auth_mode,
 )
-from opik_mcp.config import Settings, installation_type
+from opik_mcp.config import DEFAULT_WORKSPACE, Settings, installation_type
+from opik_mcp.session_identity import ResolvedIdentity, lookup_identity
 
 logger = logging.getLogger("opik_mcp.analytics")
 
@@ -215,12 +216,25 @@ class AnalyticsClient:
             # actually maps to when the user took the action.
             "timestamp": datetime.now(UTC).isoformat(),
         }
-        if self._settings.comet_workspace:
-            common["workspace"] = self._settings.comet_workspace
-        if self._settings.comet_workspace_id:
+        identity = self._resolve_identity()
+        workspace, workspace_kind = self._resolve_workspace(identity)
+        if workspace:
+            common["workspace"] = workspace
+            # Which of the three the name is: resolved from the backend, chosen
+            # by the operator, or the self-hosted placeholder. BI needs this to
+            # avoid joining a placeholder onto the real customer workspace that
+            # shares its name.
+            common["workspace_kind"] = workspace_kind
+        # An explicitly configured UUID still wins — it is the operator stating a
+        # fact about their deployment. Otherwise take the one the backend bound
+        # to the credential, which is available for OAuth callers today.
+        workspace_id = self._settings.comet_workspace_id or (
+            identity.workspace_id if identity else None
+        )
+        if workspace_id:
             # Stable UUID for the workspace — preferred join key in BI; the
             # workspace `name` is human-readable but mutable.
-            common["workspace_id"] = self._settings.comet_workspace_id
+            common["workspace_id"] = workspace_id
         if self._settings.opik_api_key:
             # Pseudonymous per-user identity. The raw key NEVER leaves the
             # process; the backend retains the raw-key → user-id mapping and
@@ -242,14 +256,71 @@ class AnalyticsClient:
         # must not shadow the server-stamped value); caller properties win over
         # per-request so server_started's settings-derived auth_mode beats the
         # contextvar-derived one (which is "none" at boot, no request in flight).
+        # comet-stats indexes events by top-level `user_id`. It carries the
+        # caller's Comet login when we know it — the same plaintext value the
+        # product sends to Segment/PostHog, and the warehouse's own user key —
+        # and the anonymous install id when we don't. It deliberately no longer
+        # carries a workspace name: one field cannot mean two things, and the
+        # workspace is reported in its own fields above.
+        if identity is not None and identity.user_name:
+            user_id, user_id_kind = identity.user_name, "comet_user"
+        else:
+            user_id, user_id_kind = get_install_id(), "install_id"
+        # Says which of the two the field holds, so a count of real users is a
+        # filter rather than a guess. Its ABSENCE is also how BI separates events
+        # predating this change, which carried the old overloaded semantics.
+        common["user_id_kind"] = user_id_kind
+
         return {
-            # comet-stats indexes events by top-level `user_id`. Kept as
-            # workspace name → install_id for dashboard continuity. The
-            # per-user identity is in event_properties.api_key_sha256.
-            "user_id": resolve_anonymous_id(self._settings),
+            "user_id": user_id,
             "event_type": event_type,
             "event_properties": {**per_request, **properties, **common},
         }
+
+    def _resolve_identity(self) -> ResolvedIdentity | None:
+        """Who is calling, if the backend has told us.
+
+        Reads the inbound bearer to learn *which* credential is in play, then
+        looks the answer up in the credential-keyed store the handshake filled.
+        Returns ``None`` whenever we simply do not know — every caller degrades
+        to anonymous telemetry rather than guessing.
+        """
+        try:
+            inbound_auth = inbound_authorization.get()
+            if inbound_auth:
+                _mode, token = classify_bearer(inbound_auth)
+                if token:
+                    return lookup_identity(token)
+                # A forwarded non-OAuth credential belongs to the caller, not to
+                # this process — resolving it against our own settings would
+                # attribute their call to us.
+                return None
+            # stdio / no inbound credential: the install's own API key is the
+            # caller. Never blocks — see account_identity.
+            return resolve_api_key_identity(self._settings)
+        except Exception:
+            logger.debug("identity resolution failed", exc_info=True)
+        return None
+
+    def _resolve_workspace(self, identity: ResolvedIdentity | None) -> tuple[str | None, str]:
+        """The workspace to report, and where it came from.
+
+        A workspace the operator deliberately configured wins: they may well be
+        working outside their account default, and reporting the default instead
+        would be wrong. The backend-resolved name wins over an *absent* setting
+        and over the literal placeholder — which our own docs invited operators
+        to set, and which collides with a real customer workspace of the same
+        name in the warehouse.
+        """
+        configured = self._settings.comet_workspace
+        resolved = identity.workspace_name if identity else None
+        if configured and configured != DEFAULT_WORKSPACE:
+            return configured, "configured"
+        if resolved:
+            return resolved, "resolved"
+        if configured:
+            return configured, "placeholder"
+        return None, ""
 
     def _per_request_props(self) -> dict[str, str]:
         """Identity derived from the inbound-auth ContextVars (HTTP/OAuth mode).

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -6,7 +6,6 @@ Daemon-thread worker model (not asyncio): callable from any context, including
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import platform
 import queue
@@ -32,7 +31,11 @@ from opik_mcp.auth_context import (
     settings_auth_mode,
 )
 from opik_mcp.config import DEFAULT_WORKSPACE, Settings, installation_type
-from opik_mcp.session_identity import ResolvedIdentity, lookup_identity
+from opik_mcp.credential_identity import (
+    ResolvedIdentity,
+    credential_digest,
+    lookup_identity,
+)
 
 logger = logging.getLogger("opik_mcp.analytics")
 
@@ -353,7 +356,7 @@ class AnalyticsClient:
                 if token:  # oauth bearer
                     # PRIVACY: only the digest is emitted; the raw token never
                     # enters the result.
-                    props["token_sha256"] = hashlib.sha256(token.encode("utf-8")).hexdigest()
+                    props["token_sha256"] = credential_digest(token)
             else:
                 # No inbound header: stdio or unauthenticated HTTP. Fall back to
                 # the settings-derived mode (shared with auth_mode_at_boot, so an

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -17,8 +17,7 @@ from typing import Any
 
 import httpx
 
-from opik_mcp.account_identity import resolve_api_key_identity
-from opik_mcp.analytics.events import UserIdKind, WorkspaceKind
+from opik_mcp.analytics.events import Attributed, UserIdKind, WorkspaceKind
 from opik_mcp.analytics.identity import (
     OPIK_MCP_VERSION,
     api_key_sha256,
@@ -30,12 +29,9 @@ from opik_mcp.auth_context import (
     inbound_workspace,
     settings_auth_mode,
 )
+from opik_mcp.caller_identity import caller_identity
 from opik_mcp.config import DEFAULT_WORKSPACE, Settings, installation_type
-from opik_mcp.credential_identity import (
-    ResolvedIdentity,
-    credential_digest,
-    lookup_identity,
-)
+from opik_mcp.credential_identity import ResolvedIdentity, credential_digest
 
 logger = logging.getLogger("opik_mcp.analytics")
 
@@ -220,15 +216,15 @@ class AnalyticsClient:
             # actually maps to when the user took the action.
             "timestamp": datetime.now(UTC).isoformat(),
         }
-        identity = self._resolve_identity()
-        workspace, workspace_kind = self._resolve_workspace(identity)
-        if workspace and workspace_kind:
-            common["workspace"] = workspace
+        identity = caller_identity(self._settings)
+        workspace = self._resolve_workspace(identity)
+        if workspace is not None:
+            common["workspace"] = workspace.value
             # Which of the three the name is: resolved from the backend, chosen
             # by the operator, or the self-hosted placeholder. BI needs this to
             # avoid joining a placeholder onto the real customer workspace that
             # shares its name.
-            common["workspace_kind"] = workspace_kind
+            common["workspace_kind"] = workspace.kind
         # An explicitly configured UUID still wins — it is the operator stating a
         # fact about their deployment. Otherwise take the one the backend bound
         # to the credential, which is available for OAuth callers today.
@@ -266,50 +262,28 @@ class AnalyticsClient:
         # and the anonymous install id when we don't. It deliberately no longer
         # carries a workspace name: one field cannot mean two things, and the
         # workspace is reported in its own fields above.
-        user_id_kind: UserIdKind
-        if identity is not None and identity.user_name:
-            user_id, user_id_kind = identity.user_name, "comet_user"
-        else:
-            user_id, user_id_kind = get_install_id(), "install_id"
+        user = self._resolve_user(identity)
         # Says which of the two the field holds, so a count of real users is a
         # filter rather than a guess. Its ABSENCE is also how BI separates events
         # predating this change, which carried the old overloaded semantics.
-        common["user_id_kind"] = user_id_kind
+        common["user_id_kind"] = user.kind
 
         return {
-            "user_id": user_id,
+            "user_id": user.value,
             "event_type": event_type,
             "event_properties": {**per_request, **properties, **common},
         }
 
-    def _resolve_identity(self) -> ResolvedIdentity | None:
-        """Who is calling, if the backend has told us.
-
-        Reads the inbound bearer to learn *which* credential is in play, then
-        looks the answer up in the credential-keyed store the handshake filled.
-        Returns ``None`` whenever we simply do not know — every caller degrades
-        to anonymous telemetry rather than guessing.
-        """
-        try:
-            inbound_auth = inbound_authorization.get()
-            if inbound_auth:
-                _mode, token = classify_bearer(inbound_auth)
-                if token:
-                    return lookup_identity(token)
-                # A forwarded non-OAuth credential belongs to the caller, not to
-                # this process — resolving it against our own settings would
-                # attribute their call to us.
-                return None
-            # stdio / no inbound credential: the install's own API key is the
-            # caller. Never blocks — see account_identity.
-            return resolve_api_key_identity(self._settings)
-        except Exception:
-            logger.debug("identity resolution failed", exc_info=True)
-        return None
+    @staticmethod
+    def _resolve_user(identity: ResolvedIdentity | None) -> Attributed[UserIdKind]:
+        """The caller's login when known, the anonymous install id when not."""
+        if identity is not None and identity.user_name:
+            return Attributed(identity.user_name, "comet_user")
+        return Attributed(get_install_id(), "install_id")
 
     def _resolve_workspace(
         self, identity: ResolvedIdentity | None
-    ) -> tuple[str | None, WorkspaceKind | None]:
+    ) -> Attributed[WorkspaceKind] | None:
         """The workspace to report, and where it came from.
 
         A workspace the operator deliberately configured wins: they may well be
@@ -322,12 +296,12 @@ class AnalyticsClient:
         configured = self._settings.comet_workspace
         resolved = identity.workspace_name if identity else None
         if configured and configured != DEFAULT_WORKSPACE:
-            return configured, "configured"
+            return Attributed(configured, "configured")
         if resolved:
-            return resolved, "resolved"
+            return Attributed(resolved, "resolved")
         if configured:
-            return configured, "placeholder"
-        return None, None
+            return Attributed(configured, "placeholder")
+        return None
 
     def _per_request_props(self) -> dict[str, str]:
         """Identity derived from the inbound-auth ContextVars (HTTP/OAuth mode).

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -19,6 +19,7 @@ from typing import Any
 import httpx
 
 from opik_mcp.account_identity import resolve_api_key_identity
+from opik_mcp.analytics.events import UserIdKind, WorkspaceKind
 from opik_mcp.analytics.identity import (
     OPIK_MCP_VERSION,
     api_key_sha256,
@@ -218,7 +219,7 @@ class AnalyticsClient:
         }
         identity = self._resolve_identity()
         workspace, workspace_kind = self._resolve_workspace(identity)
-        if workspace:
+        if workspace and workspace_kind:
             common["workspace"] = workspace
             # Which of the three the name is: resolved from the backend, chosen
             # by the operator, or the self-hosted placeholder. BI needs this to
@@ -262,6 +263,7 @@ class AnalyticsClient:
         # and the anonymous install id when we don't. It deliberately no longer
         # carries a workspace name: one field cannot mean two things, and the
         # workspace is reported in its own fields above.
+        user_id_kind: UserIdKind
         if identity is not None and identity.user_name:
             user_id, user_id_kind = identity.user_name, "comet_user"
         else:
@@ -302,7 +304,9 @@ class AnalyticsClient:
             logger.debug("identity resolution failed", exc_info=True)
         return None
 
-    def _resolve_workspace(self, identity: ResolvedIdentity | None) -> tuple[str | None, str]:
+    def _resolve_workspace(
+        self, identity: ResolvedIdentity | None
+    ) -> tuple[str | None, WorkspaceKind | None]:
         """The workspace to report, and where it came from.
 
         A workspace the operator deliberately configured wins: they may well be
@@ -320,7 +324,7 @@ class AnalyticsClient:
             return resolved, "resolved"
         if configured:
             return configured, "placeholder"
-        return None, ""
+        return None, None
 
     def _per_request_props(self) -> dict[str, str]:
         """Identity derived from the inbound-auth ContextVars (HTTP/OAuth mode).
@@ -333,7 +337,7 @@ class AnalyticsClient:
         cohort. PRIVACY: the raw bearer token never enters the result — only its
         sha256 digest, and only for ``OAUTH_ACCESS_TOKEN_PREFIX``-prefixed OAuth
         tokens. ``request_workspace`` mirrors the existing plaintext ``workspace``
-        posture (workspace names are used as ``user_id`` in ``resolve_anonymous_id``).
+        posture — a workspace name is a tenant label, not a person.
         """
         props: dict[str, str] = {}
         try:

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -19,19 +19,35 @@ Each Literal documents the *only* values the receiver will ever see for that
 property. Anything outside the allowlist is bucketed to a fallback ("other",
 "unknown", "") at the emit site — the receiver never sees raw host input.
 
-Two declared exceptions to "boolean / enum / bucket":
+Three declared exceptions to "boolean / enum / bucket":
 
 - Pseudonymous identity hashes (``api_key_sha256``, ``token_sha256``) are
   64-char SHA-256 hex digests. Not enums, but safe: irreversible one-way
-  transforms of secrets the backend already holds (it joins on the digest).
-  The raw key/token NEVER leaves the process. This is enforced by tests that
-  call ``client._build_event`` directly
+  transforms of secrets the backend already holds. The raw key/token NEVER
+  leaves the process. This is enforced by tests that call
+  ``client._build_event`` directly
   (``tests/test_analytics_client_build_event.py``); the recorder-based tests in
   ``test_analytics_privacy.py`` intercept at ``track_event`` and never see what
   ``_build_event`` builds, so they cannot catch a leak inside it.
 - Workspace fields (``workspace``, ``request_workspace``, ``workspace_id``) are
-  emitted as plaintext/UUID — an accepted posture, since the workspace name is
-  already used as the top-level ``user_id`` (``resolve_anonymous_id``).
+  emitted as plaintext/UUID — an accepted posture: the workspace name is a
+  tenant label, not a person, and BI cannot attribute usage without it.
+- **Caller identity** (top-level ``user_id``) is the caller's Comet login, in
+  plaintext. This is a deliberate amendment to the original "identity only as a
+  digest" rule, agreed with BI, and it is the ONLY personal identifier emitted.
+  Three reasons it is sanctioned rather than hashed:
+
+  1. It is what the rest of the product already sends. The Opik frontend
+     identifies users to Segment, PostHog and Reo.Dev with this same plaintext
+     login; opik-mcp was the outlier.
+  2. The warehouse's canonical user key *is* that login. A digest would be
+     unjoinable, recreating the dead end already demonstrated by
+     ``api_key_sha256``, for which no key→user mapping exists anywhere.
+  3. It travels to Comet's own analytics endpoint — a service that already
+     holds the value.
+
+  ``user_id_kind`` declares which sort of identifier the field holds, so a
+  reader never has to infer it. Widening identity does NOT widen anything else.
 
 Never emit free-text queries, paths, filenames, or other user prose.
 """

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -47,7 +47,10 @@ Three declared exceptions to "boolean / enum / bucket":
      holds the value.
 
   ``user_id_kind`` declares which sort of identifier the field holds, so a
-  reader never has to infer it. Widening identity does NOT widen anything else.
+  reader never has to infer it. Widening identity does NOT widen anything else:
+  that the login appears ONLY as ``user_id`` and never bleeds into
+  ``event_properties`` is pinned in ``tests/test_analytics_client_build_event.py``
+  (the recorder-based suite cannot see the common block — see its docstring).
 
 Never emit free-text queries, paths, filenames, or other user prose.
 """
@@ -161,6 +164,19 @@ ResourceUriScheme = Literal["https", "http", "none"]
 # build_app() Starlette lifespan, the hosted Docker/--factory path). Lets BI
 # confirm the hosted fleet is no longer dark for boot events (GAP#1).
 LifecycleSource = Literal["main", "lifespan"]
+
+# ``user_id_kind``: what the top-level ``user_id`` actually holds. The classifier
+# is ``client._build_event``. BI counts real users with
+# ``WHERE user_id_kind = 'comet_user'``; the field's ABSENCE marks events emitted
+# before identity resolution shipped, when ``user_id`` was a workspace name
+# falling back to an install id.
+UserIdKind = Literal["comet_user", "install_id"]
+
+# ``workspace_kind``: where the reported ``workspace`` name came from. The
+# classifier is ``client._resolve_workspace``. CRITICAL for BI: "placeholder" is
+# the literal "default" on an install that resolved nothing, and it collides with
+# a real cloud workspace of that name — those rows must never be name-joined.
+WorkspaceKind = Literal["resolved", "configured", "placeholder"]
 
 
 EVENT_SERVER_STARTED = "opik_mcp_server_started"

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -57,6 +57,7 @@ Never emit free-text queries, paths, filenames, or other user prose.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
 # ``launch_method``: bucketed ``sys.executable`` path. See
@@ -177,6 +178,21 @@ UserIdKind = Literal["comet_user", "install_id"]
 # the literal "default" on an install that resolved nothing, and it collides with
 # a real cloud workspace of that name — those rows must never be name-joined.
 WorkspaceKind = Literal["resolved", "configured", "placeholder"]
+
+
+@dataclass(frozen=True, slots=True)
+class Attributed[K: str]:
+    """A value emitted alongside the discriminator that says where it came from.
+
+    Both identity fields in the common block have this shape — a string BI reads,
+    plus a Literal saying how to interpret it — and neither is safe to read
+    without the other: a login and an install id are both strings, and a resolved
+    workspace and the placeholder are both names. Pairing them in one type is
+    what stops an emit site stamping the value and forgetting the label.
+    """
+
+    value: str
+    kind: K
 
 
 EVENT_SERVER_STARTED = "opik_mcp_server_started"

--- a/src/opik_mcp/analytics/identity.py
+++ b/src/opik_mcp/analytics/identity.py
@@ -2,13 +2,14 @@
 
 - ``get_install_id()``: per-laptop UUID4 persisted at ``~/.opik-mcp/install-id``.
   Mirrors ``MetadataDAO.ANONYMOUS_ID`` in opik-backend, file-backed.
-- ``resolve_anonymous_id(settings)``: top-level ``user_id`` for comet-stats —
-  workspace name → install_id. **Kept stable on purpose**; the per-user
-  identity ships as ``event_properties.api_key_sha256`` so BI dashboards
-  built against the old ``user_id`` semantics keep working.
-- ``api_key_sha256(key)``: per-user pseudonymous identity. SHA-256 of the
-  OPIK_API_KEY. The backend retains the raw-key → user-id mapping; BI joins
-  on the digest. The raw key NEVER leaves this module.
+- ``api_key_sha256(key)``: SHA-256 of the OPIK_API_KEY, emitted as a stable
+  pseudonymous per-credential label. NOTE: it is not a usable join key on its
+  own — the warehouse holds no api-key-hash → user mapping, which is why real
+  identity is resolved from the backend instead (see ``session_identity``).
+  The raw key NEVER leaves this module.
+
+The top-level ``user_id`` is assembled in ``analytics.client``; see the note at
+the foot of this module for what used to live here and why it is gone.
 """
 
 from __future__ import annotations
@@ -19,8 +20,6 @@ from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from uuid import UUID, uuid4
-
-from opik_mcp.config import Settings
 
 logger = logging.getLogger("opik_mcp.analytics.identity")
 
@@ -103,24 +102,28 @@ def install_id_was_freshly_generated() -> bool:
 
 
 def api_key_sha256(api_key: str) -> str:
-    """SHA-256 hex digest of the API key. Stable, irreversible, per-user.
+    """SHA-256 hex digest of the API key. Stable, irreversible, per-credential.
 
-    The backend retains the raw-key → user-id mapping; BI can JOIN on the
-    digest to recover the Comet user account without ever seeing plaintext.
+    A useful label for grouping calls made with the same key. It is NOT a user
+    join key: this module used to claim the backend retained a raw-key → user-id
+    mapping BI could join on, and it does not — a digest join against the
+    warehouse returns zero matches. Real identity is resolved from the backend
+    (see ``session_identity``); this stays as a credential-level label only.
+
     Lowercase hex (64 chars) matches the convention used elsewhere in Comet
     (e.g. ``hashlib.sha256(...).hexdigest()`` defaults).
     """
     return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
 
 
-def resolve_anonymous_id(settings: Settings) -> str:
-    """Top-level ``user_id`` for comet-stats: workspace name → install_id.
-
-    Intentionally does NOT include the api_key hash. comet-stats indexes
-    events by ``user_id`` and existing Metabase / Looker dashboards filter
-    and join on workspace strings; flipping that field to a 64-char hex
-    digest would discontinuously break those queries. The per-user identity
-    is exposed as ``event_properties.api_key_sha256`` instead — BI can
-    migrate join keys on its own schedule.
-    """
-    return settings.comet_workspace or get_install_id()
+# NOTE: there is deliberately no `resolve_anonymous_id` here any more.
+#
+# It used to compute the top-level `user_id` as "workspace name → install_id",
+# kept that way so dashboards built on the old meaning would not break. The
+# warehouse showed what that cost: 75.1% of events carried a workspace name in
+# the user field, 24.8% an install id, and 0% an actual user — a column that
+# looked fully populated while answering the wrong question.
+#
+# `user_id` is now the caller's Comet login (see `client._build_event`), falling
+# back to `get_install_id()` only when no identity could be resolved, with
+# `user_id_kind` saying which. Do not reintroduce the workspace fallback.

--- a/src/opik_mcp/analytics/identity.py
+++ b/src/opik_mcp/analytics/identity.py
@@ -5,7 +5,7 @@
 - ``api_key_sha256(key)``: SHA-256 of the OPIK_API_KEY, emitted as a stable
   pseudonymous per-credential label. NOTE: it is not a usable join key on its
   own — the warehouse holds no api-key-hash → user mapping, which is why real
-  identity is resolved from the backend instead (see ``session_identity``).
+  identity is resolved from the backend instead (see ``credential_identity``).
   The raw key NEVER leaves this module.
 
 The top-level ``user_id`` is assembled in ``analytics.client``; see the note at
@@ -14,12 +14,13 @@ the foot of this module for what used to live here and why it is gone.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from uuid import UUID, uuid4
+
+from opik_mcp.credential_identity import credential_digest
 
 logger = logging.getLogger("opik_mcp.analytics.identity")
 
@@ -108,12 +109,13 @@ def api_key_sha256(api_key: str) -> str:
     join key: this module used to claim the backend retained a raw-key → user-id
     mapping BI could join on, and it does not — a digest join against the
     warehouse returns zero matches. Real identity is resolved from the backend
-    (see ``session_identity``); this stays as a credential-level label only.
+    (see ``credential_identity``); this stays as a credential-level label only.
 
-    Lowercase hex (64 chars) matches the convention used elsewhere in Comet
-    (e.g. ``hashlib.sha256(...).hexdigest()`` defaults).
+    Lowercase hex (64 chars) matches the convention used elsewhere in Comet.
+    Delegates to ``credential_digest`` so every digest in the codebase is the
+    same transform; this function exists for the BI-facing name.
     """
-    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+    return credential_digest(api_key)
 
 
 # NOTE: there is deliberately no `resolve_anonymous_id` here any more.

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -39,7 +39,7 @@ inbound_authorization: ContextVar[str | None] = ContextVar("inbound_authorizatio
 inbound_workspace: ContextVar[str | None] = ContextVar("inbound_workspace", default=None)
 
 # OAuth-authorized workspace *name*, resolved from the opaque bearer via
-# ``oauth_identity.resolve_workspace_name`` on the ``initialize`` handshake.
+# ``oauth_identity.resolve_oauth_identity`` on the ``initialize`` handshake.
 # Consumed ONLY by the instructions blob (``instructions.render_instructions``)
 # so an agent can truthfully name the workspace it is operating against. Kept
 # deliberately separate from ``inbound_workspace`` so this read-only display

--- a/src/opik_mcp/caller_identity.py
+++ b/src/opik_mcp/caller_identity.py
@@ -1,0 +1,52 @@
+"""Which identity applies to the call being made right now.
+
+Three modules can each answer "who is this": ``oauth_identity`` introspects an
+inbound bearer, ``account_identity`` resolves this install's own API key, and
+``credential_identity`` remembers what either of them found. This module owns the
+one policy question that sits above all three — *whose* credential is in play —
+so that the analytics layer can stamp an answer without also deciding it.
+
+The rule is short and worth stating plainly, because getting it wrong
+misattributes usage rather than merely losing it:
+
+- An **inbound bearer** belongs to the caller, not to this process. Its identity
+  is whatever the handshake resolved and stored against that token. If nothing
+  was stored, the call is anonymous — falling back to this server's own
+  configured identity would credit somebody else's work to the operator.
+- **No inbound credential** means stdio, or unauthenticated HTTP. Here the
+  install's own API key *is* the caller, so resolving it against settings is
+  correct.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from opik_mcp.account_identity import resolve_api_key_identity
+from opik_mcp.auth_context import classify_bearer, inbound_authorization
+from opik_mcp.config import Settings
+from opik_mcp.credential_identity import ResolvedIdentity, lookup_identity
+
+logger = logging.getLogger("opik_mcp.caller_identity")
+
+
+def caller_identity(settings: Settings) -> ResolvedIdentity | None:
+    """The identity of whoever is making this call, or ``None`` if unknown.
+
+    Never raises and never blocks: identity is a telemetry nicety, and the call
+    it describes must not be affected by it in any way.
+    """
+    try:
+        inbound_auth = inbound_authorization.get()
+        if inbound_auth:
+            _mode, token = classify_bearer(inbound_auth)
+            # Only an OAuth bearer has an identity we could have resolved; a
+            # forwarded API-key-shaped credential is opaque to us.
+            return lookup_identity(token) if token else None
+        return resolve_api_key_identity(settings)
+    except Exception:
+        logger.debug("caller identity resolution failed", exc_info=True)
+        return None
+
+
+__all__ = ["caller_identity"]

--- a/src/opik_mcp/credential_identity.py
+++ b/src/opik_mcp/credential_identity.py
@@ -60,7 +60,15 @@ _LOCK = threading.Lock()
 
 
 def credential_digest(credential: str) -> str:
-    """SHA-256 hex digest of a credential. The raw value never leaves the caller."""
+    """SHA-256 hex digest of a credential. The raw value never leaves the caller.
+
+    The single implementation of this transform in the codebase. ``analytics``
+    re-exports it under BI-facing names (``api_key_sha256``, ``token_sha256``)
+    because those are contract terms in the event schema, but there is exactly
+    one place the hashing actually happens — three hand-rolled copies of
+    ``hashlib.sha256(x.encode("utf-8")).hexdigest()`` is three chances to drift
+    on encoding or casing, and BI joins on the exact string.
+    """
     return hashlib.sha256(credential.encode("utf-8")).hexdigest()
 
 

--- a/src/opik_mcp/oauth_identity.py
+++ b/src/opik_mcp/oauth_identity.py
@@ -89,7 +89,6 @@ async def resolve_oauth_identity(authorization: str, settings: Settings) -> Reso
         user_name=user_name,
         workspace_name=workspace_name,
         workspace_id=_text(body.get("workspace_id")),
-        source="oauth",
     )
 
 

--- a/src/opik_mcp/oauth_identity.py
+++ b/src/opik_mcp/oauth_identity.py
@@ -12,7 +12,7 @@ opik-backend exposes a purpose-built introspection endpoint for exactly this —
 ``POST /opik/auth-oauth`` (``OAuthValidateTokenResource``) returns the full
 ``ValidatedToken``: ``user_name``, ``workspace_id`` and ``workspace_name``. We
 call it once per token, on the ``initialize`` handshake, forwarding the inbound
-bearer verbatim, and keep the whole answer in ``session_identity``.
+bearer verbatim, and keep the whole answer in ``credential_identity``.
 
 This is best-effort: any failure (unconfigured base, non-200, network error,
 malformed body) returns ``None`` so the handshake never breaks — the blob simply
@@ -26,8 +26,8 @@ import logging
 import httpx
 
 from opik_mcp.config import Settings
+from opik_mcp.credential_identity import ResolvedIdentity
 from opik_mcp.opik_client import opik_rest_base
-from opik_mcp.session_identity import ResolvedIdentity
 
 logger = logging.getLogger("opik_mcp")
 

--- a/src/opik_mcp/oauth_identity.py
+++ b/src/opik_mcp/oauth_identity.py
@@ -1,21 +1,22 @@
-"""Resolve the OAuth-authorized workspace name for the session-context blob.
+"""Resolve the identity an OAuth bearer stands for.
 
 In OAuth-passthrough mode opik-mcp forwards an opaque ``opik_mcp_at_``-prefixed
 bearer onward and lets opik-backend derive the workspace from the token row — it
-never learns the workspace *name* itself (the host doesn't send ``Comet-Workspace``
-in OAuth mode; the name lives only in the token binding). That's fine for data
-routing, but the per-session ``initialize`` instructions blob (``instructions.py``)
-needs the human-readable name so an agent can truthfully say which workspace it is
-operating against.
+never learns who the caller is (the host doesn't send ``Comet-Workspace`` in OAuth
+mode; the identity lives only in the token binding). Two consumers need that
+answer: the per-session ``initialize`` instructions blob (``instructions.py``),
+so an agent can truthfully say which workspace it is operating against, and BI,
+which cannot attribute a call without a user and a workspace.
 
 opik-backend exposes a purpose-built introspection endpoint for exactly this —
-``POST /opik/auth-oauth`` (``OAuthValidateTokenResource``) returns the identity a
-bearer resolves to, including ``workspace_name``. We call it once per session, on
-the ``initialize`` handshake, forwarding the inbound bearer verbatim.
+``POST /opik/auth-oauth`` (``OAuthValidateTokenResource``) returns the full
+``ValidatedToken``: ``user_name``, ``workspace_id`` and ``workspace_name``. We
+call it once per token, on the ``initialize`` handshake, forwarding the inbound
+bearer verbatim, and keep the whole answer in ``session_identity``.
 
 This is best-effort: any failure (unconfigured base, non-200, network error,
 malformed body) returns ``None`` so the handshake never breaks — the blob simply
-falls back to the static settings workspace.
+falls back to the static settings workspace and the call is reported anonymously.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ import httpx
 
 from opik_mcp.config import Settings
 from opik_mcp.opik_client import opik_rest_base
+from opik_mcp.session_identity import ResolvedIdentity
 
 logger = logging.getLogger("opik_mcp")
 
@@ -36,13 +38,18 @@ logger = logging.getLogger("opik_mcp")
 _VALIDATE_TOKEN_PATH = "/opik/auth-oauth"
 
 
-async def resolve_workspace_name(authorization: str, settings: Settings) -> str | None:
-    """Introspect an inbound OAuth bearer → its ``workspace_name``, or ``None``.
+async def resolve_oauth_identity(authorization: str, settings: Settings) -> ResolvedIdentity | None:
+    """Introspect an inbound OAuth bearer → the identity it stands for, or ``None``.
 
     ``authorization`` is the full inbound ``Authorization`` header value
     (``"Bearer opik_mcp_at_…"``), forwarded verbatim — opik-backend re-validates
     the token shape and resolves it server-side. Never raises; returns ``None`` on
     any failure so the ``initialize`` handshake degrades gracefully.
+
+    Returns ``None`` rather than an empty identity when the response carries
+    neither a workspace name nor a user name: an identity with nothing in it is
+    indistinguishable from an unresolved one to every consumer, and storing it
+    would only suppress a later retry.
     """
     base = opik_rest_base(settings)
     if base is None:
@@ -74,10 +81,28 @@ async def resolve_workspace_name(authorization: str, settings: Settings) -> str 
         return None
     if not isinstance(body, dict):
         return None
-    workspace_name = body.get("workspace_name")
-    if isinstance(workspace_name, str) and workspace_name:
-        return workspace_name
+    workspace_name = _text(body.get("workspace_name"))
+    user_name = _text(body.get("user_name"))
+    if workspace_name is None and user_name is None:
+        return None
+    return ResolvedIdentity(
+        user_name=user_name,
+        workspace_name=workspace_name,
+        workspace_id=_text(body.get("workspace_id")),
+        source="oauth",
+    )
+
+
+def _text(value: object) -> str | None:
+    """A non-empty string from the introspection body, or ``None``.
+
+    Absent, null, blank and wrongly-typed values collapse to ``None`` so every
+    downstream consumer can treat "unknown" as one case. Emitting a blank string
+    would land in BI as an empty value rather than a null.
+    """
+    if isinstance(value, str) and value.strip():
+        return value.strip()
     return None
 
 
-__all__ = ["resolve_workspace_name"]
+__all__ = ["resolve_oauth_identity"]

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -800,7 +800,7 @@ def opik_rest_base(settings: Settings) -> str | None:
     Single source of truth for the rule: an explicit ``OPIK_URL`` override wins;
     otherwise derive from ``COMET_URL_OVERRIDE + "/opik/api"``. Shared by
     ``resolve_opik_config`` (which treats ``None`` as a fatal misconfig) and
-    ``oauth_identity.resolve_workspace_name`` (which treats ``None`` as "skip,
+    ``oauth_identity.resolve_oauth_identity`` (which treats ``None`` as "skip,
     fall back to the static workspace"), so both agree on where Opik lives.
     """
     if settings.opik_url:

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -38,13 +38,14 @@ from opik_mcp.auth_context import (
 )
 from opik_mcp.config import MissingConfigError, Settings, get_settings
 from opik_mcp.instructions import render_instructions
-from opik_mcp.oauth_identity import resolve_workspace_name
+from opik_mcp.oauth_identity import resolve_oauth_identity
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
 from opik_mcp.read_list import run_list, run_read
 from opik_mcp.read_list.registry import LISTABLE_TYPES, READABLE_TYPES
 from opik_mcp.read_list.uri import looks_like_thread_url
 from opik_mcp.run_experiment import run_experiment_impl
 from opik_mcp.run_experiment_models import RunExperimentConfig, RunExperimentResult
+from opik_mcp.session_identity import remember_identity
 from opik_mcp.writes import (
     SCHEMA_TOOL_DESCRIPTION,
     WRITE_TOOL_DESCRIPTION,
@@ -696,10 +697,16 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         # session id and skip this. Best-effort: a failure leaves the blob on its
         # static fallback and never blocks the handshake.
         resolved_token = None
-        if request.headers.get("mcp-session-id") is None and classify_bearer(auth)[0] == "oauth":
-            workspace_name = await resolve_workspace_name(auth, get_settings())
-            if workspace_name:
-                resolved_token = resolved_workspace_name.set(workspace_name)
+        auth_mode, oauth_token = classify_bearer(auth)
+        if request.headers.get("mcp-session-id") is None and auth_mode == "oauth":
+            identity = await resolve_oauth_identity(auth, get_settings())
+            if identity is not None:
+                # Held against the token, not this request: the analytics layer
+                # builds events in the MCP session task and never sees a request,
+                # and a second session on the same token needs no second lookup.
+                remember_identity(oauth_token, identity)
+                if identity.workspace_name:
+                    resolved_token = resolved_workspace_name.set(identity.workspace_name)
         try:
             return await call_next(request)
         finally:

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -37,6 +37,7 @@ from opik_mcp.auth_context import (
     settings_auth_mode,
 )
 from opik_mcp.config import MissingConfigError, Settings, get_settings
+from opik_mcp.credential_identity import remember_identity
 from opik_mcp.instructions import render_instructions
 from opik_mcp.oauth_identity import resolve_oauth_identity
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
@@ -45,7 +46,6 @@ from opik_mcp.read_list.registry import LISTABLE_TYPES, READABLE_TYPES
 from opik_mcp.read_list.uri import looks_like_thread_url
 from opik_mcp.run_experiment import run_experiment_impl
 from opik_mcp.run_experiment_models import RunExperimentConfig, RunExperimentResult
-from opik_mcp.session_identity import remember_identity
 from opik_mcp.writes import (
     SCHEMA_TOOL_DESCRIPTION,
     WRITE_TOOL_DESCRIPTION,

--- a/src/opik_mcp/session_identity.py
+++ b/src/opik_mcp/session_identity.py
@@ -40,15 +40,16 @@ class ResolvedIdentity:
     """What the backend told us about the holder of a credential.
 
     Every field is optional because every resolution path is best-effort: a
-    failed lookup must degrade to anonymous telemetry, never to an error. The
-    ``source`` field records which path produced the answer so BI can tell an
-    OAuth-derived identity from an API-key-derived one.
+    failed lookup must degrade to anonymous telemetry, never to an error.
+
+    There is deliberately no "which path resolved this" field: ``auth_mode``
+    already tells BI whether the caller authenticated by OAuth or API key, and a
+    second field saying the same thing could only ever disagree with it.
     """
 
     user_name: str | None
     workspace_name: str | None
     workspace_id: str | None
-    source: str
 
 
 _STORE: OrderedDict[str, ResolvedIdentity] = OrderedDict()

--- a/src/opik_mcp/session_identity.py
+++ b/src/opik_mcp/session_identity.py
@@ -1,0 +1,101 @@
+"""Resolved caller identity, held explicitly and keyed by credential.
+
+opik-mcp learns *who* is calling from the backend, not from local config: an
+OAuth bearer is introspected on the ``initialize`` handshake, and an API key is
+resolved against Comet's account-details endpoint. Both answers land here.
+
+Keyed by a digest of the credential rather than by the MCP session object on
+purpose:
+
+- The identity is bound to the credential, not to the session. One OAuth token
+  resolves to exactly one user and workspace for its whole lifetime, so a second
+  session on the same token needs no second round-trip.
+- ``analytics.client._build_event`` is where the answer is needed, and it never
+  sees an MCP session object — it builds events synchronously in whatever task
+  is emitting, including lifecycle emits that have no session at all.
+
+The raw credential is never stored: it is hashed on the way in, both as key and
+in the API surface, so a long-lived process never holds a bearer or an API key
+in a process-level dict.
+
+Bounded on purpose. A hosted deployment sees one token per user and would
+otherwise grow this map for the life of the pod; eviction is least-recently-used
+so an active session is never evicted in favour of a stale one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+
+# One entry per active credential. Sized well above any realistic concurrent
+# user count for a single pod while staying trivially small in memory.
+MAX_TRACKED_CREDENTIALS = 512
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedIdentity:
+    """What the backend told us about the holder of a credential.
+
+    Every field is optional because every resolution path is best-effort: a
+    failed lookup must degrade to anonymous telemetry, never to an error. The
+    ``source`` field records which path produced the answer so BI can tell an
+    OAuth-derived identity from an API-key-derived one.
+    """
+
+    user_name: str | None
+    workspace_name: str | None
+    workspace_id: str | None
+    source: str
+
+
+_STORE: OrderedDict[str, ResolvedIdentity] = OrderedDict()
+# The store is read from the analytics dispatch thread and written from request
+# handlers, so it needs its own lock — OrderedDict move_to_end plus popitem is
+# not atomic under the GIL the way a single dict operation is.
+_LOCK = threading.Lock()
+
+
+def credential_digest(credential: str) -> str:
+    """SHA-256 hex digest of a credential. The raw value never leaves the caller."""
+    return hashlib.sha256(credential.encode("utf-8")).hexdigest()
+
+
+def remember_identity(credential: str, identity: ResolvedIdentity) -> None:
+    """Record what a credential resolved to, evicting the least-recently-used."""
+    key = credential_digest(credential)
+    with _LOCK:
+        _STORE[key] = identity
+        _STORE.move_to_end(key)
+        while len(_STORE) > MAX_TRACKED_CREDENTIALS:
+            _STORE.popitem(last=False)
+
+
+def lookup_identity(credential: str) -> ResolvedIdentity | None:
+    """What this credential resolved to, or ``None`` if we never found out."""
+    key = credential_digest(credential)
+    with _LOCK:
+        identity = _STORE.get(key)
+        if identity is not None:
+            # Reading marks the credential as live, so an in-use session is not
+            # evicted in favour of one that has gone quiet.
+            _STORE.move_to_end(key)
+        return identity
+
+
+def reset_identities_for_tests() -> None:
+    """Drop every resolved identity. Test-only — never call from production."""
+    with _LOCK:
+        _STORE.clear()
+
+
+__all__ = [
+    "MAX_TRACKED_CREDENTIALS",
+    "ResolvedIdentity",
+    "credential_digest",
+    "lookup_identity",
+    "remember_identity",
+    "reset_identities_for_tests",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
         _reset_seen_sessions_for_tests,
         _reset_seen_tools_listed_for_tests,
     )
-    from opik_mcp.session_identity import reset_identities_for_tests
+    from opik_mcp.credential_identity import reset_identities_for_tests
 
     reset_analytics_for_tests()
     _reset_seen_sessions_for_tests()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ def _disable_api_key_identity() -> Generator[None]:
         return None
 
     mp = pytest.MonkeyPatch()
-    mp.setattr("opik_mcp.analytics.client.resolve_api_key_identity", _none)
+    mp.setattr("opik_mcp.caller_identity.resolve_api_key_identity", _none)
     try:
         yield
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,11 +43,13 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
         _reset_seen_sessions_for_tests,
         _reset_seen_tools_listed_for_tests,
     )
+    from opik_mcp.session_identity import reset_identities_for_tests
 
     reset_analytics_for_tests()
     _reset_seen_sessions_for_tests()
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()
+    reset_identities_for_tests()
     # main() sets this sentinel so the build_app() lifespan skips its own emit.
     # Clear it between tests or a test that calls main() leaves the build_app()
     # lifespan (e.g. the session http_client fixture) permanently muted.
@@ -57,6 +59,7 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     _reset_seen_sessions_for_tests()
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()
+    reset_identities_for_tests()
     os.environ.pop(LIFECYCLE_SENTINEL, None)
 
 
@@ -64,13 +67,13 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
 def _disable_workspace_introspection() -> Generator[None]:
     """Stub OAuth workspace introspection to a no-op by default.
 
-    The ``initialize`` handshake resolves the authorized workspace name by
-    POSTing to opik-backend's ``/opik/auth-oauth`` (``server.resolve_workspace_name``).
+    The ``initialize`` handshake resolves the caller's identity by POSTing to
+    opik-backend's ``/opik/auth-oauth`` (``server.resolve_oauth_identity``).
     Left live, every test that sends a session-less OAuth bearer to ``/mcp`` would
     fire a real network call — slow, flaky, and able to land in another test's
     ``@respx.mock`` window. Disabled by default (mirrors the analytics default
     above); tests that exercise resolution ``monkeypatch.setattr`` this, and the
-    ``resolve_workspace_name`` unit tests call the real function directly.
+    ``resolve_oauth_identity`` unit tests call the real function directly.
 
     Uses a standalone ``pytest.MonkeyPatch()`` rather than the ``monkeypatch``
     *fixture* on purpose: depending on that fixture from an autouse fixture pulls
@@ -84,7 +87,37 @@ def _disable_workspace_introspection() -> Generator[None]:
         return None
 
     mp = pytest.MonkeyPatch()
-    mp.setattr("opik_mcp.server.resolve_workspace_name", _none)
+    mp.setattr("opik_mcp.server.resolve_oauth_identity", _none)
+    try:
+        yield
+    finally:
+        mp.undo()
+
+
+@pytest.fixture(autouse=True)
+def _disable_api_key_identity() -> Generator[None]:
+    """Stub API-key identity resolution to a no-op by default.
+
+    ``_build_event`` resolves the install's own identity from Comet's
+    account-details endpoint for cloud deployments. Left live, any test that
+    builds an event with an ``opik_api_key`` set would spawn a background
+    refresh thread pointed at www.comet.com — a real network call escaping into
+    whatever ``@respx.mock`` window happened to be open, from a thread whose
+    failure is swallowed by design and therefore invisible.
+
+    Disabled by default (mirrors the OAuth introspection stub above). The
+    ``resolve_api_key_identity`` tests call the real function directly, and a
+    test wanting resolution inside an event patches this back.
+
+    Uses a self-owned ``MonkeyPatch`` for the same fixture-ordering reason
+    documented on ``_disable_workspace_introspection``.
+    """
+
+    def _none(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr("opik_mcp.analytics.client.resolve_api_key_identity", _none)
     try:
         yield
     finally:

--- a/tests/test_account_identity.py
+++ b/tests/test_account_identity.py
@@ -26,7 +26,7 @@ from opik_mcp.account_identity import (
     resolve_api_key_identity,
 )
 from opik_mcp.config import Settings
-from opik_mcp.session_identity import credential_digest, reset_identities_for_tests
+from opik_mcp.credential_identity import credential_digest, reset_identities_for_tests
 
 API_KEY = "sk-test-key"
 ACCOUNT_URL = "https://www.comet.com/api/rest/v2/account-details"

--- a/tests/test_account_identity.py
+++ b/tests/test_account_identity.py
@@ -1,0 +1,259 @@
+"""Identity resolution for API-key installs.
+
+The behaviour that matters is not "does it fetch" — it is that a user never
+waits for it, a deployment that cannot answer is never asked, and every failure
+lands on "we don't know" rather than on an exception or a wrong answer.
+
+Every test runs against a throwaway HOME so the developer's real cache is never
+read or written.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from opik_mcp.account_identity import (
+    CACHE_TTL_SECONDS,
+    reset_account_identity_for_tests,
+    resolve_api_key_identity,
+)
+from opik_mcp.config import Settings
+from opik_mcp.session_identity import credential_digest, reset_identities_for_tests
+
+API_KEY = "sk-test-key"
+ACCOUNT_URL = "https://www.comet.com/api/rest/v2/account-details"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    reset_identities_for_tests()
+    reset_account_identity_for_tests()
+    yield tmp_path
+    reset_identities_for_tests()
+    reset_account_identity_for_tests()
+
+
+def _cloud_settings(**overrides: Any) -> Settings:
+    base: dict[str, Any] = dict(opik_api_key=API_KEY, opik_url="https://www.comet.com/opik/api")
+    return Settings(**{**base, **overrides})
+
+
+def _cache_file(home: Path) -> Path:
+    return home / ".opik-mcp" / "identity-cache.json"
+
+
+def _write_cache(
+    home: Path, *, key: str = API_KEY, age_seconds: float = 0.0, **fields: Any
+) -> None:
+    path = _cache_file(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {"user_name": "cached-user", "workspace_name": "cached-ws", **fields}
+    entry["cached_at"] = time.time() - age_seconds
+    path.write_text(json.dumps({credential_digest(key): entry}))
+
+
+def _await_resolution(settings: Settings, timeout_s: float = 3.0) -> Any:
+    """Poll until the background refresh lands, or give up.
+
+    Resolution is deliberately asynchronous, so a test that asserts the *result*
+    has to wait for it. A test asserting the *absence* of a call must not use
+    this — it would pass for the wrong reason.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        identity = resolve_api_key_identity(settings)
+        if identity is not None:
+            return identity
+        time.sleep(0.02)
+    return None
+
+
+# --- the endpoint is only called where it can answer --------------------- #
+
+
+@respx.mock
+def test_self_hosted_never_asks() -> None:
+    """This endpoint does not exist on a self-hosted Opik; asking costs a
+    timeout on every install that can never be attributed anyway."""
+    route = respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(200))
+    settings = _cloud_settings(opik_url="https://opik.acme-internal.example/api")
+    assert resolve_api_key_identity(settings) is None
+    time.sleep(0.1)  # give a stray thread the chance to prove us wrong
+    assert not route.called
+
+
+@respx.mock
+def test_no_api_key_means_nothing_to_resolve() -> None:
+    route = respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(200))
+    assert resolve_api_key_identity(_cloud_settings(opik_api_key=None)) is None
+    time.sleep(0.1)
+    assert not route.called
+
+
+# --- startup is never blocked -------------------------------------------- #
+
+
+@respx.mock
+def test_a_cold_cache_returns_immediately_without_an_answer() -> None:
+    """The first call must not wait for the network. It reports nothing, and the
+    caller falls back to the install id with the discriminator saying so."""
+    respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(200, json={"userName": "awkoy", "defaultWorkspaceName": "ws"})
+    )
+    started = time.monotonic()
+    first = resolve_api_key_identity(_cloud_settings())
+    elapsed = time.monotonic() - started
+    assert first is None
+    assert elapsed < 0.5, "resolution must not block the caller"
+
+
+@respx.mock
+def test_the_background_refresh_eventually_lands(_fresh_home: Path) -> None:
+    respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(
+            200, json={"userName": "awkoy", "defaultWorkspaceName": "awkoy-v2"}
+        )
+    )
+    identity = _await_resolution(_cloud_settings())
+    assert identity is not None
+    assert identity.user_name == "awkoy"
+    assert identity.workspace_name == "awkoy-v2"
+    assert identity.source == "api_key"
+    # This endpoint has never returned a workspace UUID; claiming one would lie.
+    assert identity.workspace_id is None
+
+
+@respx.mock
+def test_a_warm_cache_answers_with_no_network_call(_fresh_home: Path) -> None:
+    route = respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(200))
+    _write_cache(_fresh_home)
+    identity = resolve_api_key_identity(_cloud_settings())
+    assert identity is not None
+    assert identity.user_name == "cached-user"
+    time.sleep(0.1)
+    assert not route.called
+
+
+@respx.mock
+def test_a_stale_entry_is_served_while_it_refreshes(_fresh_home: Path) -> None:
+    """A stale answer beats no answer; the correction arrives on a later event."""
+    respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(
+            200, json={"userName": "renamed-user", "defaultWorkspaceName": "cached-ws"}
+        )
+    )
+    _write_cache(_fresh_home, age_seconds=CACHE_TTL_SECONDS + 60)
+
+    served = resolve_api_key_identity(_cloud_settings())
+    assert served is not None
+    assert served.user_name == "cached-user"
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        current = resolve_api_key_identity(_cloud_settings())
+        if current is not None and current.user_name == "renamed-user":
+            break
+        time.sleep(0.02)
+    else:
+        pytest.fail("stale entry was never refreshed")
+
+
+# --- credentials --------------------------------------------------------- #
+
+
+def test_the_raw_key_is_never_written_to_disk(_fresh_home: Path) -> None:
+    _write_cache(_fresh_home)
+    raw = _cache_file(_fresh_home).read_text()
+    assert API_KEY not in raw
+    assert credential_digest(API_KEY) in raw
+
+
+@respx.mock
+def test_rotating_the_key_does_not_report_the_previous_user(_fresh_home: Path) -> None:
+    """A cache keyed by the credential is what makes this safe."""
+    _write_cache(_fresh_home)  # belongs to the OLD key
+    respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(
+            200, json={"userName": "new-user", "defaultWorkspaceName": "new-ws"}
+        )
+    )
+    rotated = _cloud_settings(opik_api_key="sk-rotated-key")
+
+    immediate = resolve_api_key_identity(rotated)
+    assert immediate is None, "the previous user must not be served for a new key"
+
+    identity = _await_resolution(rotated)
+    assert identity is not None
+    assert identity.user_name == "new-user"
+
+
+# --- every failure degrades quietly -------------------------------------- #
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(401),
+        httpx.Response(500),
+        httpx.Response(200, text="not json"),
+        httpx.Response(200, json=["unexpected", "shape"]),
+        httpx.Response(200, json={}),
+    ],
+    ids=["unauthorised", "server-error", "not-json", "wrong-shape", "identifies-nobody"],
+)
+def test_a_useless_response_leaves_us_anonymous(response: httpx.Response) -> None:
+    respx.get(ACCOUNT_URL).mock(return_value=response)
+    assert resolve_api_key_identity(_cloud_settings()) is None
+    time.sleep(0.2)
+    assert resolve_api_key_identity(_cloud_settings()) is None
+
+
+@respx.mock
+def test_an_unreachable_host_leaves_us_anonymous() -> None:
+    respx.get(ACCOUNT_URL).mock(side_effect=httpx.ConnectError("nope"))
+    assert resolve_api_key_identity(_cloud_settings()) is None
+    time.sleep(0.2)
+    assert resolve_api_key_identity(_cloud_settings()) is None
+
+
+@respx.mock
+def test_a_corrupt_cache_is_treated_as_empty(_fresh_home: Path) -> None:
+    path = _cache_file(_fresh_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ this is not json")
+    respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(
+            200, json={"userName": "awkoy", "defaultWorkspaceName": "awkoy-v2"}
+        )
+    )
+    identity = _await_resolution(_cloud_settings())
+    assert identity is not None
+    assert identity.user_name == "awkoy"
+
+
+@respx.mock
+def test_an_unwritable_cache_still_resolves_for_this_process(_fresh_home: Path) -> None:
+    """Losing the cache costs a lookup next boot, not the feature."""
+    cache_dir = _fresh_home / ".opik-mcp"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    # A directory where the cache file belongs: every write attempt fails.
+    (cache_dir / "identity-cache.json").mkdir()
+    respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(
+            200, json={"userName": "awkoy", "defaultWorkspaceName": "awkoy-v2"}
+        )
+    )
+    identity = _await_resolution(_cloud_settings())
+    assert identity is not None
+    assert identity.user_name == "awkoy"

--- a/tests/test_account_identity.py
+++ b/tests/test_account_identity.py
@@ -128,7 +128,6 @@ def test_the_background_refresh_eventually_lands(_fresh_home: Path) -> None:
     assert identity is not None
     assert identity.user_name == "awkoy"
     assert identity.workspace_name == "awkoy-v2"
-    assert identity.source == "api_key"
     # This endpoint has never returned a workspace UUID; claiming one would lie.
     assert identity.workspace_id is None
 
@@ -257,3 +256,70 @@ def test_an_unwritable_cache_still_resolves_for_this_process(_fresh_home: Path) 
     identity = _await_resolution(_cloud_settings())
     assert identity is not None
     assert identity.user_name == "awkoy"
+
+
+# --- a failing cache must not become a retry storm ----------------------- #
+
+
+@respx.mock
+def test_an_unwritable_cache_does_not_refetch_on_every_event(_fresh_home: Path) -> None:
+    """The failure mode this module promises to avoid.
+
+    With the cache unwritable, nothing persists between calls. Without an
+    attempt floor, every single analytics event would start a fresh lookup —
+    a request per event, forever, from a path whose failures are swallowed.
+    """
+    cache_dir = _fresh_home / ".opik-mcp"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "identity-cache.json").mkdir()  # every write attempt fails
+    route = respx.get(ACCOUNT_URL).mock(
+        return_value=httpx.Response(
+            200, json={"userName": "awkoy", "defaultWorkspaceName": "awkoy-v2"}
+        )
+    )
+    settings = _cloud_settings()
+    assert _await_resolution(settings) is not None
+    calls_after_first = route.call_count
+
+    for _ in range(25):
+        resolve_api_key_identity(settings)
+    time.sleep(0.2)
+
+    assert route.call_count == calls_after_first, (
+        f"expected no further lookups, saw {route.call_count - calls_after_first}"
+    )
+
+
+@respx.mock
+def test_a_rejected_key_is_not_retried_on_every_event(_fresh_home: Path) -> None:
+    """An invalid key never resolves and never caches; it must still go quiet."""
+    route = respx.get(ACCOUNT_URL).mock(return_value=httpx.Response(401))
+    settings = _cloud_settings()
+
+    for _ in range(25):
+        resolve_api_key_identity(settings)
+    time.sleep(0.3)
+
+    assert route.call_count <= 1, f"a rejected key was retried {route.call_count} times"
+
+
+def test_the_disk_cache_is_read_once_not_once_per_event(
+    _fresh_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_build_event`` runs on the emitting thread — disk I/O per event would
+    put a JSON parse on the caller's path."""
+    import opik_mcp.account_identity as mod
+
+    _write_cache(_fresh_home)
+    reads: list[int] = []
+    real = mod._read_cache
+
+    def counting_read() -> Any:
+        reads.append(1)
+        return real()
+
+    monkeypatch.setattr(mod, "_read_cache", counting_read)
+    settings = _cloud_settings()
+    for _ in range(10):
+        assert resolve_api_key_identity(settings) is not None
+    assert len(reads) == 1, f"disk was read {len(reads)} times"

--- a/tests/test_analytics_client.py
+++ b/tests/test_analytics_client.py
@@ -681,7 +681,7 @@ def test_api_key_install_reports_its_resolved_login(monkeypatch: pytest.MonkeyPa
     from opik_mcp.credential_identity import ResolvedIdentity
 
     monkeypatch.setattr(
-        "opik_mcp.analytics.client.resolve_api_key_identity",
+        "opik_mcp.caller_identity.resolve_api_key_identity",
         lambda _s: ResolvedIdentity(
             user_name="awkoy",
             workspace_name="awkoy-v2",
@@ -717,7 +717,7 @@ def test_a_forwarded_api_key_bearer_is_not_resolved_as_our_own(
     from opik_mcp.credential_identity import ResolvedIdentity
 
     monkeypatch.setattr(
-        "opik_mcp.analytics.client.resolve_api_key_identity",
+        "opik_mcp.caller_identity.resolve_api_key_identity",
         lambda _s: ResolvedIdentity(
             user_name="server-operator",
             workspace_name="ops",

--- a/tests/test_analytics_client.py
+++ b/tests/test_analytics_client.py
@@ -527,7 +527,7 @@ def _with_oauth_identity(
     ``inbound_authorization`` so ``_build_event`` finds it.
     """
     from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
-    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+    from opik_mcp.credential_identity import ResolvedIdentity, remember_identity
 
     token = f"{OAUTH_ACCESS_TOKEN_PREFIX}wire-shape-token"
     remember_identity(
@@ -678,7 +678,7 @@ def test_api_key_install_reports_its_resolved_login(monkeypatch: pytest.MonkeyPa
     The install's own API key identifies the caller, so unlike a forwarded
     bearer it is safe to resolve against our settings.
     """
-    from opik_mcp.session_identity import ResolvedIdentity
+    from opik_mcp.credential_identity import ResolvedIdentity
 
     monkeypatch.setattr(
         "opik_mcp.analytics.client.resolve_api_key_identity",
@@ -714,7 +714,7 @@ def test_a_forwarded_api_key_bearer_is_not_resolved_as_our_own(
     """In hosted mode the inbound credential belongs to the caller. Resolving
     our own settings identity here would attribute their call to this server."""
     from opik_mcp.auth_context import inbound_authorization
-    from opik_mcp.session_identity import ResolvedIdentity
+    from opik_mcp.credential_identity import ResolvedIdentity
 
     monkeypatch.setattr(
         "opik_mcp.analytics.client.resolve_api_key_identity",

--- a/tests/test_analytics_client.py
+++ b/tests/test_analytics_client.py
@@ -536,7 +536,6 @@ def _with_oauth_identity(
             user_name=user_name,
             workspace_name=workspace_name,
             workspace_id=workspace_id,
-            source="oauth",
         ),
     )
     return f"Bearer {token}"
@@ -687,7 +686,6 @@ def test_api_key_install_reports_its_resolved_login(monkeypatch: pytest.MonkeyPa
             user_name="awkoy",
             workspace_name="awkoy-v2",
             workspace_id=None,
-            source="api_key",
         ),
     )
     route = respx.post(URL).mock(return_value=httpx.Response(200))
@@ -724,7 +722,6 @@ def test_a_forwarded_api_key_bearer_is_not_resolved_as_our_own(
             user_name="server-operator",
             workspace_name="ops",
             workspace_id=None,
-            source="api_key",
         ),
     )
     route = respx.post(URL).mock(return_value=httpx.Response(200))

--- a/tests/test_analytics_client.py
+++ b/tests/test_analytics_client.py
@@ -8,6 +8,7 @@ import pytest
 import respx
 
 from opik_mcp.analytics.client import AnalyticsClient
+from opik_mcp.analytics.identity import get_install_id
 from opik_mcp.config import Settings
 
 URL = "https://stats.comet.com/notify/event/"
@@ -44,7 +45,10 @@ def test_track_event_posts_wire_shape() -> None:
     body = json.loads(route.calls.last.request.content)
     assert body["event_type"] == "opik_mcp_test"
     # comet-stats indexes events by top-level `user_id` (ollie-assist contract).
-    assert body["user_id"] == "ws-1"
+    # With no credential to resolve, that is the anonymous install id — NEVER the
+    # workspace name, which is what the field used to be overloaded with.
+    assert body["user_id"] == get_install_id()
+    assert body["user_id"] != "ws-1"
     # Legacy `anonymous_id` key must not be sent — receiver wouldn't index it.
     assert "anonymous_id" not in body
     props = body["event_properties"]
@@ -53,6 +57,9 @@ def test_track_event_posts_wire_shape() -> None:
     assert props["environment"] == "prod"
     # `workspace` (not `workspace_id`) so it joins with ollie-assist events.
     assert props["workspace"] == "ws-1"
+    # A deliberately configured workspace is reported as the operator's choice.
+    assert props["workspace_kind"] == "configured"
+    assert props["user_id_kind"] == "install_id"
     assert "workspace_id" not in props
     assert "opik_mcp_version" in props
     assert "install_id" in props
@@ -168,8 +175,11 @@ def test_track_event_falls_back_to_install_id_without_workspace() -> None:
 
     body = json.loads(route.calls.last.request.content)
     assert body["user_id"]  # never empty / None
+    assert body["event_properties"]["user_id_kind"] == "install_id"
     # No workspace was set, so `workspace` must NOT appear in event_properties.
     assert "workspace" not in body["event_properties"]
+    # ...and neither must its discriminator, rather than an empty string.
+    assert "workspace_kind" not in body["event_properties"]
     # No api_key was set, so `api_key_sha256` must NOT appear either.
     assert "api_key_sha256" not in body["event_properties"]
 
@@ -181,9 +191,9 @@ def test_track_event_falls_back_to_install_id_without_workspace() -> None:
 def test_api_key_hash_stamped_in_event_properties_when_key_set() -> None:
     """OPIK_API_KEY set → SHA-256 hash appears in event_properties.api_key_sha256.
 
-    The backend retains the raw-key → user-id mapping; BI joins the digest
-    to the auth table to count distinct Comet users. Top-level ``user_id``
-    is intentionally unchanged (workspace name) for dashboard continuity.
+    Kept as a stable per-credential label. It is explicitly NOT the join key
+    BI counts users by — no api-key-hash -> user mapping exists in the
+    warehouse — so it never feeds the top-level ``user_id``.
     """
     from opik_mcp.analytics.identity import api_key_sha256
 
@@ -198,9 +208,11 @@ def test_api_key_hash_stamped_in_event_properties_when_key_set() -> None:
 
     body = json.loads(route.calls.last.request.content)
     assert body["event_properties"]["api_key_sha256"] == api_key_sha256(raw_key)
-    # Top-level user_id stays workspace name — dashboards built against the
-    # pre-Phase-1.5 schema must not see a discontinuous type-flip.
-    assert body["user_id"] == "ws-1"
+    # An api-key digest is NOT an identity: the warehouse holds no key -> user
+    # mapping, so it cannot stand in for a resolved login. Until one is resolved
+    # the caller is anonymous and the discriminator says so.
+    assert body["user_id"] == get_install_id()
+    assert body["event_properties"]["user_id_kind"] == "install_id"
     assert body["event_properties"]["workspace"] == "ws-1"
 
 
@@ -497,3 +509,234 @@ def _has_running_loop() -> bool:
         return True
     except RuntimeError:
         return False
+
+
+# --- resolved caller identity (the BI join key) -------------------------- #
+
+
+def _with_oauth_identity(
+    *,
+    user_name: str | None = "awkoy",
+    workspace_name: str | None = "awkoy-v2",
+    workspace_id: str | None = "ws-uuid-1",
+) -> str:
+    """Register an identity against a bearer and return the header value.
+
+    Mirrors what the ``initialize`` handshake does: introspect once, keep the
+    answer against the credential. Returns the header the caller should set on
+    ``inbound_authorization`` so ``_build_event`` finds it.
+    """
+    from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
+    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+
+    token = f"{OAUTH_ACCESS_TOKEN_PREFIX}wire-shape-token"
+    remember_identity(
+        token,
+        ResolvedIdentity(
+            user_name=user_name,
+            workspace_name=workspace_name,
+            workspace_id=workspace_id,
+            source="oauth",
+        ),
+    )
+    return f"Bearer {token}"
+
+
+@respx.mock
+def test_resolved_login_becomes_the_top_level_user_id() -> None:
+    """The whole point: BI joins this straight to the warehouse user key."""
+    from opik_mcp.auth_context import inbound_authorization
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    auth = _with_oauth_identity()
+    client = AnalyticsClient(_settings(comet_workspace=None))
+    tok = inbound_authorization.set(auth)
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_authorization.reset(tok)
+        client.close()
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["user_id"] == "awkoy"
+    props = body["event_properties"]
+    assert props["user_id_kind"] == "comet_user"
+    # The workspace UUID BI asked for — it was always in the introspection
+    # response and used to be discarded.
+    assert props["workspace_id"] == "ws-uuid-1"
+    assert props["workspace"] == "awkoy-v2"
+    assert props["workspace_kind"] == "resolved"
+
+
+@respx.mock
+def test_backend_workspace_beats_the_placeholder_operators_were_told_to_set() -> None:
+    """Our own docs invited ``default``; it collides with a real customer
+    workspace of that name in the warehouse, so the resolved name must win."""
+    from opik_mcp.auth_context import inbound_authorization
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    auth = _with_oauth_identity(workspace_name="awkoy-v2")
+    client = AnalyticsClient(_settings(comet_workspace="default"))
+    tok = inbound_authorization.set(auth)
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_authorization.reset(tok)
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace"] == "awkoy-v2"
+    assert props["workspace_kind"] == "resolved"
+
+
+@respx.mock
+def test_a_deliberately_configured_workspace_is_not_overridden() -> None:
+    """An operator working outside their account default must not be reported
+    as being in it."""
+    from opik_mcp.auth_context import inbound_authorization
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    auth = _with_oauth_identity(workspace_name="account-default-ws")
+    client = AnalyticsClient(_settings(comet_workspace="team-ws"))
+    tok = inbound_authorization.set(auth)
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_authorization.reset(tok)
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace"] == "team-ws"
+    assert props["workspace_kind"] == "configured"
+
+
+@respx.mock
+def test_placeholder_workspace_is_labelled_when_nothing_resolves() -> None:
+    """Self-hosted keeps reporting ``default`` — but marked, so BI never joins
+    it onto the real customer workspace sharing that name."""
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace="default"))
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace"] == "default"
+    assert props["workspace_kind"] == "placeholder"
+
+
+@respx.mock
+def test_unresolved_caller_stays_anonymous_and_says_so() -> None:
+    """A bearer we never resolved must not silently borrow another identity."""
+    from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX, inbound_authorization
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=None))
+    tok = inbound_authorization.set(f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}never-resolved")
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_authorization.reset(tok)
+        client.close()
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["user_id"] == get_install_id()
+    assert body["event_properties"]["user_id_kind"] == "install_id"
+
+
+@respx.mock
+def test_configured_workspace_uuid_still_wins_over_the_resolved_one() -> None:
+    """The env var is an operator stating a fact about their deployment."""
+    from opik_mcp.auth_context import inbound_authorization
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    auth = _with_oauth_identity(workspace_id="resolved-uuid")
+    client = AnalyticsClient(
+        _settings(comet_workspace=None, comet_workspace_id="11111111-2222-3333-4444-555555555555")
+    )
+    tok = inbound_authorization.set(auth)
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_authorization.reset(tok)
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace_id"] == "11111111-2222-3333-4444-555555555555"
+
+
+@respx.mock
+def test_api_key_install_reports_its_resolved_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The stdio cohort — the documented uvx path and most of the traffic.
+
+    The install's own API key identifies the caller, so unlike a forwarded
+    bearer it is safe to resolve against our settings.
+    """
+    from opik_mcp.session_identity import ResolvedIdentity
+
+    monkeypatch.setattr(
+        "opik_mcp.analytics.client.resolve_api_key_identity",
+        lambda _s: ResolvedIdentity(
+            user_name="awkoy",
+            workspace_name="awkoy-v2",
+            workspace_id=None,
+            source="api_key",
+        ),
+    )
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=None, opik_api_key="sk-key"))
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["user_id"] == "awkoy"
+    props = body["event_properties"]
+    assert props["user_id_kind"] == "comet_user"
+    assert props["workspace"] == "awkoy-v2"
+    assert props["workspace_kind"] == "resolved"
+    # account-details carries no workspace UUID — the field stays absent rather
+    # than being invented.
+    assert "workspace_id" not in props
+
+
+@respx.mock
+def test_a_forwarded_api_key_bearer_is_not_resolved_as_our_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In hosted mode the inbound credential belongs to the caller. Resolving
+    our own settings identity here would attribute their call to this server."""
+    from opik_mcp.auth_context import inbound_authorization
+    from opik_mcp.session_identity import ResolvedIdentity
+
+    monkeypatch.setattr(
+        "opik_mcp.analytics.client.resolve_api_key_identity",
+        lambda _s: ResolvedIdentity(
+            user_name="server-operator",
+            workspace_name="ops",
+            workspace_id=None,
+            source="api_key",
+        ),
+    )
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=None, opik_api_key="sk-key"))
+    tok = inbound_authorization.set("Bearer someone-elses-static-key")
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_authorization.reset(tok)
+        client.close()
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["user_id"] == get_install_id()
+    assert body["event_properties"]["user_id_kind"] == "install_id"

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -196,7 +196,7 @@ def test_login_is_emitted_plaintext_as_the_top_level_user_id(make_client: Any) -
     same plaintext login — so the contract was amended rather than worked around.
     """
     from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
-    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+    from opik_mcp.credential_identity import ResolvedIdentity, remember_identity
 
     token = f"{OAUTH_ACCESS_TOKEN_PREFIX}build-event-token"
     remember_identity(
@@ -215,7 +215,7 @@ def test_the_login_never_leaks_into_any_other_field(make_client: Any) -> None:
     """Widening identity must not widen anything else: the login belongs in
     exactly one place, and nowhere in event_properties except its discriminator."""
     from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
-    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+    from opik_mcp.credential_identity import ResolvedIdentity, remember_identity
 
     canary_login = "LOGIN-CANARY-MUST-APPEAR-ONLY-AS-USER-ID-5e1f7a"
     token = f"{OAUTH_ACCESS_TOKEN_PREFIX}leak-check-token"
@@ -235,7 +235,7 @@ def test_the_raw_bearer_is_still_never_emitted_now_identity_rides_along(
     make_client: Any,
 ) -> None:
     """The pre-existing guarantee must survive the identity change."""
-    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+    from opik_mcp.credential_identity import ResolvedIdentity, remember_identity
 
     remember_identity(
         RAW_OAUTH_TOKEN,

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -91,8 +91,7 @@ def test_request_workspace_plaintext_present(make_client: Any) -> None:
     client = make_client()
     with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}", workspace=RAW_WORKSPACE):
         props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
-    # Plaintext by design — matches the existing settings `workspace` posture
-    # (workspace names are used as user_id in resolve_anonymous_id).
+    # Plaintext by design — a workspace name is a tenant label, not a person.
     assert props["request_workspace"] == RAW_WORKSPACE
 
 
@@ -180,3 +179,80 @@ def test_transport_lowercased_in_common_block(make_client: Any) -> None:
     client = make_client(opik_mcp_transport="HTTP")
     props = client._build_event("opik_mcp_tool_called", {})["event_properties"]
     assert props["transport"] == "http"
+
+
+# --- caller identity (the amended privacy contract) ---------------------- #
+#
+# events.py names this module as what enforces the identity rule. These tests
+# call _build_event directly, which is the only way to catch a leak *inside* it:
+# the recorder-based privacy suite intercepts at track_event and never sees what
+# _build_event builds.
+
+
+def test_login_is_emitted_plaintext_as_the_top_level_user_id(make_client: Any) -> None:
+    """The sanctioned exception to "identity only as a digest".
+
+    Hashing it would make it unjoinable — the warehouse's own user key is this
+    same plaintext login — so the contract was amended rather than worked around.
+    """
+    from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
+    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+
+    token = f"{OAUTH_ACCESS_TOKEN_PREFIX}build-event-token"
+    remember_identity(
+        token,
+        ResolvedIdentity(user_name="awkoy", workspace_name="awkoy-v2", workspace_id="ws-1"),
+    )
+    client = make_client()
+    with _inbound(auth=f"Bearer {token}"):
+        event = client._build_event("opik_mcp_tool_called", {})
+
+    assert event["user_id"] == "awkoy"
+    assert event["event_properties"]["user_id_kind"] == "comet_user"
+
+
+def test_the_login_never_leaks_into_any_other_field(make_client: Any) -> None:
+    """Widening identity must not widen anything else: the login belongs in
+    exactly one place, and nowhere in event_properties except its discriminator."""
+    from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
+    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+
+    canary_login = "LOGIN-CANARY-MUST-APPEAR-ONLY-AS-USER-ID-5e1f7a"
+    token = f"{OAUTH_ACCESS_TOKEN_PREFIX}leak-check-token"
+    remember_identity(
+        token,
+        ResolvedIdentity(user_name=canary_login, workspace_name="ws", workspace_id=None),
+    )
+    client = make_client()
+    with _inbound(auth=f"Bearer {token}"):
+        event = client._build_event("opik_mcp_tool_called", {})
+
+    assert event["user_id"] == canary_login
+    assert canary_login not in json.dumps(event["event_properties"])
+
+
+def test_the_raw_bearer_is_still_never_emitted_now_identity_rides_along(
+    make_client: Any,
+) -> None:
+    """The pre-existing guarantee must survive the identity change."""
+    from opik_mcp.session_identity import ResolvedIdentity, remember_identity
+
+    remember_identity(
+        RAW_OAUTH_TOKEN,
+        ResolvedIdentity(user_name="awkoy", workspace_name="ws", workspace_id=None),
+    )
+    client = make_client()
+    with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}"):
+        event = client._build_event("opik_mcp_tool_called", {})
+
+    assert RAW_OAUTH_TOKEN not in json.dumps(event)
+
+
+def test_unresolved_caller_reports_the_install_id_not_an_empty_field(
+    make_client: Any,
+) -> None:
+    """The warehouse must see a real value or a null — never an empty string."""
+    client = make_client()
+    event = client._build_event("opik_mcp_tool_called", {})
+    assert event["user_id"]
+    assert event["event_properties"]["user_id_kind"] == "install_id"

--- a/tests/test_analytics_identity.py
+++ b/tests/test_analytics_identity.py
@@ -5,7 +5,6 @@ from uuid import UUID
 import pytest
 
 from opik_mcp.analytics import identity
-from opik_mcp.config import Settings
 
 
 @pytest.fixture(autouse=True)
@@ -49,15 +48,14 @@ def test_corrupt_file_is_regenerated(_fresh_home: Path) -> None:
     assert path.read_text().strip() == val
 
 
-def test_resolve_anonymous_id_prefers_workspace(_fresh_home: Path) -> None:
-    s = Settings(comet_workspace="ws-1")
-    assert identity.resolve_anonymous_id(s) == "ws-1"
+def test_workspace_name_is_not_an_identity_resolver(_fresh_home: Path) -> None:
+    """The workspace fallback that used to produce ``user_id`` is gone for good.
 
-
-def test_resolve_anonymous_id_falls_back_to_install_id(_fresh_home: Path) -> None:
-    s = Settings(comet_workspace=None)
-    val = identity.resolve_anonymous_id(s)
-    UUID(val)
+    It made the user column look 100% populated while holding a tenant name for
+    three quarters of events. ``client._build_event`` now assembles ``user_id``
+    from a resolved login, falling back to the install id.
+    """
+    assert not hasattr(identity, "resolve_anonymous_id")
 
 
 # --- api_key_sha256 ------------------------------------------------------- #
@@ -101,19 +99,6 @@ def test_api_key_sha256_handles_unicode() -> None:
     """Non-ASCII keys must hash via UTF-8 without raising."""
     out = identity.api_key_sha256("sécrët-€-🔑")
     assert len(out) == 64
-
-
-# --- resolve_anonymous_id (top-level user_id) ---------------------------- #
-
-
-def test_resolve_anonymous_id_treats_empty_api_key_as_unset(_fresh_home: Path) -> None:
-    """OPIK_API_KEY='' MUST behave identically to unset — no hash, fall
-    through to the next priority. Documents that ``if settings.opik_api_key``
-    (the implementation check) is truthy-aware.
-    """
-    s = Settings(opik_api_key="", comet_workspace="ws-1")
-    # user_id stays workspace name (api_key hash is event_properties-only, not user_id)
-    assert identity.resolve_anonymous_id(s) == "ws-1"
 
 
 # --- install_id_was_freshly_generated ----------------------------------- #

--- a/tests/test_analytics_identity.py
+++ b/tests/test_analytics_identity.py
@@ -144,3 +144,12 @@ def test_get_install_id_returns_string_only(_fresh_home: Path) -> None:
     result = identity.get_install_id()
     assert isinstance(result, str)
     assert len(result) == 36  # UUID4 hex with dashes
+
+
+def test_every_digest_in_the_codebase_is_the_same_transform() -> None:
+    """BI joins on the exact string, so encoding or casing drift between two
+    hand-rolled digests would be invisible until a join quietly returned zero."""
+    from opik_mcp.credential_identity import credential_digest
+
+    for value in ["sk-key", "opik_mcp_at_token", "ünïcode-ключ", ""]:
+        assert identity.api_key_sha256(value) == credential_digest(value)

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -1,5 +1,12 @@
 """Enforce §4.5 — no user prose ever appears in an analytics event.
 
+SCOPE: this suite intercepts at ``track_event``, so it sees the properties the
+call sites supply and NOT the common block ``_build_event`` stamps on top. The
+one personal identifier the contract sanctions — the caller's plaintext login in
+the top-level ``user_id`` — is therefore invisible here by construction, and is
+pinned in ``tests/test_analytics_client_build_event.py`` instead, which calls
+``_build_event`` directly. Asserting it here would pass vacuously.
+
 Drives the *real* MCP tool entry points (server.read, server.list_entities,
 server.write, run_ask_ollie) so the wrapper's `props_fn` is exercised on
 every call. Each test:

--- a/tests/test_credential_identity.py
+++ b/tests/test_credential_identity.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import hashlib
 
-from opik_mcp.session_identity import (
+from opik_mcp.credential_identity import (
     MAX_TRACKED_CREDENTIALS,
     ResolvedIdentity,
     credential_digest,
@@ -93,6 +93,6 @@ def test_reading_an_entry_keeps_it_from_being_evicted_first() -> None:
 
 
 def _keys() -> set[str]:
-    from opik_mcp.session_identity import _STORE
+    from opik_mcp.credential_identity import _STORE
 
     return set(_STORE)

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -77,7 +77,6 @@ async def test_initialize_names_oauth_workspace(
             user_name="andrei",
             workspace_name="andreicautisanu",
             workspace_id="ws-uuid-e2e",
-            source="oauth",
         )
 
     monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", fake_resolve)

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -70,7 +70,7 @@ async def test_initialize_names_oauth_workspace(
     only the backend introspection call stubbed.
     """
 
-    from opik_mcp.session_identity import ResolvedIdentity, lookup_identity
+    from opik_mcp.credential_identity import ResolvedIdentity, lookup_identity
 
     async def fake_resolve(_auth: str, _settings: object) -> ResolvedIdentity:
         return ResolvedIdentity(

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -70,10 +70,17 @@ async def test_initialize_names_oauth_workspace(
     only the backend introspection call stubbed.
     """
 
-    async def fake_resolve(_auth: str, _settings: object) -> str:
-        return "andreicautisanu"
+    from opik_mcp.session_identity import ResolvedIdentity, lookup_identity
 
-    monkeypatch.setattr("opik_mcp.server.resolve_workspace_name", fake_resolve)
+    async def fake_resolve(_auth: str, _settings: object) -> ResolvedIdentity:
+        return ResolvedIdentity(
+            user_name="andrei",
+            workspace_name="andreicautisanu",
+            workspace_id="ws-uuid-e2e",
+            source="oauth",
+        )
+
+    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", fake_resolve)
     r = await http_client.post(
         "/mcp",
         json=INITIALIZE,
@@ -83,6 +90,13 @@ async def test_initialize_names_oauth_workspace(
         },
     )
     assert r.status_code == 200
+    # The identity resolved during this handshake outlives the request that
+    # resolved it: the ContextVars are reset on the way out, and the analytics
+    # layer builds events in the MCP session task, not in this request.
+    stored = lookup_identity(f"{OAUTH_ACCESS_TOKEN_PREFIX}tok")
+    assert stored is not None
+    assert stored.user_name == "andrei"
+    assert stored.workspace_id == "ws-uuid-e2e"
     # The blob is a JSON string inside the JSON-RPC result, so its inner quotes
     # are backslash-escaped in the raw SSE body.
     assert 'workspace \\"andreicautisanu\\"' in r.text

--- a/tests/test_oauth_identity.py
+++ b/tests/test_oauth_identity.py
@@ -48,7 +48,6 @@ async def test_resolves_workspace_name_on_200() -> None:
     # workspace UUID, which this endpoint has always returned and we dropped.
     assert identity.user_name == "u"
     assert identity.workspace_id == "ws-id"
-    assert identity.source == "oauth"
     assert route.called
     # Inbound bearer is forwarded verbatim — opik-backend re-validates it.
     assert route.calls.last.request.headers["authorization"] == AUTH

--- a/tests/test_oauth_identity.py
+++ b/tests/test_oauth_identity.py
@@ -1,6 +1,6 @@
 """Unit tests for OAuth token → workspace-name introspection.
 
-``resolve_workspace_name`` POSTs the inbound bearer to opik-backend's
+``resolve_oauth_identity`` POSTs the inbound bearer to opik-backend's
 ``/opik/auth-oauth`` introspection endpoint and pulls ``workspace_name`` out of
 the ``ValidatedToken`` response. It is best-effort: any failure resolves to
 ``None`` so the ``initialize`` handshake never breaks.
@@ -11,7 +11,7 @@ import pytest
 import respx
 
 from opik_mcp.config import Settings
-from opik_mcp.oauth_identity import resolve_workspace_name
+from opik_mcp.oauth_identity import resolve_oauth_identity
 
 AUTH = "Bearer opik_mcp_at_abc123"
 
@@ -41,8 +41,14 @@ async def test_resolves_workspace_name_on_200() -> None:
             },
         )
     )
-    ws = await resolve_workspace_name(AUTH, _settings())
-    assert ws == "andreicautisanu"
+    identity = await resolve_oauth_identity(AUTH, _settings())
+    assert identity is not None
+    assert identity.workspace_name == "andreicautisanu"
+    # The whole ValidatedToken is retained now — BI needs the user and the
+    # workspace UUID, which this endpoint has always returned and we dropped.
+    assert identity.user_name == "u"
+    assert identity.workspace_id == "ws-id"
+    assert identity.source == "oauth"
     assert route.called
     # Inbound bearer is forwarded verbatim — opik-backend re-validates it.
     assert route.calls.last.request.headers["authorization"] == AUTH
@@ -52,7 +58,7 @@ async def test_resolves_workspace_name_on_200() -> None:
 @respx.mock
 async def test_returns_none_on_401() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(return_value=httpx.Response(401))
-    assert await resolve_workspace_name(AUTH, _settings()) is None
+    assert await resolve_oauth_identity(AUTH, _settings()) is None
 
 
 @pytest.mark.anyio
@@ -65,7 +71,7 @@ async def test_returns_none_on_invalid_url() -> None:
     request-build time (before any transport / respx mock is consulted).
     """
     s = _settings(opik_url="http://exa mple.com/api")
-    assert await resolve_workspace_name(AUTH, s) is None
+    assert await resolve_oauth_identity(AUTH, s) is None
 
 
 @pytest.mark.anyio
@@ -74,7 +80,7 @@ async def test_returns_none_on_network_error() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(
         side_effect=httpx.ConnectError("backend unreachable")
     )
-    assert await resolve_workspace_name(AUTH, _settings()) is None
+    assert await resolve_oauth_identity(AUTH, _settings()) is None
 
 
 @pytest.mark.anyio
@@ -83,16 +89,50 @@ async def test_returns_none_on_non_json_body() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(
         return_value=httpx.Response(200, text="<html>not json</html>")
     )
-    assert await resolve_workspace_name(AUTH, _settings()) is None
+    assert await resolve_oauth_identity(AUTH, _settings()) is None
 
 
 @pytest.mark.anyio
 @respx.mock
-async def test_returns_none_when_workspace_name_absent() -> None:
+async def test_keeps_a_user_only_response() -> None:
+    """A response with a user but no workspace is still worth keeping.
+
+    The old contract threw the whole thing away unless a workspace name was
+    present, because the only consumer was the instructions blob. BI can
+    attribute a call from the user alone, so only a response carrying neither
+    is treated as unresolved.
+    """
     respx.post("https://opik.test/api/opik/auth-oauth").mock(
         return_value=httpx.Response(200, json={"user_name": "u"})
     )
-    assert await resolve_workspace_name(AUTH, _settings()) is None
+    identity = await resolve_oauth_identity(AUTH, _settings())
+    assert identity is not None
+    assert identity.user_name == "u"
+    assert identity.workspace_name is None
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_returns_none_when_the_body_identifies_nobody() -> None:
+    respx.post("https://opik.test/api/opik/auth-oauth").mock(
+        return_value=httpx.Response(200, json={"resource": "https://opik.test/api/v1/mcp"})
+    )
+    assert await resolve_oauth_identity(AUTH, _settings()) is None
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_blank_fields_collapse_to_none_not_empty_strings() -> None:
+    """An empty string would reach BI as a value; unknown must stay unknown."""
+    respx.post("https://opik.test/api/opik/auth-oauth").mock(
+        return_value=httpx.Response(
+            200, json={"user_name": "u", "workspace_name": "   ", "workspace_id": ""}
+        )
+    )
+    identity = await resolve_oauth_identity(AUTH, _settings())
+    assert identity is not None
+    assert identity.workspace_name is None
+    assert identity.workspace_id is None
 
 
 @pytest.mark.anyio
@@ -101,10 +141,11 @@ async def test_derives_url_from_comet_url_override() -> None:
     route = respx.post("https://demo.comet.com/opik/api/opik/auth-oauth").mock(
         return_value=httpx.Response(200, json={"workspace_name": "demo-ws"})
     )
-    ws = await resolve_workspace_name(
+    identity = await resolve_oauth_identity(
         AUTH, Settings(opik_url=None, comet_url_override="https://demo.comet.com/")
     )
-    assert ws == "demo-ws"
+    assert identity is not None
+    assert identity.workspace_name == "demo-ws"
     assert route.called
 
 
@@ -113,4 +154,4 @@ async def test_returns_none_when_base_unconfigured() -> None:
     # No OPIK_URL and an explicitly empty COMET_URL_OVERRIDE → no base → skip
     # without any network call.
     s = Settings(opik_url=None, comet_url_override="")
-    assert await resolve_workspace_name(AUTH, s) is None
+    assert await resolve_oauth_identity(AUTH, s) is None

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -112,7 +112,6 @@ async def test_resolves_workspace_on_session_creating_oauth_request(
             user_name="u",
             workspace_name="andreicautisanu",
             workspace_id="ws-id",
-            source="oauth",
         )
 
     monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", fake_resolve)
@@ -303,7 +302,6 @@ async def test_handshake_stores_the_resolved_identity_against_the_token(
         user_name="awkoy",
         workspace_name="awkoy-v2",
         workspace_id="ws-uuid-1",
-        source="oauth",
     )
 
     async def _resolve(*_a: object, **_k: object) -> ResolvedIdentity:

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -105,7 +105,7 @@ async def test_resolves_workspace_on_session_creating_oauth_request(
     introspects the workspace name and exposes it via the ContextVar the
     instructions blob reads — then resets it after the request."""
     from opik_mcp.auth_context import resolved_workspace_name
-    from opik_mcp.session_identity import ResolvedIdentity
+    from opik_mcp.credential_identity import ResolvedIdentity
 
     async def fake_resolve(_auth: str, _settings: object) -> ResolvedIdentity:
         return ResolvedIdentity(
@@ -295,7 +295,7 @@ async def test_handshake_stores_the_resolved_identity_against_the_token(
     the MCP session task, which never runs inside this request. Keeping the
     identity in a credential-keyed store is what makes it readable from both.
     """
-    from opik_mcp.session_identity import ResolvedIdentity, lookup_identity
+    from opik_mcp.credential_identity import ResolvedIdentity, lookup_identity
 
     token = f"{OAUTH_ACCESS_TOKEN_PREFIX}handshake-abc"
     resolved = ResolvedIdentity(
@@ -359,7 +359,7 @@ async def test_failed_introspection_leaves_the_handshake_working(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Telemetry and display niceties must never cost a session."""
-    from opik_mcp.session_identity import lookup_identity
+    from opik_mcp.credential_identity import lookup_identity
 
     async def _resolve(*_a: object, **_k: object) -> None:
         return None

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -105,11 +105,17 @@ async def test_resolves_workspace_on_session_creating_oauth_request(
     introspects the workspace name and exposes it via the ContextVar the
     instructions blob reads — then resets it after the request."""
     from opik_mcp.auth_context import resolved_workspace_name
+    from opik_mcp.session_identity import ResolvedIdentity
 
-    async def fake_resolve(_auth: str, _settings: object) -> str:
-        return "andreicautisanu"
+    async def fake_resolve(_auth: str, _settings: object) -> ResolvedIdentity:
+        return ResolvedIdentity(
+            user_name="u",
+            workspace_name="andreicautisanu",
+            workspace_id="ws-id",
+            source="oauth",
+        )
 
-    monkeypatch.setattr("opik_mcp.server.resolve_workspace_name", fake_resolve)
+    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", fake_resolve)
     mw = _build_middleware()
     request = _make_request({"authorization": f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}abc"})
 
@@ -135,11 +141,11 @@ async def test_skips_resolution_when_session_already_exists(
 
     calls: list[str] = []
 
-    async def spy_resolve(auth: str, _settings: object) -> str:
+    async def spy_resolve(auth: str, _settings: object) -> None:
         calls.append(auth)
-        return "x"
+        return None
 
-    monkeypatch.setattr("opik_mcp.server.resolve_workspace_name", spy_resolve)
+    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", spy_resolve)
     mw = _build_middleware()
     request = _make_request(
         {
@@ -165,11 +171,11 @@ async def test_skips_resolution_for_api_key_bearer(monkeypatch: pytest.MonkeyPat
     an API-key-shaped bearer keeps the legacy header/settings workspace path."""
     calls: list[str] = []
 
-    async def spy_resolve(auth: str, _settings: object) -> str:
+    async def spy_resolve(auth: str, _settings: object) -> None:
         calls.append(auth)
-        return "x"
+        return None
 
-    monkeypatch.setattr("opik_mcp.server.resolve_workspace_name", spy_resolve)
+    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", spy_resolve)
     mw = _build_middleware()
     request = _make_request({"authorization": "Bearer some-static-api-key"})
 
@@ -277,3 +283,98 @@ async def test_unauthorized_without_resource_metadata_url() -> None:
     assert resp.status_code == 401
     # Starlette ``MutableHeaders`` is case-insensitive — direct ``in`` is enough.
     assert "www-authenticate" not in resp.headers
+
+
+@pytest.mark.anyio
+async def test_handshake_stores_the_resolved_identity_against_the_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handshake is the only request that introspects; the answer must outlive it.
+
+    The instructions blob reads the workspace out of a ContextVar that this
+    middleware resets on the way out, and the analytics layer builds events in
+    the MCP session task, which never runs inside this request. Keeping the
+    identity in a credential-keyed store is what makes it readable from both.
+    """
+    from opik_mcp.session_identity import ResolvedIdentity, lookup_identity
+
+    token = f"{OAUTH_ACCESS_TOKEN_PREFIX}handshake-abc"
+    resolved = ResolvedIdentity(
+        user_name="awkoy",
+        workspace_name="awkoy-v2",
+        workspace_id="ws-uuid-1",
+        source="oauth",
+    )
+
+    async def _resolve(*_a: object, **_k: object) -> ResolvedIdentity:
+        return resolved
+
+    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", _resolve)
+
+    mw = _build_middleware()
+    request = _make_request({"authorization": f"Bearer {token}"})
+
+    async def call_next(_r: Request) -> Response:
+        return JSONResponse({"ok": True})
+
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 200
+
+    # The ContextVars are gone the moment the request returns...
+    assert inbound_authorization.get() is None
+    # ...but the identity is still reachable by the credential it belongs to,
+    # which is what a later tool call in this session has to work with.
+    assert lookup_identity(token) == resolved
+
+
+@pytest.mark.anyio
+async def test_tool_call_requests_do_not_reintrospect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the session-creating request introspects. Every later request carries
+    an ``Mcp-Session-Id`` and must not pay a round-trip for an answer we hold."""
+    calls: list[str] = []
+
+    async def _resolve(*_a: object, **_k: object) -> None:
+        calls.append("resolved")
+        return None
+
+    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", _resolve)
+
+    mw = _build_middleware()
+    request = _make_request(
+        {
+            "authorization": f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}abc",
+            "mcp-session-id": "session-1",
+        }
+    )
+
+    async def call_next(_r: Request) -> Response:
+        return JSONResponse({"ok": True})
+
+    await mw.dispatch(request, call_next)
+    assert calls == []
+
+
+@pytest.mark.anyio
+async def test_failed_introspection_leaves_the_handshake_working(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Telemetry and display niceties must never cost a session."""
+    from opik_mcp.session_identity import lookup_identity
+
+    async def _resolve(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", _resolve)
+
+    token = f"{OAUTH_ACCESS_TOKEN_PREFIX}unresolvable"
+    mw = _build_middleware()
+    request = _make_request({"authorization": f"Bearer {token}"})
+
+    async def call_next(_r: Request) -> Response:
+        return JSONResponse({"ok": True})
+
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 200
+    assert lookup_identity(token) is None

--- a/tests/test_session_identity.py
+++ b/tests/test_session_identity.py
@@ -1,0 +1,99 @@
+"""Unit tests for the resolved-identity store.
+
+The store is what lets a tool call report *who* is calling. It is keyed by a
+digest of the credential rather than by the MCP session object, because the
+identity is bound to the credential: one OAuth token resolves to exactly one
+user and workspace for its whole lifetime, and the analytics layer that needs
+the answer never sees the session object.
+
+Two properties matter and are pinned here: the raw credential never becomes a
+key, and the store cannot grow without bound on a long-lived hosted server that
+sees a new token per user.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from opik_mcp.session_identity import (
+    MAX_TRACKED_CREDENTIALS,
+    ResolvedIdentity,
+    credential_digest,
+    lookup_identity,
+    remember_identity,
+    reset_identities_for_tests,
+)
+
+RAW_TOKEN = "opik_mcp_at_CREDENTIAL-CANARY-MUST-NOT-BE-A-KEY-4f2a9b"
+
+
+def _identity(user: str = "awkoy") -> ResolvedIdentity:
+    return ResolvedIdentity(
+        user_name=user,
+        workspace_name="awkoy-v2",
+        workspace_id="0190babc-62a0-71d2-832a-0feffa4676eb",
+        source="oauth",
+    )
+
+
+def setup_function() -> None:
+    reset_identities_for_tests()
+
+
+def test_remembered_identity_is_readable_by_the_same_credential() -> None:
+    remember_identity(RAW_TOKEN, _identity())
+    found = lookup_identity(RAW_TOKEN)
+    assert found is not None
+    assert found.user_name == "awkoy"
+    assert found.workspace_id == "0190babc-62a0-71d2-832a-0feffa4676eb"
+
+
+def test_unknown_credential_resolves_to_nothing() -> None:
+    assert lookup_identity("some-other-credential") is None
+
+
+def test_raw_credential_never_appears_as_a_key() -> None:
+    """The store lives for the process lifetime; a raw bearer must not sit in it."""
+    remember_identity(RAW_TOKEN, _identity())
+    assert RAW_TOKEN not in _keys()
+    assert credential_digest(RAW_TOKEN) in _keys()
+
+
+def test_digest_is_a_sha256_hex_of_the_credential() -> None:
+    assert credential_digest(RAW_TOKEN) == hashlib.sha256(RAW_TOKEN.encode("utf-8")).hexdigest()
+
+
+def test_rotating_the_credential_does_not_report_the_previous_user() -> None:
+    remember_identity(RAW_TOKEN, _identity(user="old-user"))
+    rotated = RAW_TOKEN + "-rotated"
+    assert lookup_identity(rotated) is None
+    remember_identity(rotated, _identity(user="new-user"))
+    found = lookup_identity(rotated)
+    assert found is not None
+    assert found.user_name == "new-user"
+
+
+def test_store_is_bounded_and_evicts_the_least_recently_used() -> None:
+    """A hosted server sees one token per user; unbounded growth is a leak."""
+    for i in range(MAX_TRACKED_CREDENTIALS + 10):
+        remember_identity(f"token-{i}", _identity(user=f"user-{i}"))
+    assert len(_keys()) <= MAX_TRACKED_CREDENTIALS
+    # The oldest entries are gone, the newest survive.
+    assert lookup_identity("token-0") is None
+    assert lookup_identity(f"token-{MAX_TRACKED_CREDENTIALS + 9}") is not None
+
+
+def test_reading_an_entry_keeps_it_from_being_evicted_first() -> None:
+    for i in range(MAX_TRACKED_CREDENTIALS):
+        remember_identity(f"token-{i}", _identity(user=f"user-{i}"))
+    # Touch the oldest so it is no longer the least-recently-used.
+    assert lookup_identity("token-0") is not None
+    remember_identity("token-overflow", _identity(user="overflow"))
+    assert lookup_identity("token-0") is not None
+    assert lookup_identity("token-1") is None
+
+
+def _keys() -> set[str]:
+    from opik_mcp.session_identity import _STORE
+
+    return set(_STORE)

--- a/tests/test_session_identity.py
+++ b/tests/test_session_identity.py
@@ -32,7 +32,6 @@ def _identity(user: str = "awkoy") -> ResolvedIdentity:
         user_name=user,
         workspace_name="awkoy-v2",
         workspace_id="0190babc-62a0-71d2-832a-0feffa4676eb",
-        source="oauth",
     )
 
 


### PR DESCRIPTION
## What was wrong

`user_id` was never missing. It was populated on 100% of events, just with the wrong thing: the workspace name, falling back to an anonymous install UUID. Measured over 30,386 calls in the warehouse: 75.1% workspace names, 24.8% install ids, 0% an actual user. A column that looks fully populated while answering the wrong question.

`workspace_id` was populated on 0.14% of calls, and every value ever recorded was a workspace *name* from a three-day window in May before the field was redefined.

There is no retroactive fix. The one plausible bridge, `api_key_sha256`, has no key to user mapping anywhere in the warehouse: a digest join returns zero matches. Only new events can be correct.

## What changes

`user_id` now carries the caller's Comet login, resolved from the backend. This is the same plaintext value the Opik frontend already sends to Segment, PostHog and Reo.Dev, and it is the warehouse's own user key, so it joins directly.

New discriminators:

- `user_id_kind` (`comet_user` / `install_id`) says which sort of identifier the field holds. Its **absence** is also how BI splits the history, so no date or version filter is needed.
- `workspace_kind` (`resolved` / `configured` / `placeholder`) says where the workspace name came from.

Identity is resolved from the backend, never from local config:

- **OAuth sessions** reuse the introspection already performed at the handshake. It has always returned the login and the workspace UUID alongside the workspace name we kept; the rest was discarded. The answer is now held against the credential rather than in a request ContextVar the handshake resets on the way out.
- **API-key cloud installs** resolve against Comet's account-details endpoint on a background thread, cached on disk under a digest of the key. Startup never waits, and every failure degrades to anonymous.

Workspace attribution is fixed at the source: a backend-resolved name outranks an operator-configured one when that value is absent or is the `default` sentinel.

### On `default`

`default` is a reserved name, not a workspace. `WorkspaceUtils.getWorkspaceName()` turns a missing workspace header into it, and `RemoteAuthService` then refuses it: 403 on both `authorizeWorkspace` and UI auth, and it is filtered out of the eligible-workspace list. It means "no workspace given".

Our own README used to present it as the default value to configure, so cloud users were setting it by hand. Those now resolve a real name instead. A row named `default` does exist in the warehouse workspaces table, so a name join would still match these events onto something that is not a real workspace; `workspace_kind = 'placeholder'` exists so they can be excluded.

## What identifiers these actually are

Worth stating plainly for reviewers: what we send is a workspace *name* and a `user_id` that is really a username. Both are user-editable, and a rename silently breaks the join on older rows.

That is not new here. There is no stable ID anywhere in Comet; the warehouse's canonical `user_id` is the login itself, and the frontend identifies users with that same plaintext username across three analytics destinations. This change matches the existing convention rather than inventing a second one.

## Self-hosted and open source

These keep reporting `install_id` and no user, deliberately. Open source Opik has no accounts: everyone is the hardcoded `admin` in the hardcoded `default` workspace, so there is nothing to resolve and no endpoint to resolve it from. It also ships a single hardcoded workspace UUID identical on every install, so a populated `workspace_id` there would merge all of them into one fake workspace.

This matches how the Opik backend already reports from self-hosted deployments: `infrastructure/bi` posts to the same `stats.comet.com` endpoint, on by default with `OPIK_USAGE_REPORT_ENABLED` to opt out, and its payload's top-level key is `anonymous_id`, an installation UUID. Install-level anonymous telemetry is the established line, and `analytics` canary tests already block sending the OS username or hostname.

## Privacy

The contract in `events.py` sanctioned only enumerated literals and one-way digests as identity. It is amended explicitly, with the reasoning recorded in the module docstring, to permit one plaintext personal identifier: the login. Hashing it would make it unjoinable, recreating the dead end `api_key_sha256` already demonstrates. Free-text user prose stays forbidden and its canaries are untouched.

## Known limits

- Coverage ramps with upgrades rather than switching on.
- First run with a new credential emits `install_id` until the background refresh lands, labelled honestly. This is the price of never delaying startup.
- `workspace_id` is available for OAuth callers only. Comet's account-details endpoint returns the login and workspace name but never the UUID, so closing that gap needs a backend change and is deliberately out of scope here.
- `installation_type` is URL-based, so a self-hosted Comet deployment with real accounts is not distinguishable from open source and is not resolved today. Noted as a follow-up.

## Testing

1188 passing. The load-bearing assertions are made against the decoded request body that actually reaches the analytics receiver, not against internal calls. Two regression tests cover defects found in review: an unwritable cache turning every event into a fresh lookup, and the disk cache being parsed on the emitting thread per event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)