### PR TITLE
fix(analytics): close the workspace gaps 0.2.16 exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,18 @@ curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS / Linux
 You'll need two things from your Opik workspace:
 
 - **`OPIK_API_KEY`** — get it from [`comet.com/api/my/settings/`](https://www.comet.com/api/my/settings/).
-- **`OPIK_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. Optional: leave it unset and cloud installs resolve your account's workspace automatically. Do **not** set it to the literal `default` — that is a placeholder for local/OSS installs, and it is also a real cloud workspace belonging to someone else, so setting it on a cloud install misattributes your usage. `COMET_WORKSPACE` is accepted as a deprecated alias.
+- **`OPIK_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. `COMET_WORKSPACE` is accepted as a deprecated alias.
 
-> **`OPIK_WORKSPACE` is optional.** Omit the `OPIK_WORKSPACE` line/key in any
-> snippet below. On a cloud install the server resolves your account's workspace
-> for you; on a local/OSS install it falls back to the `default` placeholder.
-> Set it explicitly only when you work in a named workspace that is not your
-> account default.
+> **Cloud users: set `OPIK_WORKSPACE`.** Leave it out and the server falls back
+> to `default`, which is a reserved name rather than a workspace — your tool
+> calls will be rejected. Set it to the workspace name from your Opik URL, and
+> not to the literal string `default`.
+>
+> **Local / open source: leave it unset.** Open source Opik has a single
+> workspace named `default` and no way to create others, which is exactly what
+> the fallback gives you. Also make sure the value is really substituted: a
+> snippet pasted with `<your-workspace>` or `${input:OPIK_WORKSPACE}` still in
+> it is not a workspace name and nothing will resolve.
 
 ### Claude Code
 
@@ -303,7 +308,7 @@ Every setting is an environment variable. Required ones in **bold**.
 | Variable | Default | Notes |
 |---|---|---|
 | **`OPIK_API_KEY`** | — | Required for `ask_ollie` and any authenticated read/write. |
-| `OPIK_WORKSPACE` | _unset_ | Workspace name. Optional — cloud installs resolve the account workspace; local/OSS installs fall back to the `default` placeholder. Set it only for a named workspace that is not your account default, and never to the literal `default` on cloud. |
+| `OPIK_WORKSPACE` | _unset_ | Workspace name. Required on cloud: unset falls back to `default`, which is a reserved name and not a workspace you can reach. Leave unset on local/OSS, where `default` is the only workspace. Never set it to the literal `default` on cloud. |
 | `COMET_WORKSPACE` | — | Deprecated alias for `OPIK_WORKSPACE` (backward compat). `OPIK_WORKSPACE` wins if both are set. |
 | `COMET_WORKSPACE_ID` | _unset_ | Optional workspace UUID. Stamped into analytics events when set, and takes precedence over the resolved one. Rarely needed — OAuth installs get the UUID from the token automatically. |
 | `COMET_URL_OVERRIDE` | `https://www.comet.com` | Set to your self-hosted Comet host, or `https://dev.comet.com` for staging. |

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Add the server with one command:
 
 ```bash
 claude mcp add --transport stdio opik-mcp \
-  --env OPIK_API_KEY=sk-your-key \
-  --env OPIK_WORKSPACE=acme-ai \
+  --env OPIK_API_KEY=<your-key> \
+  --env OPIK_WORKSPACE=<your-workspace> \
   -- uvx opik-mcp
 ```
 
@@ -80,8 +80,8 @@ Or edit `~/.claude.json` directly:
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "sk-your-key",
-        "OPIK_WORKSPACE": "acme-ai"
+        "OPIK_API_KEY": "<your-key>",
+        "OPIK_WORKSPACE": "<your-workspace>"
       }
     }
   }
@@ -105,8 +105,8 @@ Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project), or open
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "sk-your-key",
-        "OPIK_WORKSPACE": "acme-ai"
+        "OPIK_API_KEY": "<your-key>",
+        "OPIK_WORKSPACE": "<your-workspace>"
       }
     }
   }
@@ -132,8 +132,8 @@ connection. Ask in chat: **"list my Opik projects"**.
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "sk-your-key",
-        "OPIK_WORKSPACE": "acme-ai"
+        "OPIK_API_KEY": "<your-key>",
+        "OPIK_WORKSPACE": "<your-workspace>"
       }
     }
   }
@@ -146,7 +146,7 @@ the server is reachable. Ask in chat: **"list my Opik projects"**.
 ### MCP Inspector (manual testing)
 
 ```bash
-OPIK_API_KEY=sk-your-key OPIK_WORKSPACE=acme-ai \
+OPIK_API_KEY=<your-key> OPIK_WORKSPACE=<your-workspace> \
   npx @modelcontextprotocol/inspector uvx opik-mcp
 ```
 
@@ -163,7 +163,7 @@ the same `env` block in your host config:
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "sk-your-key",
+        "OPIK_API_KEY": "<your-key>",
         "COMET_URL_OVERRIDE": "https://opik.your-company.com",
         "OPIK_MCP_ANALYTICS_SOURCE": ""
       }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ You'll need two things from your Opik workspace:
 > workspace named `default` and no way to create others, which is exactly what
 > the fallback gives you.
 >
+> **Self-hosted Comet: set it.** Unlike open source, these deployments have real
+> named workspaces, and the same silent-wrong-workspace risk applies.
+>
 > Whichever applies, make sure the value is actually substituted. Snippets in
 > the wild ship placeholders like `<your-workspace>` or `${input:OPIK_WORKSPACE}`;
 > pasted as-is, those are not workspace names. The server now refuses them
@@ -165,6 +168,7 @@ the same `env` block in your host config:
       "args": ["opik-mcp"],
       "env": {
         "OPIK_API_KEY": "<your-key>",
+        "OPIK_WORKSPACE": "<your-workspace>",
         "COMET_URL_OVERRIDE": "https://opik.your-company.com",
         "OPIK_MCP_ANALYTICS_SOURCE": ""
       }
@@ -172,6 +176,9 @@ the same `env` block in your host config:
   }
 }
 ```
+
+Omit `OPIK_WORKSPACE` on an open-source deployment, where `default` is the only
+workspace; keep it on a self-hosted Comet, which has real named ones.
 
 `ask_ollie` and `run_experiment` are available on Comet Cloud only — on
 self-hosted those calls will fail at dispatch, so use `read` / `list` / `write`

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ You'll need two things from your Opik workspace:
 - **`OPIK_API_KEY`** — get it from [`comet.com/api/my/settings/`](https://www.comet.com/api/my/settings/).
 - **`OPIK_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. `COMET_WORKSPACE` is accepted as a deprecated alias.
 
-> **Cloud, with an API key: set `OPIK_WORKSPACE`.** Leave it out and the server
-> falls back to `default`, which the backend treats as a reserved name rather
-> than a workspace, so your tool calls are rejected. Use the workspace name from
-> your Opik URL, never the literal string `default`.
+> **Cloud, with an API key: set it unless your account default is the one you
+> want.** Left out, the server sends `default`, which Comet resolves to your
+> account's default workspace. That works, but if you actually work in a named
+> workspace you will be pointed at a different one with nothing to tell you —
+> your reads come back from the wrong place rather than failing.
 >
 > **Cloud, over OAuth: leave it unset.** The workspace comes from the token you
 > authorized, and the server ignores this setting entirely.
@@ -315,7 +316,7 @@ Every setting is an environment variable. Required ones in **bold**.
 | Variable | Default | Notes |
 |---|---|---|
 | **`OPIK_API_KEY`** | — | Required for `ask_ollie` and any authenticated read/write. |
-| **`OPIK_WORKSPACE`** | _unset_ | Workspace name. **Required on cloud with an API key** — unset falls back to `default`, a reserved name the backend refuses. Leave unset over OAuth (the token carries the workspace) and on local/OSS (`default` is the only workspace there). Never set it to the literal `default` on cloud. |
+| `OPIK_WORKSPACE` | _unset_ | Workspace name. On cloud with an API key, unset sends `default`, which resolves to your account's **default** workspace — set it explicitly if you work in a different one, or reads come from the wrong workspace silently. Leave unset over OAuth (the token carries it) and on local/OSS (`default` is the only workspace there). |
 | `COMET_WORKSPACE` | — | Deprecated alias for `OPIK_WORKSPACE` (backward compat). `OPIK_WORKSPACE` wins if both are set. |
 | `COMET_WORKSPACE_ID` | _unset_ | Optional workspace UUID. Stamped into analytics events when set, and takes precedence over the resolved one. Rarely needed — OAuth installs get the UUID from the token automatically. |
 | `COMET_URL_OVERRIDE` | `https://www.comet.com` | Set to your self-hosted Comet host, or `https://dev.comet.com` for staging. |

--- a/README.md
+++ b/README.md
@@ -41,16 +41,23 @@ You'll need two things from your Opik workspace:
 - **`OPIK_API_KEY`** — get it from [`comet.com/api/my/settings/`](https://www.comet.com/api/my/settings/).
 - **`OPIK_WORKSPACE`** — your workspace name (lowercase, as it appears in the URL). E.g. `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. `COMET_WORKSPACE` is accepted as a deprecated alias.
 
-> **Cloud users: set `OPIK_WORKSPACE`.** Leave it out and the server falls back
-> to `default`, which is a reserved name rather than a workspace — your tool
-> calls will be rejected. Set it to the workspace name from your Opik URL, and
-> not to the literal string `default`.
+> **Cloud, with an API key: set `OPIK_WORKSPACE`.** Leave it out and the server
+> falls back to `default`, which the backend treats as a reserved name rather
+> than a workspace, so your tool calls are rejected. Use the workspace name from
+> your Opik URL, never the literal string `default`.
+>
+> **Cloud, over OAuth: leave it unset.** The workspace comes from the token you
+> authorized, and the server ignores this setting entirely.
 >
 > **Local / open source: leave it unset.** Open source Opik has a single
 > workspace named `default` and no way to create others, which is exactly what
-> the fallback gives you. Also make sure the value is really substituted: a
-> snippet pasted with `<your-workspace>` or `${input:OPIK_WORKSPACE}` still in
-> it is not a workspace name and nothing will resolve.
+> the fallback gives you.
+>
+> Whichever applies, make sure the value is actually substituted. Snippets in
+> the wild ship placeholders like `<your-workspace>` or `${input:OPIK_WORKSPACE}`;
+> pasted as-is, those are not workspace names. The server now refuses them
+> outright rather than letting the backend answer with an auth error that
+> explains nothing.
 
 ### Claude Code
 
@@ -58,8 +65,8 @@ Add the server with one command:
 
 ```bash
 claude mcp add --transport stdio opik-mcp \
-  --env OPIK_API_KEY=<your-key> \
-  --env OPIK_WORKSPACE=<your-workspace> \
+  --env OPIK_API_KEY=sk-your-key \
+  --env OPIK_WORKSPACE=acme-ai \
   -- uvx opik-mcp
 ```
 
@@ -73,8 +80,8 @@ Or edit `~/.claude.json` directly:
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "<your-key>",
-        "OPIK_WORKSPACE": "<your-workspace>"
+        "OPIK_API_KEY": "sk-your-key",
+        "OPIK_WORKSPACE": "acme-ai"
       }
     }
   }
@@ -98,8 +105,8 @@ Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project), or open
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "<your-key>",
-        "OPIK_WORKSPACE": "<your-workspace>"
+        "OPIK_API_KEY": "sk-your-key",
+        "OPIK_WORKSPACE": "acme-ai"
       }
     }
   }
@@ -125,8 +132,8 @@ connection. Ask in chat: **"list my Opik projects"**.
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "<your-key>",
-        "OPIK_WORKSPACE": "<your-workspace>"
+        "OPIK_API_KEY": "sk-your-key",
+        "OPIK_WORKSPACE": "acme-ai"
       }
     }
   }
@@ -139,7 +146,7 @@ the server is reachable. Ask in chat: **"list my Opik projects"**.
 ### MCP Inspector (manual testing)
 
 ```bash
-OPIK_API_KEY=<your-key> OPIK_WORKSPACE=<your-workspace> \
+OPIK_API_KEY=sk-your-key OPIK_WORKSPACE=acme-ai \
   npx @modelcontextprotocol/inspector uvx opik-mcp
 ```
 
@@ -156,7 +163,7 @@ the same `env` block in your host config:
       "command": "uvx",
       "args": ["opik-mcp"],
       "env": {
-        "OPIK_API_KEY": "<your-key>",
+        "OPIK_API_KEY": "sk-your-key",
         "COMET_URL_OVERRIDE": "https://opik.your-company.com",
         "OPIK_MCP_ANALYTICS_SOURCE": ""
       }
@@ -308,7 +315,7 @@ Every setting is an environment variable. Required ones in **bold**.
 | Variable | Default | Notes |
 |---|---|---|
 | **`OPIK_API_KEY`** | — | Required for `ask_ollie` and any authenticated read/write. |
-| `OPIK_WORKSPACE` | _unset_ | Workspace name. Required on cloud: unset falls back to `default`, which is a reserved name and not a workspace you can reach. Leave unset on local/OSS, where `default` is the only workspace. Never set it to the literal `default` on cloud. |
+| **`OPIK_WORKSPACE`** | _unset_ | Workspace name. **Required on cloud with an API key** — unset falls back to `default`, a reserved name the backend refuses. Leave unset over OAuth (the token carries the workspace) and on local/OSS (`default` is the only workspace there). Never set it to the literal `default` on cloud. |
 | `COMET_WORKSPACE` | — | Deprecated alias for `OPIK_WORKSPACE` (backward compat). `OPIK_WORKSPACE` wins if both are set. |
 | `COMET_WORKSPACE_ID` | _unset_ | Optional workspace UUID. Stamped into analytics events when set, and takes precedence over the resolved one. Rarely needed — OAuth installs get the UUID from the token automatically. |
 | `COMET_URL_OVERRIDE` | `https://www.comet.com` | Set to your self-hosted Comet host, or `https://dev.comet.com` for staging. |

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -35,6 +35,38 @@ from opik_mcp.credential_identity import ResolvedIdentity, credential_digest
 
 logger = logging.getLogger("opik_mcp.analytics")
 
+# Config-snippet placeholders users paste without substituting. `${…}` is the
+# VS Code / shell form (`${input:OPIK_WORKSPACE}`), `<…>` is the one our own
+# README uses (`<your-workspace>`), plus the mustache and Windows forms. All
+# showed up in production within a day of the identity change shipping,
+# classified as deliberate operator choices.
+#
+# We label these rather than validate them. Nothing else in the product checks
+# the workspace string — the SDK defaults it and lets the backend judge — so
+# opik-mcp is not the place to start failing installs. Reporting the value with
+# an honest label is what tells us which snippet is failing users.
+_TEMPLATE_WRAPPERS = (("${", "}"), ("<", ">"), ("{{", "}}"), ("%", "%"))
+
+
+def _looks_unsubstituted(value: str) -> bool:
+    """True for an obviously unfilled config placeholder.
+
+    Deliberately narrow: the whole value must both open and close with a wrapper
+    pair, so a real workspace name containing a stray bracket is not caught.
+    Mislabelling a legitimate workspace would quietly drop it out of joins.
+    """
+    candidate = value.strip()
+    if candidate.startswith("$") and not candidate.startswith("${"):
+        # Bare `$OPIK_WORKSPACE` — a shell variable that never expanded.
+        return True
+    return any(
+        len(candidate) > len(open_) + len(close)
+        and candidate.startswith(open_)
+        and candidate.endswith(close)
+        for open_, close in _TEMPLATE_WRAPPERS
+    )
+
+
 _QUEUE_SENTINEL: Any = object()
 
 
@@ -218,13 +250,18 @@ class AnalyticsClient:
         }
         identity = caller_identity(self._settings)
         workspace = self._resolve_workspace(identity)
-        if workspace is not None:
+        # Where the name came from: resolved from the backend, chosen by the
+        # operator, an unfilled config snippet, the self-hosted placeholder, or
+        # nothing at all. BI needs this to keep placeholders out of workspace
+        # joins. ALWAYS stamped, so it totals against user_id_kind with no
+        # silent remainder.
+        common["workspace_kind"] = workspace.kind
+        if workspace.value:
             common["workspace"] = workspace.value
-            # Which of the three the name is: resolved from the backend, chosen
-            # by the operator, or the self-hosted placeholder. BI needs this to
-            # avoid joining a placeholder onto the real customer workspace that
-            # shares its name.
-            common["workspace_kind"] = workspace.kind
+        else:
+            # "unknown" carries no name. Drop a caller-supplied one too, so the
+            # pair can never contradict each other.
+            properties = {k: v for k, v in properties.items() if k != "workspace"}
         # An explicitly configured UUID still wins — it is the operator stating a
         # fact about their deployment. Otherwise take the one the backend bound
         # to the credential, which is available for OAuth callers today.
@@ -281,9 +318,7 @@ class AnalyticsClient:
             return Attributed(identity.user_name, "comet_user")
         return Attributed(get_install_id(), "install_id")
 
-    def _resolve_workspace(
-        self, identity: ResolvedIdentity | None
-    ) -> Attributed[WorkspaceKind] | None:
+    def _resolve_workspace(self, identity: ResolvedIdentity | None) -> Attributed[WorkspaceKind]:
         """The workspace to report, and where it came from.
 
         A workspace the operator deliberately configured wins: they may well be
@@ -295,13 +330,19 @@ class AnalyticsClient:
         """
         configured = self._settings.comet_workspace
         resolved = identity.workspace_name if identity else None
+        if configured and _looks_unsubstituted(configured):
+            # Reported, not hidden: the raw value is the only thing that tells
+            # us which config snippet the user pasted without filling in.
+            return Attributed(configured, "template")
         if configured and configured != DEFAULT_WORKSPACE:
             return Attributed(configured, "configured")
         if resolved:
             return Attributed(resolved, "resolved")
         if configured:
             return Attributed(configured, "placeholder")
-        return None
+        # Nothing configured and nothing resolved. Empty value by contract: the
+        # caller omits `workspace` entirely for this kind.
+        return Attributed("", "unknown")
 
     def _per_request_props(self) -> dict[str, str]:
         """Identity derived from the inbound-auth ContextVars (HTTP/OAuth mode).

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -30,42 +30,15 @@ from opik_mcp.auth_context import (
     settings_auth_mode,
 )
 from opik_mcp.caller_identity import caller_identity
-from opik_mcp.config import DEFAULT_WORKSPACE, Settings, installation_type
+from opik_mcp.config import (
+    DEFAULT_WORKSPACE,
+    Settings,
+    installation_type,
+    looks_unsubstituted,
+)
 from opik_mcp.credential_identity import ResolvedIdentity, credential_digest
 
 logger = logging.getLogger("opik_mcp.analytics")
-
-# Config-snippet placeholders users paste without substituting. `${…}` is the
-# VS Code / shell form (`${input:OPIK_WORKSPACE}`), `<…>` is the one our own
-# README uses (`<your-workspace>`), plus the mustache and Windows forms. All
-# showed up in production within a day of the identity change shipping,
-# classified as deliberate operator choices.
-#
-# We label these rather than validate them. Nothing else in the product checks
-# the workspace string — the SDK defaults it and lets the backend judge — so
-# opik-mcp is not the place to start failing installs. Reporting the value with
-# an honest label is what tells us which snippet is failing users.
-_TEMPLATE_WRAPPERS = (("${", "}"), ("<", ">"), ("{{", "}}"), ("%", "%"))
-
-
-def _looks_unsubstituted(value: str) -> bool:
-    """True for an obviously unfilled config placeholder.
-
-    Deliberately narrow: the whole value must both open and close with a wrapper
-    pair, so a real workspace name containing a stray bracket is not caught.
-    Mislabelling a legitimate workspace would quietly drop it out of joins.
-    """
-    candidate = value.strip()
-    if candidate.startswith("$") and not candidate.startswith("${"):
-        # Bare `$OPIK_WORKSPACE` — a shell variable that never expanded.
-        return True
-    return any(
-        len(candidate) > len(open_) + len(close)
-        and candidate.startswith(open_)
-        and candidate.endswith(close)
-        for open_, close in _TEMPLATE_WRAPPERS
-    )
-
 
 _QUEUE_SENTINEL: Any = object()
 
@@ -330,7 +303,7 @@ class AnalyticsClient:
         """
         configured = self._settings.comet_workspace
         resolved = identity.workspace_name if identity else None
-        if configured and _looks_unsubstituted(configured):
+        if configured and looks_unsubstituted(configured):
             # Reported, not hidden: the raw value is the only thing that tells
             # us which config snippet the user pasted without filling in.
             return Attributed(configured, "template")

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -294,14 +294,31 @@ class AnalyticsClient:
     def _resolve_workspace(self, identity: ResolvedIdentity | None) -> Attributed[WorkspaceKind]:
         """The workspace to report, and where it came from.
 
-        A workspace the operator deliberately configured wins: they may well be
-        working outside their account default, and reporting the default instead
-        would be wrong. The backend-resolved name wins over an *absent* setting
-        and over the literal placeholder — which our own docs invited operators
-        to set, and which collides with a real customer workspace of the same
-        name in the warehouse.
+        Precedence, highest first:
+
+        - ``template`` — a configured value that was never filled in. Wins
+          outright, and keeps its raw value: that value is the only thing that
+          says which snippet failed the user. Deliberately not papered over by a
+          resolved name, since user attribution never depended on the workspace.
+        - ``configured`` — a workspace someone deliberately named: the inbound
+          ``Comet-Workspace`` header for this call if present, else the process
+          setting. They may be working outside their account default, so
+          reporting the resolved one instead would be wrong.
+        - ``resolved`` — from the backend. Beats an *absent* setting and the
+          literal ``default`` placeholder, which our own docs once invited
+          operators to set and which collides with a same-named row in the
+          warehouse.
+        - ``placeholder`` — the literal ``default``, nothing resolved.
+        - ``unknown`` — nothing configured, nothing resolved. Returns an EMPTY
+          value; the caller omits ``workspace`` entirely for this kind.
         """
-        configured = self._settings.comet_workspace
+        # An inbound header is the caller naming the workspace for THIS call,
+        # which outranks anything this process was started with — it is what
+        # opik_client actually routes on (`resolve_opik_config`). Without it a
+        # hosted call would claim "unknown" while `request_workspace` in the
+        # same payload carries the name.
+        inbound = inbound_workspace.get()
+        configured = (inbound.strip() if inbound else None) or self._settings.comet_workspace
         resolved = identity.workspace_name if identity else None
         if configured and looks_unsubstituted(configured):
             # Reported, not hidden: the raw value is the only thing that tells

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -13,8 +13,9 @@ with the classifiers in ``environment.py`` (launch method / parent process),
 (``_resolve_workspace`` / ``_resolve_user``) — adding a new bucket is a BI
 schema change and requires updating both the classifier and the corresponding
 Literal here. Tests that pin the BI shape live in
-``tests/test_analytics_events.py``, ``tests/test_analytics_privacy.py`` and
-``tests/test_analytics_lifespan.py``.
+``tests/test_analytics_events.py``, ``tests/test_analytics_privacy.py``,
+``tests/test_analytics_lifespan.py`` and ``tests/test_analytics_client.py``
+(the last asserts against the decoded request body actually posted).
 
 Each Literal documents the *only* values the receiver will ever see for that
 property. Anything outside the allowlist is bucketed to a fallback ("other",

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -8,8 +8,9 @@ identifiable values. Thresholds picked to align with common LLM-context budgets
 
 Every analytics property is either a boolean string, a hardcoded-allowlist
 string, or a bucketed integer/duration. The allowlists below MUST stay in sync
-with the classifiers in ``environment.py`` (launch method / parent process) and
-``mcp_client_info.py`` (mcp host / host LLM family) — adding a new bucket is a BI
+with the classifiers in ``environment.py`` (launch method / parent process),
+``mcp_client_info.py`` (mcp host / host LLM family) and ``analytics/client.py``
+(``_resolve_workspace`` / ``_resolve_user``) — adding a new bucket is a BI
 schema change and requires updating both the classifier and the corresponding
 Literal here. Tests that pin the BI shape live in
 ``tests/test_analytics_events.py``, ``tests/test_analytics_privacy.py`` and

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -177,7 +177,16 @@ UserIdKind = Literal["comet_user", "install_id"]
 # classifier is ``client._resolve_workspace``. CRITICAL for BI: "placeholder" is
 # the literal "default" on an install that resolved nothing, and it collides with
 # a real cloud workspace of that name — those rows must never be name-joined.
-WorkspaceKind = Literal["resolved", "configured", "placeholder"]
+#
+# "unknown" carries no ``workspace`` value at all: nothing was configured and
+# nothing resolved. It exists so this field is stamped on every event that
+# carries ``user_id_kind``, which is what lets BI total workspace_kind without
+# an unstamped remainder silently going missing.
+# "template" is an operator-configured value that was never filled in — a config
+# snippet pasted verbatim. It is reported rather than hidden: the value itself
+# says which snippet failed the user (`${input:…}` is VS Code, `<your-workspace>`
+# is our README), and the kind keeps it out of workspace joins.
+WorkspaceKind = Literal["resolved", "configured", "placeholder", "template", "unknown"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -13,6 +13,37 @@ from opik_mcp.error_kinds import ErrorKind
 # setting a workspace at all; cloud users with named workspaces still set one.
 DEFAULT_WORKSPACE = "default"
 
+# Config-snippet placeholders users paste without filling in. `${…}` is the
+# VS Code / shell form (`${input:OPIK_WORKSPACE}`), `<…>` is the one our own
+# README uses (`<your-workspace>`), plus the mustache and Windows forms.
+#
+# This is not cosmetic. The workspace name is sent verbatim as `Comet-Workspace`
+# on every data call, so an unfilled placeholder cannot resolve to a workspace
+# the caller can reach. Analytics found ~41 such installs within a day of the
+# identity change shipping, all of them failing against opaque upstream errors.
+_TEMPLATE_WRAPPERS = (("${", "}"), ("<", ">"), ("{{", "}}"), ("%", "%"))
+
+
+def looks_unsubstituted(value: str) -> bool:
+    """True for an obviously unfilled config placeholder.
+
+    Deliberately narrow: the whole value must both open and close with a wrapper
+    pair, so a real workspace name containing a stray bracket is not caught. A
+    false positive would break an install that works today, which is far worse
+    than missing an exotic placeholder shape.
+    """
+    candidate = value.strip()
+    if candidate.startswith("$") and not candidate.startswith("${"):
+        # Bare `$OPIK_WORKSPACE` — a shell variable that never expanded.
+        return True
+    return any(
+        len(candidate) > len(open_) + len(close)
+        and candidate.startswith(open_)
+        and candidate.endswith(close)
+        for open_, close in _TEMPLATE_WRAPPERS
+    )
+
+
 # Cloud-Comet hostnames. Strict equality (matching the opik SDK) — ``staging.
 # comet.com`` / ``enterprise.example.com`` count as self-hosted so dashboards
 # don't mix prod-cloud failures with on-prem ones.

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -9,8 +9,11 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from opik_mcp.error_kinds import ErrorKind
 
 # Workspace name used when none is configured — mirrors the Opik Python SDK
-# (`OPIK_WORKSPACE_DEFAULT_NAME = "default"`). Lets local/OSS users run without
-# setting a workspace at all; cloud users with named workspaces still set one.
+# (`OPIK_WORKSPACE_DEFAULT_NAME = "default"`). Correct for local/OSS, which has
+# exactly one workspace by this name. NOT a working fallback on cloud, where the
+# backend treats "default" as a reserved name and refuses it: cloud users have to
+# set a real workspace. The SDK papers over this by having `opik configure` write
+# the resolved name to ~/.opik.config; opik-mcp reads env vars only.
 DEFAULT_WORKSPACE = "default"
 
 # Config-snippet placeholders users paste without filling in. `${…}` is the
@@ -27,10 +30,14 @@ _TEMPLATE_WRAPPERS = (("${", "}"), ("<", ">"), ("{{", "}}"), ("%", "%"))
 def looks_unsubstituted(value: str) -> bool:
     """True for an obviously unfilled config placeholder.
 
-    Deliberately narrow: the whole value must both open and close with a wrapper
-    pair, so a real workspace name containing a stray bracket is not caught. A
-    false positive would break an install that works today, which is far worse
-    than missing an exotic placeholder shape.
+    Two rules. A value that both opens and closes with a wrapper pair
+    (``${…}``, ``<…>``, ``{{…}}``, ``%…%``), and a value starting with a bare
+    ``$`` — a shell variable that never expanded, which has no closing marker to
+    match on.
+
+    Deliberately narrow otherwise: requiring both ends means a real workspace
+    name containing a stray bracket is not caught. A false positive breaks an
+    install that works today, which is far worse than missing an exotic shape.
     """
     candidate = value.strip()
     if candidate.startswith("$") and not candidate.startswith("${"):
@@ -254,13 +261,38 @@ def get_settings() -> Settings:
     return Settings()
 
 
+def unfilled_workspace_error(value: str, source: str) -> MissingConfigError:
+    """The one message for an unfilled workspace, wherever it is noticed.
+
+    Both entry points to Opik reach the backend with a ``Comet-Workspace``
+    header: ``opik_client.resolve_opik_config`` for the data tools and
+    ``require_ollie_config`` for ``ask_ollie``. They share this so a user gets
+    the same actionable text regardless of which tool they happened to call.
+    """
+    return MissingConfigError(
+        f"{source} is {value!r}, which looks like a config placeholder that was "
+        "never filled in. Set it to your workspace name — the segment in your "
+        "Opik URL, e.g. https://www.comet.com/acme-ai/... -> acme-ai."
+    )
+
+
+# Named for the error message. Pydantic resolves the alias for us and does not
+# report which spelling matched, so name both rather than guess wrong.
+WORKSPACE_ENV_VARS = "OPIK_WORKSPACE (or COMET_WORKSPACE)"
+
+
 def require_ollie_config(settings: Settings) -> tuple[str, str]:
     if not settings.opik_api_key:
         raise MissingConfigError("OPIK_API_KEY is required to use ask_ollie")
     # Workspace is optional — fall back to "default" (Opik SDK convention).
     # Cloud pod discovery for a non-"default" account will surface its own
     # clear error downstream, which beats a hard config failure here.
-    return settings.opik_api_key, settings.comet_workspace or DEFAULT_WORKSPACE
+    workspace = settings.comet_workspace or DEFAULT_WORKSPACE
+    if looks_unsubstituted(workspace):
+        # ask_ollie does not go through resolve_opik_config, so without this it
+        # keeps hitting the opaque upstream error that guard exists to replace.
+        raise unfilled_workspace_error(workspace, WORKSPACE_ENV_VARS)
+    return settings.opik_api_key, workspace
 
 
 def installation_type(settings: Settings) -> str:

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -1,3 +1,4 @@
+import re
 from functools import lru_cache
 from typing import Any, ClassVar, Literal
 from urllib.parse import urlparse
@@ -30,22 +31,33 @@ DEFAULT_WORKSPACE = "default"
 # identity change shipping, all of them failing against opaque upstream errors.
 _TEMPLATE_WRAPPERS = (("${", "}"), ("<", ">"), ("{{", "}}"), ("%", "%"))
 
+# Bare, unbraced shell forms: `$OPIK_WORKSPACE` and the Kubernetes `$(VAR)`.
+# UPPERCASE is required and is the whole point of the pattern. Workspace names
+# are unconstrained — opik-backend enforces no charset, length or reserved list
+# beyond `default`, and `$` is a legal URI sub-delim, so `$acme` is a name
+# somebody can be using today. Matching every `$`-prefixed value would turn that
+# working install into a hard failure on every tool call. An env-var-shaped name
+# is the narrow case worth catching; anything else is left alone.
+_BARE_SHELL_VAR = re.compile(r"^\$(?:[A-Z_][A-Z0-9_]*|\([A-Z_][A-Z0-9_]*\))$")
+
 
 def looks_unsubstituted(value: str) -> bool:
     """True for an obviously unfilled config placeholder.
 
     Two rules. A value that both opens and closes with a wrapper pair
-    (``${…}``, ``<…>``, ``{{…}}``, ``%…%``), and a value starting with a bare
-    ``$`` — a shell variable that never expanded, which has no closing marker to
-    match on.
+    (``${…}``, ``<…>``, ``{{…}}``, ``%…%``), and an env-var-shaped bare shell
+    reference (``$OPIK_WORKSPACE``, ``$(OPIK_WORKSPACE)``), which has no closing
+    marker to match on.
 
-    Deliberately narrow otherwise: requiring both ends means a real workspace
-    name containing a stray bracket is not caught. A false positive breaks an
-    install that works today, which is far worse than missing an exotic shape.
+    Deliberately narrow: a false positive breaks an install that works today,
+    which is far worse than missing an exotic shape. Workspace names carry no
+    charset restriction anywhere in the product, so both rules are written to
+    leave anything plausibly real alone — see ``_BARE_SHELL_VAR``.
     """
     candidate = value.strip()
-    if candidate.startswith("$") and not candidate.startswith("${"):
-        # Bare `$OPIK_WORKSPACE` — a shell variable that never expanded.
+    if _BARE_SHELL_VAR.match(candidate):
+        # `$OPIK_WORKSPACE` / `$(OPIK_WORKSPACE)` — never expanded. The braced
+        # `${…}` form is covered by the wrapper rule below.
         return True
     return any(
         len(candidate) > len(open_) + len(close)
@@ -270,8 +282,13 @@ def unfilled_workspace_error(value: str, source: str) -> MissingConfigError:
 
     Both entry points to Opik reach the backend with a ``Comet-Workspace``
     header: ``opik_client.resolve_opik_config`` for the data tools and
-    ``require_ollie_config`` for ``ask_ollie``. They share this so a user gets
-    the same actionable text regardless of which tool they happened to call.
+    ``require_ollie_config`` for ``ask_ollie``. They share this so the wording
+    does not depend on which tool the user happened to call.
+
+    They do NOT check the same inputs. ``resolve_opik_config`` also sees the
+    inbound header, because it forwards it; ``ask_ollie`` is settings-driven by
+    design (pod discovery is per-install, not per-request), so a hosted caller
+    sending a placeholder header is caught on the data tools only.
     """
     return MissingConfigError(
         f"{source} is {value!r}, which looks like a config placeholder that was "
@@ -288,9 +305,10 @@ WORKSPACE_ENV_VARS = "OPIK_WORKSPACE (or COMET_WORKSPACE)"
 def require_ollie_config(settings: Settings) -> tuple[str, str]:
     if not settings.opik_api_key:
         raise MissingConfigError("OPIK_API_KEY is required to use ask_ollie")
-    # Workspace is optional — fall back to "default" (Opik SDK convention).
-    # Cloud pod discovery for a non-"default" account will surface its own
-    # clear error downstream, which beats a hard config failure here.
+    # Workspace is optional — fall back to "default" (Opik SDK convention),
+    # which on cloud resolves to the account's default workspace. Anything that
+    # goes wrong past that point surfaces its own error from pod discovery,
+    # which beats a hard config failure here.
     workspace = settings.comet_workspace or DEFAULT_WORKSPACE
     if looks_unsubstituted(workspace):
         # ask_ollie does not go through resolve_opik_config, so without this it

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -10,10 +10,14 @@ from opik_mcp.error_kinds import ErrorKind
 
 # Workspace name used when none is configured — mirrors the Opik Python SDK
 # (`OPIK_WORKSPACE_DEFAULT_NAME = "default"`). Correct for local/OSS, which has
-# exactly one workspace by this name. NOT a working fallback on cloud, where the
-# backend treats "default" as a reserved name and refuses it: cloud users have to
-# set a real workspace. The SDK papers over this by having `opik configure` write
-# the resolved name to ~/.opik.config; opik-mcp reads env vars only.
+# exactly one workspace by this name.
+#
+# On cloud it is NOT rejected, despite `default` being refused on the session /
+# OAuth consent paths (`RemoteAuthService.isDefaultWorkspace`). The API-key path
+# goes to react-service, which reads it as "this account's default workspace" —
+# verified live: `Comet-Workspace: default` and the account's own default name
+# return the identical project set. So the fallback works, but it silently picks
+# a workspace rather than the named one a user may have meant.
 DEFAULT_WORKSPACE = "default"
 
 # Config-snippet placeholders users paste without filling in. `${…}` is the

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -27,9 +27,11 @@ from opik_mcp.auth_context import (
 )
 from opik_mcp.config import (
     DEFAULT_WORKSPACE,
+    WORKSPACE_ENV_VARS,
     MissingConfigError,
     Settings,
     looks_unsubstituted,
+    unfilled_workspace_error,
 )
 from opik_mcp.error_kinds import ErrorKind
 
@@ -794,12 +796,8 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str | None, str | None
         # placeholder and letting the backend answer with an auth error that
         # names neither the setting nor the value. Classified as `validation`
         # (see MissingConfigError) so it buckets as a fixable setup problem.
-        source = "the inbound Comet-Workspace header" if inbound_ws else "OPIK_WORKSPACE"
-        raise MissingConfigError(
-            f"{source} is {workspace!r}, which looks like a config placeholder that "
-            "was never filled in. Set it to your workspace name — the segment in "
-            "your Opik URL, e.g. https://www.comet.com/acme-ai/... -> acme-ai."
-        )
+        source = "the inbound Comet-Workspace header" if inbound_ws else WORKSPACE_ENV_VARS
+        raise unfilled_workspace_error(workspace, source)
     base = opik_rest_base(settings)
     if base is None:
         # ``comet_url_override`` has a non-empty default in ``Settings`` but

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -25,7 +25,12 @@ from opik_mcp.auth_context import (
     inbound_authorization,
     inbound_workspace,
 )
-from opik_mcp.config import DEFAULT_WORKSPACE, MissingConfigError, Settings
+from opik_mcp.config import (
+    DEFAULT_WORKSPACE,
+    MissingConfigError,
+    Settings,
+    looks_unsubstituted,
+)
 from opik_mcp.error_kinds import ErrorKind
 
 # --- errors --------------------------------------------------------------- #
@@ -784,6 +789,17 @@ def resolve_opik_config(settings: Settings) -> tuple[str, str | None, str | None
         # configured workspace, else "default" (Opik SDK convention). No hard
         # failure — lets local/OSS users run without setting a workspace.
         workspace = inbound_ws or settings.comet_workspace or DEFAULT_WORKSPACE
+    if workspace and looks_unsubstituted(workspace):
+        # Fail here with something actionable rather than forwarding a
+        # placeholder and letting the backend answer with an auth error that
+        # names neither the setting nor the value. Classified as `validation`
+        # (see MissingConfigError) so it buckets as a fixable setup problem.
+        source = "the inbound Comet-Workspace header" if inbound_ws else "OPIK_WORKSPACE"
+        raise MissingConfigError(
+            f"{source} is {workspace!r}, which looks like a config placeholder that "
+            "was never filled in. Set it to your workspace name — the segment in "
+            "your Opik URL, e.g. https://www.comet.com/acme-ai/... -> acme-ai."
+        )
     base = opik_rest_base(settings)
     if base is None:
         # ``comet_url_override`` has a non-empty default in ``Settings`` but

--- a/tests/test_analytics_client.py
+++ b/tests/test_analytics_client.py
@@ -905,3 +905,62 @@ def test_a_caller_supplied_workspace_cannot_contradict_unknown() -> None:
     props = json.loads(route.calls.last.request.content)["event_properties"]
     assert props["workspace_kind"] == "unknown"
     assert "workspace" not in props
+
+
+@respx.mock
+def test_a_hosted_call_reports_the_workspace_from_its_own_header() -> None:
+    """The inbound header is what the call actually routes on. Reporting
+    `unknown` here while `request_workspace` carries the name would be an
+    affirmative wrong claim, not merely a missing one."""
+    from opik_mcp.auth_context import inbound_workspace
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=None))
+    tok = inbound_workspace.set("caller-workspace")
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_workspace.reset(tok)
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace"] == "caller-workspace"
+    assert props["workspace_kind"] == "configured"
+    assert props["request_workspace"] == "caller-workspace"
+
+
+@respx.mock
+def test_an_inbound_header_outranks_the_process_setting() -> None:
+    from opik_mcp.auth_context import inbound_workspace
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace="server-side-ws"))
+    tok = inbound_workspace.set("caller-workspace")
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_workspace.reset(tok)
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace"] == "caller-workspace"
+
+
+@respx.mock
+def test_an_unfilled_placeholder_in_the_inbound_header_is_labelled_too() -> None:
+    from opik_mcp.auth_context import inbound_workspace
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=None))
+    tok = inbound_workspace.set("${input:OPIK_WORKSPACE}")
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_workspace.reset(tok)
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace_kind"] == "template"

--- a/tests/test_analytics_client.py
+++ b/tests/test_analytics_client.py
@@ -178,8 +178,9 @@ def test_track_event_falls_back_to_install_id_without_workspace() -> None:
     assert body["event_properties"]["user_id_kind"] == "install_id"
     # No workspace was set, so `workspace` must NOT appear in event_properties.
     assert "workspace" not in body["event_properties"]
-    # ...and neither must its discriminator, rather than an empty string.
-    assert "workspace_kind" not in body["event_properties"]
+    # Its discriminator IS still stamped, saying we have nothing to report.
+    # Omitting it made workspace_kind totals under-count silently.
+    assert body["event_properties"]["workspace_kind"] == "unknown"
     # No api_key was set, so `api_key_sha256` must NOT appear either.
     assert "api_key_sha256" not in body["event_properties"]
 
@@ -737,3 +738,170 @@ def test_a_forwarded_api_key_bearer_is_not_resolved_as_our_own(
     body = json.loads(route.calls.last.request.content)
     assert body["user_id"] == get_install_id()
     assert body["event_properties"]["user_id_kind"] == "install_id"
+
+
+# --- workspace_kind is stamped whenever user_id_kind is ------------------ #
+
+
+@respx.mock
+def test_workspace_kind_is_present_even_when_no_workspace_is_known() -> None:
+    """The two discriminators are a pair, and BI totals them together.
+
+    Leaving workspace_kind off when there is no workspace made its counts
+    silently under-total: 2.4% of new-field rows in the first day carried
+    user_id_kind with no workspace_kind at all.
+    """
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=None))
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["user_id_kind"] == "install_id"
+    assert props["workspace_kind"] == "unknown"
+    # Still no workspace VALUE — unknown means unknown, not empty string.
+    assert "workspace" not in props
+
+
+# --- unsubstituted config templates are not a workspace ------------------ #
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "${input:OPIK_WORKSPACE}",
+        "${OPIK_WORKSPACE}",
+        "$OPIK_WORKSPACE",
+        "<your-workspace>",
+        "<workspace-name>",
+        "{{workspace}}",
+        "%OPIK_WORKSPACE%",
+        "  <your-workspace>  ",
+    ],
+    ids=[
+        "vscode-input",
+        "shell-braced",
+        "shell-bare",
+        "readme-angle",
+        "angle-generic",
+        "mustache",
+        "windows-percent",
+        "padded",
+    ],
+)
+@respx.mock
+def test_an_unfilled_config_snippet_is_reported_as_a_template(template: str) -> None:
+    """Users paste our config snippets without substituting them.
+
+    We label rather than hide. The raw value is the only thing that says WHICH
+    snippet failed them — `${input:…}` is VS Code, `<your-workspace>` is our own
+    README — and the kind keeps these rows out of workspace joins.
+    """
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=template))
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace"] == template
+    assert props["workspace_kind"] == "template"
+
+
+@respx.mock
+def test_a_template_is_not_silently_replaced_by_a_resolved_workspace() -> None:
+    """A broken config stays visible even when we could paper over it.
+
+    User attribution is unaffected either way — `user_id` resolves from the
+    credential, not the workspace — so hiding the template would cost the
+    signal and buy nothing.
+    """
+    from opik_mcp.auth_context import inbound_authorization
+
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    auth = _with_oauth_identity(workspace_name="real-workspace")
+    client = AnalyticsClient(_settings(comet_workspace="${input:OPIK_WORKSPACE}"))
+    tok = inbound_authorization.set(auth)
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        inbound_authorization.reset(tok)
+        client.close()
+
+    body = json.loads(route.calls.last.request.content)
+    props = body["event_properties"]
+    assert props["workspace_kind"] == "template"
+    # The caller is still identified — that never depended on the workspace.
+    assert body["user_id"] == "awkoy"
+    assert props["user_id_kind"] == "comet_user"
+
+
+@respx.mock
+def test_an_ordinary_workspace_name_is_not_mistaken_for_a_template() -> None:
+    """Guard the detector against false positives on real names."""
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace="portpro-devlopment"))
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace"] == "portpro-devlopment"
+    assert props["workspace_kind"] == "configured"
+
+
+@pytest.mark.parametrize(
+    "settings_kwargs",
+    [
+        {"comet_workspace": None},
+        {"comet_workspace": "default"},
+        {"comet_workspace": "acme-ai"},
+        {"comet_workspace": "<your-workspace>"},
+        {"comet_workspace": None, "opik_api_key": "sk-key"},
+    ],
+    ids=["nothing", "placeholder", "configured", "template", "with-api-key"],
+)
+@respx.mock
+def test_the_two_discriminators_are_always_stamped_together(
+    settings_kwargs: dict[str, Any],
+) -> None:
+    """BI totals workspace_kind against user_id_kind. If either can appear
+    without the other, those totals disagree and nothing says why."""
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(**settings_kwargs))
+    try:
+        client.track_event("opik_mcp_test", {})
+        _drain(client)
+    finally:
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert "user_id_kind" in props
+    assert "workspace_kind" in props
+    # Only "unknown" is allowed to carry no name.
+    assert ("workspace" in props) == (props["workspace_kind"] != "unknown")
+
+
+@respx.mock
+def test_a_caller_supplied_workspace_cannot_contradict_unknown() -> None:
+    """`properties` merges under `common`, so a call site passing a workspace
+    would otherwise survive next to workspace_kind='unknown'."""
+    route = respx.post(URL).mock(return_value=httpx.Response(200))
+    client = AnalyticsClient(_settings(comet_workspace=None))
+    try:
+        client.track_event("opik_mcp_test", {"workspace": "smuggled-in"})
+        _drain(client)
+    finally:
+        client.close()
+
+    props = json.loads(route.calls.last.request.content)["event_properties"]
+    assert props["workspace_kind"] == "unknown"
+    assert "workspace" not in props

--- a/tests/test_analytics_events.py
+++ b/tests/test_analytics_events.py
@@ -188,3 +188,59 @@ def test_path_bucket_literal_matches_bucket_path_outputs() -> None:
     # no undeclared outputs).
     samples = ["/mcp", "/health", "/.well-known/x", "/anything-else", ""]
     assert {bucket_path(p) for p in samples} == allowed
+
+
+def test_workspace_kind_literal_has_no_dead_members() -> None:
+    """Every declared WorkspaceKind must be reachable from the classifier.
+
+    mypy already stops ``_resolve_workspace`` returning a value the Literal
+    doesn't declare. What it cannot see is the other direction: a member left
+    behind after a rule changes, which BI would then wait for forever. Same
+    contract as McpHost, driven through the real classifier.
+    """
+    from typing import get_args
+
+    from opik_mcp.analytics.client import AnalyticsClient
+    from opik_mcp.analytics.events import WorkspaceKind
+    from opik_mcp.config import DEFAULT_WORKSPACE, Settings
+    from opik_mcp.credential_identity import ResolvedIdentity
+
+    def _kind(workspace: str | None, resolved: str | None) -> str:
+        client = AnalyticsClient(
+            Settings(opik_mcp_analytics_enabled=False, comet_workspace=workspace)
+        )
+        identity = (
+            ResolvedIdentity(user_name="u", workspace_name=resolved, workspace_id=None)
+            if resolved
+            else None
+        )
+        return client._resolve_workspace(identity).kind
+
+    produced = {
+        _kind("acme-ai", None),  # configured
+        _kind(None, "from-backend"),  # resolved
+        _kind(DEFAULT_WORKSPACE, None),  # placeholder
+        _kind("${input:OPIK_WORKSPACE}", None),  # template
+        _kind(None, None),  # unknown
+    }
+    declared = set(get_args(WorkspaceKind))
+    assert produced == declared, (
+        f"WorkspaceKind drift: unreachable={sorted(declared - produced)} "
+        f"undeclared={sorted(produced - declared)}"
+    )
+
+
+def test_user_id_kind_literal_has_no_dead_members() -> None:
+    from typing import get_args
+
+    from opik_mcp.analytics.client import AnalyticsClient
+    from opik_mcp.analytics.events import UserIdKind
+    from opik_mcp.credential_identity import ResolvedIdentity
+
+    produced = {
+        AnalyticsClient._resolve_user(
+            ResolvedIdentity(user_name="awkoy", workspace_name=None, workspace_id=None)
+        ).kind,
+        AnalyticsClient._resolve_user(None).kind,
+    }
+    assert produced == set(get_args(UserIdKind))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -138,3 +138,34 @@ def test_auto_approve_rejects_typo() -> None:
 
     with pytest.raises(ValidationError):
         Settings(opik_api_key="k", comet_workspace="w", opik_mcp_auto_approve="off")  # type: ignore[arg-type]
+
+
+def test_ask_ollie_refuses_an_unfilled_workspace_placeholder() -> None:
+    """ask_ollie does not go through resolve_opik_config, so it needs its own
+    guard or it keeps hitting the opaque upstream error."""
+    from opik_mcp.config import MissingConfigError, Settings, require_ollie_config
+
+    s = Settings(opik_api_key="k", comet_workspace="${input:OPIK_WORKSPACE}")
+    with pytest.raises(MissingConfigError) as excinfo:
+        require_ollie_config(s)
+    assert "config placeholder" in str(excinfo.value)
+    assert "workspace name" in str(excinfo.value)
+
+
+def test_ask_ollie_still_falls_back_to_default_when_unset() -> None:
+    from opik_mcp.config import DEFAULT_WORKSPACE, Settings, require_ollie_config
+
+    _key, workspace = require_ollie_config(Settings(opik_api_key="k", comet_workspace=None))
+    assert workspace == DEFAULT_WORKSPACE
+
+
+def test_the_workspace_error_names_both_env_spellings() -> None:
+    """Pydantic resolves the alias and does not say which one matched, so the
+    message must not guess."""
+    from opik_mcp.config import MissingConfigError, Settings, require_ollie_config
+
+    s = Settings(comet_workspace="<your-workspace>", opik_api_key="k")
+    with pytest.raises(MissingConfigError) as excinfo:
+        require_ollie_config(s)
+    assert "OPIK_WORKSPACE" in str(excinfo.value)
+    assert "COMET_WORKSPACE" in str(excinfo.value)

--- a/tests/test_opik_client.py
+++ b/tests/test_opik_client.py
@@ -485,11 +485,20 @@ async def test_execute_experiment_posts_to_execute_endpoint() -> None:
         "${input:OPIK_WORKSPACE}",
         "${OPIK_WORKSPACE}",
         "$OPIK_WORKSPACE",
+        "$(OPIK_WORKSPACE)",
         "<your-workspace>",
         "{{workspace}}",
         "%OPIK_WORKSPACE%",
     ],
-    ids=["vscode-input", "shell-braced", "shell-bare", "readme-angle", "mustache", "win-percent"],
+    ids=[
+        "vscode-input",
+        "shell-braced",
+        "shell-bare",
+        "k8s-parens",
+        "readme-angle",
+        "mustache",
+        "win-percent",
+    ],
 )
 def test_an_unfilled_workspace_placeholder_fails_with_a_usable_message(value: str) -> None:
     from opik_mcp.config import MissingConfigError, Settings
@@ -524,12 +533,41 @@ def test_an_unfilled_inbound_workspace_header_fails_the_same_way() -> None:
 
 @pytest.mark.parametrize(
     "value",
-    ["acme-ai", "default", "portpro-devlopment", "workspace", "x<y"],
-    ids=["slug", "oss-default", "real-name", "the-word", "stray-bracket"],
+    [
+        "acme-ai",
+        "default",
+        "portpro-devlopment",
+        "workspace",
+        "x<y",
+        "$acme",
+        "$acme-ai",
+        "$",
+        "$$",
+        "$a",
+    ],
+    ids=[
+        "slug",
+        "oss-default",
+        "real-name",
+        "the-word",
+        "stray-bracket",
+        "dollar-prefixed-name",
+        "dollar-prefixed-slug",
+        "lone-dollar",
+        "double-dollar",
+        "dollar-single-char",
+    ],
 )
 def test_a_real_workspace_is_untouched(value: str) -> None:
     """A false positive would break a working install, which is far worse than
-    missing an exotic placeholder shape."""
+    missing an exotic placeholder shape.
+
+    The `$`-prefixed cases are the ones that matter. Workspace names carry no
+    charset restriction anywhere in the product and `$` is a legal URI
+    sub-delim, so `$acme` is a name somebody may be using right now. An earlier
+    version of the detector matched every `$`-prefixed value and would have
+    hard-failed every tool call for that install.
+    """
     from opik_mcp.config import Settings
     from opik_mcp.opik_client import resolve_opik_config
 

--- a/tests/test_opik_client.py
+++ b/tests/test_opik_client.py
@@ -469,3 +469,80 @@ async def test_execute_experiment_posts_to_execute_endpoint() -> None:
     assert sent.headers["comet-workspace"] == "ws"
     # Body is forwarded verbatim:
     assert sent.read().startswith(b'{"dataset_name":"suite-a"')
+
+
+# --- unfilled workspace placeholders -------------------------------------- #
+#
+# The workspace goes out as `Comet-Workspace` on every data call, so a config
+# snippet the user never filled in cannot resolve to anything. These installs
+# were failing with opaque upstream auth errors; analytics found ~41 of them
+# within a day of 0.2.16 shipping.
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "${input:OPIK_WORKSPACE}",
+        "${OPIK_WORKSPACE}",
+        "$OPIK_WORKSPACE",
+        "<your-workspace>",
+        "{{workspace}}",
+        "%OPIK_WORKSPACE%",
+    ],
+    ids=["vscode-input", "shell-braced", "shell-bare", "readme-angle", "mustache", "win-percent"],
+)
+def test_an_unfilled_workspace_placeholder_fails_with_a_usable_message(value: str) -> None:
+    from opik_mcp.config import MissingConfigError, Settings
+    from opik_mcp.opik_client import resolve_opik_config
+
+    s = Settings(opik_api_key="k", comet_workspace=value)
+    with pytest.raises(MissingConfigError) as excinfo:
+        resolve_opik_config(s)
+    message = str(excinfo.value)
+    # Name the variable, show the offending value, and say what to put there —
+    # the whole point is replacing an upstream 401 nobody can act on.
+    assert "OPIK_WORKSPACE" in message
+    assert value in message
+    assert "workspace name" in message
+
+
+def test_an_unfilled_inbound_workspace_header_fails_the_same_way() -> None:
+    """Hosted callers send their own config; a host with an unfilled template in
+    its headers is just as broken as a local env var."""
+    from opik_mcp.auth_context import inbound_workspace
+    from opik_mcp.config import MissingConfigError, Settings
+    from opik_mcp.opik_client import resolve_opik_config
+
+    s = Settings(opik_api_key="k", comet_workspace="real-ws")
+    token = inbound_workspace.set("${input:OPIK_WORKSPACE}")
+    try:
+        with pytest.raises(MissingConfigError):
+            resolve_opik_config(s)
+    finally:
+        inbound_workspace.reset(token)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["acme-ai", "default", "portpro-devlopment", "workspace", "x<y"],
+    ids=["slug", "oss-default", "real-name", "the-word", "stray-bracket"],
+)
+def test_a_real_workspace_is_untouched(value: str) -> None:
+    """A false positive would break a working install, which is far worse than
+    missing an exotic placeholder shape."""
+    from opik_mcp.config import Settings
+    from opik_mcp.opik_client import resolve_opik_config
+
+    s = Settings(opik_api_key="k", comet_workspace=value)
+    _base, _api, ws = resolve_opik_config(s)
+    assert ws == value
+
+
+def test_an_unset_workspace_still_falls_back_to_default() -> None:
+    """Unchanged behaviour: OSS installs run without setting a workspace."""
+    from opik_mcp.config import DEFAULT_WORKSPACE, Settings
+    from opik_mcp.opik_client import resolve_opik_config
+
+    s = Settings(opik_api_key="k", comet_workspace=None)
+    _base, _api, ws = resolve_opik_config(s)
+    assert ws == DEFAULT_WORKSPACE


### PR DESCRIPTION
Follow-up to #161. A day of production data after `0.2.16` shipped exposed three problems; this closes them, plus two documentation errors of my own that the review and a live run caught.

## 1. `workspace_kind` went missing instead of showing up as a bucket

Omitted entirely when nothing was configured and nothing resolved, so 2.4% of new-field rows carried `user_id_kind` with no `workspace_kind` beside it. The two are a pair and BI totals them together, so that remainder vanished silently rather than appearing as its own bucket.

Now stamped on every event, with `unknown` meaning "no workspace to report". The classifier owns every outcome, so the emit site can no longer stamp a kind the `Literal` doesn't cover, and dead-member guards match what `McpHost` already has.

## 2. Unfilled config snippets looked like deliberate choices

`${input:OPIK_WORKSPACE}` (VS Code) and `<your-workspace>` (our own README) both arrived within a day, indistinguishable from a workspace an operator picked on purpose. They get their own `template` kind.

**Labelled, not hidden, and not validated at startup:**

- Reporting the raw value is the only thing that says *which* snippet is failing users.
- Hiding it behind a resolved name would cost that signal and buy nothing — user attribution never depended on the workspace (`user_id` resolves from the credential).
- Startup validation was rejected: the Opik SDK doesn't validate the workspace either, so failing installs here would make opik-mcp the outlier.

## 3. Those installs were broken, not just mislabelled

The same unfilled value is sent as `Comet-Workspace` on **every data call**, so nothing these users did worked — the backend answered with an error naming neither the setting nor the value. `resolve_opik_config` and `require_ollie_config` now raise `MissingConfigError` with an actionable message. Nothing that works today starts failing: these calls were already failing, just opaquely.

## Documentation, twice wrong

`0.2.16` told cloud users they could omit `OPIK_WORKSPACE` because "the server resolves your account's workspace" — wrong about the mechanism. My first correction then said omitting it means tool calls are **rejected** — wrong about the outcome, which is worse.

Measured against the production API:

```
Comet-Workspace: default            -> 382 projects
Comet-Workspace: <account default>  -> 382 projects   (identical)
Comet-Workspace: <named workspace>  ->  14 projects
```

`default` is refused on the session and OAuth-consent paths (`RemoteAuthService.isDefaultWorkspace`), which is what the code reads like. The API-key path doesn't go through those: react-service reads `default` as "this account's default workspace" and serves it. **The hazard is silence, not failure** — omit the setting while working in a named workspace and your reads come back from a different one, looking fine. That is what the docs now warn about, split four ways (cloud+key, cloud+OAuth, self-hosted Comet, open source) because the right answer genuinely differs.

## Verification

**Live, against a real workspace on production**, driving the actual server over stdio:

| Scenario | Result |
|---|---|
| Working config | session OK, 6 tools, `list` returned 14 projects, HTTP 200 |
| Unfilled placeholder | **session survives**, only that call fails, with the new message |
| No workspace set | session OK, `list` returned 382 projects, HTTP 200 |
| `$acme` workspace name | not intercepted — reaches the backend, which judges it |

1232 tests pass. Assertions are against the decoded analytics request body and `resolve_opik_config`'s return, not internals.

## The one regression review found, and fixed

The detector originally matched **any** value starting with `$`, so a workspace legitimately named `$acme` would have hard-failed every tool call. Nothing rules such a name out: opik-backend enforces no charset, length or reserved list beyond `default`, and `$` is a legal URI sub-delim that survives the frontend's routes. The other wrappers are safe by contrast — `<…>`, `{{…}}`, `%…%` break those same routes, so a workspace named that way cannot function anyway.

The bare form now has to look like an environment variable (`$OPIK_WORKSPACE`, or the Kubernetes `$(OPIK_WORKSPACE)`, uppercase required). `$acme`, `$acme-ai`, `$`, `$$`, `$a` pass through untouched and are pinned as such.

## Ruled out during review

No boot, handshake or health path can raise: `resolve_opik_config` is reached only from tool bodies. `MissingConfigError` surfaces as a normal `isError` tool result, never a protocol error or a killed session, and is already classified user-side so it adds no Sentry noise. OAuth passthrough is unaffected (no `Comet-Workspace` header, so the guard is skipped). OSS and self-hosted still fall through to `default`. Telemetry cannot break a call — `_build_event` sits inside `track_event`'s blanket handler. No new import edges.

## Not addressed here

- `installation_type` is URL-based, so self-hosted Comet with real accounts is indistinguishable from open source, and `dev.comet.com` is not in the cloud host list.
- `workspace_id` for OAuth callers is still unverified in production — no OAuth install has upgraded to `0.2.16` yet.
- `instructions.py` renders the same workspace value into the session blob, so a placeholder still reaches the model as a name there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)