### PR TITLE
[OPIK-7621] Generate and publish the opik-skills pack from opik-mcp

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "opik",
+  "owner": {
+    "name": "Comet ML",
+    "url": "https://github.com/comet-ml"
+  },
+  "metadata": {
+    "description": "Opik agent skills, authored here and published as the opik-skills pack.",
+    "pluginRoot": "./src/opik_mcp"
+  },
+  "plugins": [
+    {
+      "name": "opik",
+      "source": "./",
+      "description": "Skills that teach a coding agent to instrument, trace and evaluate LLM applications with Opik."
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,108 @@ jobs:
       - name: Run lint + typecheck + tests
         run: make check
 
+  # The published `opik-skills` pack (OPIK-7621). Built on every PR so a change to
+  # the authored skills is verified before it can reach users; published only from
+  # main. `python-checks` already covers spec compliance and the builder's own
+  # tests — what this adds is the end-to-end question those cannot answer: does the
+  # real installer, run the way the product's onboarding runs it, resolve exactly
+  # the skills we authored.
+  skills-pack:
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate _version.py (required before any uv build)
+        run: make version
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: 'latest'
+      - name: Install Python
+        run: uv python install 3.13
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Build the pack and install it with the real installer
+        env:
+          PYVER: ${{ needs.version.outputs.pyver }}
+          SHA: ${{ github.sha }}
+        run: make skills-verify VERSION="$PYVER" SOURCE_COMMIT="$SHA"
+      - name: Check this repository itself resolves only the authored skills
+        run: make skills-verify-source
+      - name: Package the pack for publication
+        run: |
+          set -euo pipefail
+          # Reproducible archive: sorted entries and a fixed timestamp, so an
+          # unchanged pack produces an unchanged tarball.
+          tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner \
+              -czf opik-skills-pack.tar.gz -C dist/opik-skills .
+          cp dist/opik-skills/index.json index.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: skills-pack
+          path: |
+            opik-skills-pack.tar.gz
+            index.json
+          retention-days: 7
+
+  # Publishes the pack the `skills-pack` job verified — the same bytes, downloaded
+  # rather than rebuilt, so what ships is what passed. `comet-ml/opik-skills` pulls
+  # from here on a schedule; this repo holds no credentials for it.
+  publish-skills-pack:
+    # `python-checks` is a dependency on purpose: it runs the spec-compliance suite
+    # and the builder's own tests. Without it a red test suite would still publish.
+    needs: [version, python-checks, skills-pack]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # maintain the rolling pre-release
+    env:
+      # Fixed tag: consumers fetch a stable URL. A moving tag would make every
+      # consumer track a name that changes, which is the problem this avoids.
+      PACK_TAG: skills-pack
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          name: skills-pack
+      - name: Publish the rolling pack pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.version.outputs.pyver }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Written via a here-document, not a multi-line shell string: YAML
+          # indentation inside quotes would ship as leading spaces and render
+          # every line after the first as an indented code block.
+          cat > notes.md <<EOF
+          Rolling build of the \`opik-skills\` pack, generated from \`src/opik_mcp/skills\`.
+
+          Source commit: \`${SHA}\`
+          Pack version: \`${VERSION}\`
+
+          Consumed by [comet-ml/opik-skills](https://github.com/comet-ml/opik-skills).
+          Do not edit that repository by hand — it is regenerated from this artifact.
+          EOF
+
+          if gh release view "$PACK_TAG" >/dev/null 2>&1; then
+            gh release edit "$PACK_TAG" --notes-file notes.md --prerelease
+          else
+            gh release create "$PACK_TAG" \
+              --title "Skills pack (rolling)" \
+              --notes-file notes.md \
+              --prerelease
+          fi
+
+          gh release upload "$PACK_TAG" opik-skills-pack.tar.gz index.json --clobber
+
+          DIGEST=$(python3 -c "import json;print(json.load(open('index.json'))['content_digest'])")
+          {
+            echo "### Skills pack published"
+            echo ""
+            echo "- Tag: \`$PACK_TAG\` (pre-release, rolling)"
+            echo "- Content digest: \`$DIGEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   helm-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,17 @@ logs/
 *.lcov
 coverage/
 
+# Locally-installed agent skills — never committed (OPIK-7621).
+#
+# `npx skills add` installs into these directories, and the skills CLI treats
+# them as priority search locations: a committed skill here would be resolved
+# *instead of* the ones under src/opik_mcp/skills. Since the product's onboarding
+# installs globally with `--all`, a stray commit would push an unrelated
+# third-party skill onto users' machines.
+.agents/skills/
+.claude/skills/
+skills-lock.json
+
 # Misc
 .tmp
 .temp

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 .PHONY: help version install run run-dev dev inspect test test-live conformance lint format typecheck check \
+        skills-pack skills-verify skills-verify-source \
         docker-build docker-run \
         legacy-install legacy-build legacy-test legacy-lint legacy-start
 
 VERSION_FILE := src/opik_mcp/_version.py
+
+# Pinned: this CLI is what ~40 agents use to install the pack, so a behaviour
+# change in it changes what our verification actually proves.
+SKILLS_CLI_VERSION := 1.5.22
 
 help:
 	@echo "Python (root):"
@@ -17,6 +22,11 @@ help:
 	@echo "  make format     - ruff format + ruff check --fix"
 	@echo "  make typecheck  - mypy"
 	@echo "  make check      - lint + typecheck + test"
+	@echo ""
+	@echo "Skills pack (published as comet-ml/opik-skills):"
+	@echo "  make skills-pack          - build the pack into dist/opik-skills"
+	@echo "  make skills-verify        - build it, then install it with the real npx installer"
+	@echo "  make skills-verify-source - check this repo itself resolves exactly the authored skills"
 	@echo ""
 	@echo "Docker:"
 	@echo "  make docker-build - build opik-mcp:dev image"
@@ -74,6 +84,62 @@ typecheck:
 	uv run mypy
 
 check: version lint typecheck test
+
+# --- Skills pack (OPIK-7621) -----------------------------------------------
+#
+# `opik-mcp` authors the skills; `comet-ml/opik-skills` is the generated pack
+# that `npx skills add comet-ml/opik-skills` resolves to. CI publishes the built
+# pack as an artifact and the public repo pulls it — nothing is hand-edited there.
+
+SKILLS_PACK_DIR := dist/opik-skills
+
+skills-pack:
+	uv run python scripts/build_skills_pack.py --out $(SKILLS_PACK_DIR) \
+	  $(if $(VERSION),--pack-version "$(VERSION)",) \
+	  $(if $(SOURCE_COMMIT),--source-commit "$(SOURCE_COMMIT)",)
+
+# Installs the built pack with the *exact* command the product's onboarding shows
+# (`-g --all`), into a throwaway HOME so a global install cannot touch the real
+# one, and diffs the whole installed tree against the pack. Building the pack and
+# the installer resolving it are different questions; only this answers the second.
+skills-verify: skills-pack
+	@set -euo pipefail; \
+	tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	if ! out=$$(HOME="$$tmp" npx -y skills@$(SKILLS_CLI_VERSION) \
+	      add "$(CURDIR)/$(SKILLS_PACK_DIR)" -g --all 2>&1); then \
+	  echo "::error::installer failed on the built pack"; echo "$$out"; exit 1; \
+	fi; \
+	( cd "$(SKILLS_PACK_DIR)/skills" && find . -type f | sort ) > "$$tmp/expected"; \
+	( cd "$$tmp/.agents/skills" 2>/dev/null && find . -type f | sort ) > "$$tmp/actual" \
+	  || : > "$$tmp/actual"; \
+	if ! diff -u "$$tmp/expected" "$$tmp/actual"; then \
+	  echo "::error::installed tree differs from the built pack"; exit 1; \
+	fi; \
+	echo "installer reproduced the pack exactly ($$(wc -l < "$$tmp/expected" | tr -d ' ') files)"
+
+# Ticket 02: installing straight from this repository must resolve exactly the
+# authored skills. It already worked, but only via the installer's last-resort
+# fallback — with a stray skills directory committed it resolved unrelated
+# third-party skills instead. `.claude-plugin/marketplace.json` makes it explicit;
+# this asserts it stays that way.
+skills-verify-source:
+	@set -euo pipefail; \
+	tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	if ! out=$$(HOME="$$tmp" npx -y skills@$(SKILLS_CLI_VERSION) \
+	      add "$(CURDIR)" -g --all 2>&1); then \
+	  echo "::error::installer failed against the repository"; echo "$$out"; exit 1; \
+	fi; \
+	resolved=$$(cd "$$tmp/.agents/skills" 2>/dev/null && ls -1 | sort | tr '\n' ' ' || true); \
+	authored=$$(cd src/opik_mcp/skills && \
+	  find . -mindepth 2 -maxdepth 2 -name SKILL.md -exec dirname {} \; \
+	  | sed 's|^\./||' | sort | tr '\n' ' '); \
+	if [ "$$resolved" != "$$authored" ]; then \
+	  echo "::error::installer resolved [$$resolved] but the authored skills are [$$authored]"; \
+	  exit 1; \
+	fi; \
+	echo "repository resolves exactly the authored skills: $$authored"
 
 # --- Docker image (deployable per OPIK-6667) -------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
         docker-build docker-run \
         legacy-install legacy-build legacy-test legacy-lint legacy-start
 
+# The skills recipes use `set -o pipefail`, which is a bash builtin. Make defaults
+# to /bin/sh, which is dash on Ubuntu runners (and bash on macOS) — so without this
+# those recipes pass locally and fail in CI with "Illegal option -o pipefail".
+SHELL := /bin/bash
+
 VERSION_FILE := src/opik_mcp/_version.py
 
 # Pinned: this CLI is what ~40 agents use to install the pack, so a behaviour

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ dev = [
     "pytest>=8",
     "respx>=0.21",
     "ruff>=0.7",
+    # Reference implementation of the agentskills.io spec. Used to validate the
+    # authored skills and to read their frontmatter when building the published
+    # pack, so our reading of a skill is identical to an agent's. Pinned to the
+    # 0.1.x line: a behaviour change there changes what CI accepts and what ships.
+    "skills-ref>=0.1.1,<0.2",
 ]
 
 [project.scripts]
@@ -67,8 +72,16 @@ python_version = "3.13"
 strict = true
 warn_unreachable = true
 warn_redundant_casts = true
-files = ["src", "tests"]
+# `scripts/` is otherwise unchecked, but the pack builder produces a public
+# artifact, so it is held to the same bar as the package.
+files = ["src", "tests", "scripts/build_skills_pack.py"]
 
 [[tool.mypy.overrides]]
 module = ["mcp.shared.memory"]
+ignore_missing_imports = true
+
+# The agentskills.io reference library ships no py.typed marker. It is a
+# dev-only dependency used to validate skills and read their frontmatter.
+[[tool.mypy.overrides]]
+module = ["skills_ref", "skills_ref.*"]
 ignore_missing_imports = true

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,6 @@
+"""Repository utility scripts.
+
+A package (rather than a loose directory) so `scripts.build_skills_pack` is an
+ordinary import for both mypy and the tests, instead of relying on namespace-package
+resolution and pytest's rootdir injection.
+"""

--- a/scripts/build_skills_pack.py
+++ b/scripts/build_skills_pack.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import shutil
 import sys
 from dataclasses import dataclass
@@ -60,6 +61,12 @@ UNKNOWN_COMMIT = "unknown"
 #: (OPIK-7800) that no agent reads; the product installs this pack globally with
 #: `--all`, so shipping them would push megabytes onto every user's machine.
 EXCLUDED_DIRS = frozenset({"evals", "__pycache__"})
+
+#: Relative paths to Markdown a SKILL.md tells the agent to read, in the two forms
+#: the skills use: a Markdown link, and a bare backticked path in prose. Both are
+#: instructions to open a file, so both have to resolve.
+_MARKDOWN_LINK = re.compile(r"\]\(\s*(?!<)([^)\s]+\.md)\s*\)")
+_BACKTICKED_PATH = re.compile(r"`([^`\s]+\.md)`")
 
 
 class PackBuildError(RuntimeError):
@@ -146,6 +153,40 @@ def _copy_skill(skill_dir: Path, target: Path) -> tuple[PackedFile, ...]:
     return tuple(entries)
 
 
+def _referenced_markdown(text: str) -> set[str]:
+    """Relative Markdown paths a SKILL.md instructs the agent to read."""
+    found = set(_MARKDOWN_LINK.findall(text)) | set(_BACKTICKED_PATH.findall(text))
+    return {
+        path
+        for path in found
+        # Absolute paths, URLs and anchors are not ours to resolve.
+        if "://" not in path and not path.startswith(("/", "#"))
+    }
+
+
+def _check_references_resolve(skills_root: Path) -> None:
+    """Every path a packed SKILL.md points at must exist inside the pack.
+
+    Skills reference each other — `/instrument` reads `../opik/references/*.md` —
+    so resolution is checked against the whole pack, not one skill directory.
+    That also means a typo in such a path used to fail *silently*: the agent
+    would find nothing, fall back to its own memory, and still report success.
+    Cheaper to fail the build.
+    """
+    dangling: list[str] = []
+    for skill_md in sorted(skills_root.glob("*/SKILL.md")):
+        skill_dir = skill_md.parent
+        for reference in sorted(_referenced_markdown(skill_md.read_text(encoding="utf-8"))):
+            target = (skill_dir / reference).resolve()
+            inside_pack = target.is_relative_to(skills_root.resolve())
+            if not inside_pack or not target.is_file():
+                reason = "escapes the pack" if not inside_pack else "does not exist"
+                dangling.append(f"{skill_dir.name}/SKILL.md -> {reference} ({reason})")
+
+    if dangling:
+        raise PackBuildError("unresolvable references in the pack: " + "; ".join(dangling))
+
+
 def _render_skills_table(skills: list[PackedSkill]) -> str:
     rows = [
         f"| [`{s.name}`](./skills/{s.name}/SKILL.md) | {s.description.strip()} |" for s in skills
@@ -227,6 +268,10 @@ def build_pack(
                 files=files,
             )
         )
+
+    # After every skill is in place: cross-skill references can only be checked
+    # once the whole pack exists.
+    _check_references_resolve(out_root / "skills")
 
     readme = _render_readme(skills)
     (out_root / "README.md").write_text(readme, encoding="utf-8")

--- a/scripts/build_skills_pack.py
+++ b/scripts/build_skills_pack.py
@@ -1,0 +1,282 @@
+"""Build the publishable `opik-skills` pack from the authored skills (OPIK-7621).
+
+`opik-mcp` is where the Opik agent skills are authored. `comet-ml/opik-skills` is the
+public pack that `npx skills add comet-ml/opik-skills` resolves to — a string hardcoded
+in Opik's onboarding UI, so it cannot move. This script is the bridge: it turns the
+authored skills into a standards-compliant pack that is published as an artifact and
+pulled by the public repository.
+
+Three properties matter, and the tests in `tests/test_skills_pack_build.py` pin them:
+
+*Verbatim.* Skill files are copied byte for byte. Frontmatter is made spec-compliant at
+the source (see `tests/test_skills_spec_compliance.py`), never rewritten here, so
+"published equals authored" is literally true and drift questions have a crisp answer.
+The offline export path (OPIK-7592) copies from the installed package and never runs
+this script, so normalising here would fix one distribution path and leave the other.
+
+*Deterministic.* The same input yields byte-identical output. The consumer compares
+`content_digest` to decide whether to raise a pull request, so nondeterminism would
+produce pull requests with empty diffs — and quickly teach everyone to ignore them.
+
+*Fail loudly.* An invalid or empty source aborts the build, and every emitted skill is
+re-validated after copying. The consumer replaces its skill tree with whatever it is
+handed, so a silently empty or malformed pack would break the public pack.
+
+Frontmatter is read through `skills_ref`, the reference implementation of the
+agentskills.io spec, rather than a parser of our own — so this script's reading of a
+skill is identical to the reading an agent's own tooling performs, with no second
+implementation to drift. One current skill declares its description as a folded scalar
+across six lines, exactly the construct hand-rolled parsers mishandle.
+
+Usage:
+    python scripts/build_skills_pack.py [--src DIR] [--out DIR]
+                                        [--pack-version V] [--source-commit SHA]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from skills_ref import SkillProperties, read_properties, validate
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SRC = REPO_ROOT / "src" / "opik_mcp" / "skills"
+DEFAULT_OUT = REPO_ROOT / "dist" / "opik-skills"
+README_TEMPLATE = Path(__file__).resolve().parent / "skills_pack_readme.md.tmpl"
+
+SOURCE_REPO = "comet-ml/opik-mcp"
+MANIFEST_SCHEMA_VERSION = 1
+UNVERSIONED = "0.0.0.dev0"
+UNKNOWN_COMMIT = "unknown"
+
+#: Directory names never published. `evals/` holds fixture repositories and harnesses
+#: (OPIK-7800) that no agent reads; the product installs this pack globally with
+#: `--all`, so shipping them would push megabytes onto every user's machine.
+EXCLUDED_DIRS = frozenset({"evals", "__pycache__"})
+
+
+class PackBuildError(RuntimeError):
+    """The source tree cannot produce a publishable pack."""
+
+
+@dataclass(frozen=True)
+class PackedFile:
+    path: str
+    sha256: str
+
+    def as_json(self) -> dict[str, str]:
+        return {"path": self.path, "sha256": self.sha256}
+
+
+@dataclass(frozen=True)
+class PackedSkill:
+    name: str
+    description: str
+    files: tuple[PackedFile, ...]
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "files": [f.as_json() for f in self.files],
+        }
+
+
+def _is_publishable(path: Path, skill_dir: Path) -> bool:
+    """Exclude by rule, not by allow-list.
+
+    An allow-list would silently drop an author's new `scripts/` or `assets/`
+    directory — both blessed by the spec — and they would never find out.
+    """
+    relative = path.relative_to(skill_dir)
+    return not any(part in EXCLUDED_DIRS or part.startswith(".") for part in relative.parts)
+
+
+def _discover_skills(src_root: Path) -> list[Path]:
+    """Every directory holding a SKILL.md, sorted for determinism.
+
+    A directory without a SKILL.md is not a skill — shared notes and scratch
+    directories must not become one by sitting in the right place.
+    """
+    if not src_root.is_dir():
+        raise PackBuildError(f"source directory does not exist: {src_root}")
+    return sorted(d for d in src_root.iterdir() if d.is_dir() and (d / "SKILL.md").is_file())
+
+
+def _read_valid_skill(skill_dir: Path) -> SkillProperties:
+    """Validate against the spec and confirm the declared name matches the directory."""
+    errors = validate(skill_dir)
+    if errors:
+        raise PackBuildError(f"{skill_dir.name} fails the agentskills.io spec: {errors}")
+
+    properties: SkillProperties = read_properties(skill_dir)
+    if properties.name != skill_dir.name:
+        # The installer keys on the directory name; a mismatch installs the skill
+        # under a name nothing references.
+        raise PackBuildError(
+            f"{skill_dir.name} declares name {properties.name!r}, which does not match "
+            "its directory"
+        )
+    return properties
+
+
+def _copy_skill(skill_dir: Path, target: Path) -> tuple[PackedFile, ...]:
+    """Copy one skill verbatim, returning its manifest file entries."""
+    entries: list[PackedFile] = []
+    for source in sorted(p for p in skill_dir.rglob("*") if p.is_file()):
+        if not _is_publishable(source, skill_dir):
+            continue
+        relative = source.relative_to(skill_dir)
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        payload = source.read_bytes()
+        destination.write_bytes(payload)
+        entries.append(
+            PackedFile(path=relative.as_posix(), sha256=hashlib.sha256(payload).hexdigest())
+        )
+    # SKILL.md first — it is the entry point, and Stripe's public manifest orders it so.
+    entries.sort(key=lambda e: (e.path != "SKILL.md", e.path))
+    return tuple(entries)
+
+
+def _render_skills_table(skills: list[PackedSkill]) -> str:
+    rows = [
+        f"| [`{s.name}`](./skills/{s.name}/SKILL.md) | {s.description.strip()} |" for s in skills
+    ]
+    return "\n".join(["| Skill | What it does |", "| --- | --- |", *rows])
+
+
+def _render_repository_tree(skills: list[PackedSkill]) -> str:
+    """Skills only, deliberately.
+
+    Listing every reference document would make the README churn on any rename,
+    which is noise in a diff a human is asked to review on each sync.
+    """
+    lines = ["opik-skills/", "├── skills/"]
+    for index, skill in enumerate(skills):
+        lines.append(f"│   {'└──' if index == len(skills) - 1 else '├──'} {skill.name}/")
+    lines += ["├── README.md", "├── index.json", "└── LICENSE"]
+    return "\n".join(lines)
+
+
+def _render_readme(skills: list[PackedSkill]) -> str:
+    template = README_TEMPLATE.read_text(encoding="utf-8")
+    return template.replace("{{SKILLS_TABLE}}", _render_skills_table(skills)).replace(
+        "{{REPOSITORY_TREE}}", _render_repository_tree(skills)
+    )
+
+
+def _content_digest(skills: list[PackedSkill], readme: str) -> str:
+    """A digest over what the consumer actually writes — skills and README.
+
+    Deliberately excludes `pack_version` and `source_commit`: every merge produces
+    new values for both, and folding them in would make each merge look like a
+    content change, so the sync would raise a pull request with an empty diff.
+    """
+    hasher = hashlib.sha256()
+    for skill in skills:
+        for entry in skill.files:
+            hasher.update(f"{skill.name}/{entry.path}\0{entry.sha256}\0".encode())
+    hasher.update(hashlib.sha256(readme.encode("utf-8")).hexdigest().encode())
+    return hasher.hexdigest()
+
+
+def build_pack(
+    src_root: Path,
+    out_root: Path,
+    *,
+    pack_version: str = UNVERSIONED,
+    source_commit: str = UNKNOWN_COMMIT,
+) -> dict[str, Any]:
+    """Build the pack at `out_root` from the skills in `src_root`; return the manifest.
+
+    `out_root` is replaced, not merged: a skill deleted upstream must disappear here,
+    or stale content would be published as though it were current.
+    """
+    skill_dirs = _discover_skills(src_root)
+    if not skill_dirs:
+        raise PackBuildError(f"no skills found under {src_root} — refusing to build an empty pack")
+
+    properties = {d: _read_valid_skill(d) for d in skill_dirs}
+
+    if out_root.exists():
+        shutil.rmtree(out_root)
+    (out_root / "skills").mkdir(parents=True)
+
+    skills: list[PackedSkill] = []
+    for skill_dir in skill_dirs:
+        target = out_root / "skills" / skill_dir.name
+        files = _copy_skill(skill_dir, target)
+        # Re-validate what was emitted, not only what was read: the exclusion rules
+        # run between the two, and dropping a file the skill depends on must not be
+        # something a user discovers instead of CI.
+        emitted_errors = validate(target)
+        if emitted_errors:
+            raise PackBuildError(f"packed {skill_dir.name} fails the spec: {emitted_errors}")
+        skills.append(
+            PackedSkill(
+                name=properties[skill_dir].name,
+                description=properties[skill_dir].description,
+                files=files,
+            )
+        )
+
+    readme = _render_readme(skills)
+    (out_root / "README.md").write_text(readme, encoding="utf-8")
+
+    manifest: dict[str, Any] = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "pack_version": pack_version,
+        "source": SOURCE_REPO,
+        "source_commit": source_commit,
+        "content_digest": _content_digest(skills, readme),
+        "skills": [s.as_json() for s in skills],
+    }
+    (out_root / "index.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build the publishable opik-skills pack.")
+    parser.add_argument("--src", type=Path, default=DEFAULT_SRC)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument(
+        "--pack-version",
+        default=UNVERSIONED,
+        help="informational only; excluded from content_digest",
+    )
+    parser.add_argument(
+        "--source-commit",
+        default=UNKNOWN_COMMIT,
+        help="revision this pack was built from; excluded from content_digest",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = build_pack(
+            args.src,
+            args.out,
+            pack_version=args.pack_version,
+            source_commit=args.source_commit,
+        )
+    except PackBuildError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    names = ", ".join(s["name"] for s in manifest["skills"])
+    print(f"built {len(manifest['skills'])} skills ({names}) -> {args.out}")
+    print(f"content_digest: {manifest['content_digest']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/skills_pack_readme.md.tmpl
+++ b/scripts/skills_pack_readme.md.tmpl
@@ -1,0 +1,89 @@
+<h1 align="center" style="border-bottom: none">
+  <div>
+    <a href="https://www.comet.com/site/products/opik/?from=llm&utm_source=opik&utm_medium=github&utm_content=header_img&utm_campaign=opik">
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/comet-ml/opik/refs/heads/main/apps/opik-documentation/documentation/static/img/logo-dark-mode.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/comet-ml/opik/refs/heads/main/apps/opik-documentation/documentation/static/img/opik-logo.svg">
+        <img alt="Comet Opik logo" src="https://raw.githubusercontent.com/comet-ml/opik/refs/heads/main/apps/opik-documentation/documentation/static/img/opik-logo.svg" width="200" />
+      </picture>
+    </a>
+    <br />
+    Opik Skills
+  </div>
+</h1>
+
+<p align="center">
+  Official Opik skill pack for coding agents. Install it with one command to give your agent<br/>
+  practical guidance for tracing, evaluating, configuring, and debugging LLM applications with
+  <a href="https://github.com/comet-ml/opik">Opik</a>.
+</p>
+
+<div align="center">
+
+[![License](https://img.shields.io/github/license/comet-ml/opik-skills)](./LICENSE)
+
+</div>
+
+> **This repository is generated.** The skills are authored in
+> [comet-ml/opik-mcp](https://github.com/comet-ml/opik-mcp) under `src/opik_mcp/skills/`
+> and published here automatically. Edits made here are overwritten by the next sync —
+> please open your pull request against `opik-mcp` instead.
+
+[Opik](https://github.com/comet-ml/opik) is the open-source LLM observability and evaluation platform, built by [Comet](https://www.comet.com). These agent skills teach coding agents to instrument applications with Opik.
+
+## Install
+
+```bash
+npx skills add comet-ml/opik-skills -g --all
+```
+
+This works across ~40 coding agents, including Claude Code, Cursor, Codex, and GitHub Copilot.
+
+## Skills in this pack
+
+{{SKILLS_TABLE}}
+
+## One-time Opik setup
+
+Before using them, authenticate Opik once in the environment where your agent will work:
+
+- Python: run `opik configure`
+- TypeScript: run `npx opik-ts configure`
+
+Those commands save your Opik configuration locally, including the API key and connection details the agent will use while wiring up instrumentation.
+
+For setup details, see the [Opik documentation](https://www.comet.com/docs/opik/).
+
+## Example prompts
+
+Once installed, you can ask your agent things like:
+
+- "Add Opik tracing to this FastAPI app."
+- "Instrument this TypeScript OpenAI app with Opik."
+- "Help me connect this local agent to Opik with `opik connect`."
+- "Create a Test Suite for this chatbot."
+- "Add `thread_id` support so Opik groups each conversation correctly."
+
+## Repository structure
+
+```text
+{{REPOSITORY_TREE}}
+```
+
+## Opik for Claude Code
+
+This repo is part of a set of tools for observing Claude Code and other coding agents with [Opik](https://github.com/comet-ml/opik):
+
+- [opik-claude-code-plugin](https://github.com/comet-ml/opik-claude-code-plugin): log Claude Code sessions as Opik traces, with skills and agents included
+- [ccsync](https://github.com/comet-ml/ccsync): export Claude Code conversation history to Opik
+- [cost-intelligence-proxy](https://github.com/comet-ml/cost-intelligence-proxy): meter Claude Code token spend and cost per call
+- [opik-skills](https://github.com/comet-ml/opik-skills): agent skills for instrumenting your code with Opik **(this repo)**
+
+## Learn more
+
+- [Opik repository](https://github.com/comet-ml/opik)
+- [Opik documentation](https://www.comet.com/docs/opik/)
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/src/opik_mcp/skills/evaluate/SKILL.md
+++ b/src/opik_mcp/skills/evaluate/SKILL.md
@@ -6,8 +6,9 @@ description: >
   error analysis, and validating evaluators against human labels. Use when the
   user wants to measure or improve AI product quality, or asks about evals,
   judges, or evaluation metrics.
-last_updated: "2026-07-30"
-source_commit: "2.0.0"
+metadata:
+  last_updated: "2026-07-30"
+  source_commit: "2.0.0"
 ---
 
 # LLM Evaluation

--- a/src/opik_mcp/skills/opik/SKILL.md
+++ b/src/opik_mcp/skills/opik/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: opik
 description: Reference for the Opik SDK — tracing, span types, framework integrations, threads, and the prompt library (Python, TypeScript, REST). Use for "what span types exist", "how do I flush", "track_openai", "add OpikTracer", "version a prompt". To instrument a repo end to end, use the `instrument` skill.
-last_updated: "2026-07-27"
-source_commit: "TODO — pin to the Opik release this was verified against (OPIK-7471)"
+metadata:
+  last_updated: "2026-07-27"
+  source_commit: "TODO — pin to the Opik release this was verified against (OPIK-7471)"
 ---
 
 # Opik SDK Reference

--- a/tests/test_skills_pack_build.py
+++ b/tests/test_skills_pack_build.py
@@ -14,6 +14,7 @@ the builder.
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 
 import pytest
@@ -285,6 +286,54 @@ def test_every_emitted_skill_is_validated_not_only_the_source(src: Path, out: Pa
 
     for skill in ("opik", "evaluate"):
         assert validate(out / "skills" / skill) == []
+
+
+def test_cross_skill_references_are_allowed_when_they_resolve(src: Path, out: Path) -> None:
+    """`/instrument` reads `../opik/references/*.md`; siblings in the pack make that work.
+
+    Verified against the real installer too: with `-g --all`, the command the product
+    shows, the skills land as siblings and these paths resolve.
+    """
+    (src / "opik" / "references" / "integrations.md").write_text("# Integrations\n")
+    _write_skill(src, "instrument")
+    (src / "instrument" / "SKILL.md").write_text(
+        SKILL_MD.format(name="instrument", description="Adds tracing. Use to instrument.")
+        + "\nRead `../opik/references/integrations.md` for the full list.\n",
+        encoding="utf-8",
+    )
+    build_pack(src, out)
+    assert (out / "skills" / "instrument" / "SKILL.md").is_file()
+
+
+def test_a_dangling_reference_fails_the_build(src: Path, out: Path) -> None:
+    """A typo used to fail silently: the agent finds nothing, falls back to its own
+    memory, and still reports success. Failing the build is cheaper."""
+    (src / "opik" / "SKILL.md").write_text(
+        SKILL_MD.format(name="opik", description="Reference. Use for SDK questions.")
+        + "\nSee `references/tracing-pythn.md` for details.\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(PackBuildError, match=re.escape("tracing-pythn.md")):
+        build_pack(src, out)
+
+
+def test_a_reference_escaping_the_pack_fails_the_build(src: Path, out: Path) -> None:
+    (src / "opik" / "SKILL.md").write_text(
+        SKILL_MD.format(name="opik", description="Reference. Use for SDK questions.")
+        + "\nSee [notes](../../../secrets.md).\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(PackBuildError, match="escapes the pack"):
+        build_pack(src, out)
+
+
+def test_urls_and_anchors_are_not_treated_as_paths(src: Path, out: Path) -> None:
+    (src / "opik" / "SKILL.md").write_text(
+        SKILL_MD.format(name="opik", description="Reference. Use for SDK questions.")
+        + "\nSee [docs](https://www.comet.com/docs/opik/x.md) and [above](#core-concepts).\n",
+        encoding="utf-8",
+    )
+    build_pack(src, out)  # must not raise
 
 
 def test_identical_input_produces_identical_output(src: Path, tmp_path: Path) -> None:

--- a/tests/test_skills_pack_build.py
+++ b/tests/test_skills_pack_build.py
@@ -1,0 +1,311 @@
+"""Building the publishable skills pack (OPIK-7621).
+
+The pack is what `npx skills add comet-ml/opik-skills` resolves to, and the product's
+onboarding installs it globally with `--all`. So the contract under test is "what
+lands on a user's disk", and every assertion here is about the emitted directory —
+never about how the builder gets there.
+
+Tests run against fixture trees, never against `src/opik_mcp/skills`. Four more
+skills already have open scaffolding PRs (OPIK-7648/7649/7650/7651); a suite pinned
+to today's set would fail on each arrival, and would stop telling us anything about
+the builder.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from scripts.build_skills_pack import PackBuildError, build_pack
+
+SKILL_MD = """\
+---
+name: {name}
+description: {description}
+metadata:
+  last_updated: "2026-08-01"
+---
+
+# {name}
+
+Body of {name}.
+"""
+
+
+def _write_skill(
+    root: Path,
+    name: str,
+    *,
+    description: str = "Does a thing. Use when the user asks for the thing.",
+    references: dict[str, str] | None = None,
+    extra: dict[str, str] | None = None,
+) -> Path:
+    """Create one skill directory. `extra` takes paths relative to the skill root."""
+    skill_dir = root / name
+    (skill_dir / "references").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        SKILL_MD.format(name=name, description=description), encoding="utf-8"
+    )
+    for filename, body in (references or {}).items():
+        (skill_dir / "references" / filename).write_text(body, encoding="utf-8")
+    for relpath, body in (extra or {}).items():
+        target = skill_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+    return skill_dir
+
+
+def _files_under(root: Path) -> set[Path]:
+    return {p.relative_to(root) for p in root.rglob("*") if p.is_file()}
+
+
+@pytest.fixture
+def src(tmp_path: Path) -> Path:
+    root = tmp_path / "skills"
+    root.mkdir()
+    _write_skill(root, "opik", references={"tracing.md": "# Tracing\n"})
+    _write_skill(root, "evaluate", description="Runs evals. Use for measuring quality.")
+    return root
+
+
+@pytest.fixture
+def out(tmp_path: Path) -> Path:
+    return tmp_path / "pack"
+
+
+def test_every_skill_reaches_the_pack(src: Path, out: Path) -> None:
+    build_pack(src, out)
+    assert (out / "skills" / "opik" / "SKILL.md").is_file()
+    assert (out / "skills" / "evaluate" / "SKILL.md").is_file()
+
+
+def test_reference_documents_travel_with_their_skill(src: Path, out: Path) -> None:
+    build_pack(src, out)
+    assert (out / "skills" / "opik" / "references" / "tracing.md").read_text() == "# Tracing\n"
+
+
+def test_skill_files_are_byte_identical_to_source(src: Path, out: Path) -> None:
+    """Verbatim copying is what makes divergence questions answerable.
+
+    There is no normalisation step downstream, so if the published bytes could
+    differ from the authored bytes, "did this drift?" would have no crisp answer.
+    """
+    build_pack(src, out)
+    for authored in sorted(src.rglob("*.md")):
+        published = out / "skills" / authored.relative_to(src)
+        assert published.read_bytes() == authored.read_bytes(), authored
+
+
+def test_optional_spec_directories_are_published(src: Path, out: Path) -> None:
+    """`scripts/` and `assets/` are blessed by the spec; authors may add them."""
+    _write_skill(
+        src,
+        "instrument",
+        extra={"scripts/detect.py": "print('hi')\n", "assets/template.txt": "x\n"},
+    )
+    build_pack(src, out)
+    assert (out / "skills" / "instrument" / "scripts" / "detect.py").is_file()
+    assert (out / "skills" / "instrument" / "assets" / "template.txt").is_file()
+
+
+def test_evaluation_fixtures_do_not_ship(src: Path, out: Path) -> None:
+    """Fixtures are development artifacts and the pack installs globally.
+
+    OPIK-7800 builds fixture repositories under `evals/`; shipping them would
+    push megabytes no agent reads onto every user's machine.
+    """
+    _write_skill(src, "instrument", extra={"evals/fixtures/app/main.py": "x = 1\n"})
+    build_pack(src, out)
+    assert (out / "skills" / "instrument" / "SKILL.md").is_file()
+    assert not (out / "skills" / "instrument" / "evals").exists()
+
+
+def test_dotfiles_do_not_ship(src: Path, out: Path) -> None:
+    _write_skill(src, "instrument", extra={".DS_Store": "junk\n", ".notes/scratch.md": "x\n"})
+    build_pack(src, out)
+    assert not (out / "skills" / "instrument" / ".DS_Store").exists()
+    assert not (out / "skills" / "instrument" / ".notes").exists()
+
+
+def test_a_directory_without_a_skill_md_is_not_a_skill(src: Path, out: Path) -> None:
+    (src / "shared-notes").mkdir()
+    (src / "shared-notes" / "draft.md").write_text("wip\n", encoding="utf-8")
+    manifest = build_pack(src, out)
+    assert [s["name"] for s in manifest["skills"]] == ["evaluate", "opik"]
+    assert not (out / "skills" / "shared-notes").exists()
+
+
+def test_manifest_lists_every_skill_with_its_description(src: Path, out: Path) -> None:
+    manifest = build_pack(src, out)
+    by_name = {s["name"]: s for s in manifest["skills"]}
+    assert set(by_name) == {"opik", "evaluate"}
+    assert by_name["evaluate"]["description"].startswith("Runs evals.")
+
+
+def test_manifest_lists_the_files_that_were_emitted(src: Path, out: Path) -> None:
+    manifest = build_pack(src, out)
+    opik = next(s for s in manifest["skills"] if s["name"] == "opik")
+    assert [f["path"] for f in opik["files"]] == ["SKILL.md", "references/tracing.md"]
+
+
+def test_manifest_checksums_match_the_emitted_bytes(src: Path, out: Path) -> None:
+    manifest = build_pack(src, out)
+    for skill in manifest["skills"]:
+        for entry in skill["files"]:
+            published = out / "skills" / skill["name"] / entry["path"]
+            digest = hashlib.sha256(published.read_bytes()).hexdigest()
+            assert entry["sha256"] == digest, f"{skill['name']}/{entry['path']}"
+
+
+def test_manifest_records_the_revision_it_was_built_from(src: Path, out: Path) -> None:
+    """A user's installed pack must be traceable to a commit."""
+    manifest = build_pack(src, out, pack_version="1.2.3", source_commit="abc1234")
+    assert manifest["source_commit"] == "abc1234"
+    assert manifest["pack_version"] == "1.2.3"
+    assert manifest["schema_version"] == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "values"),
+    [("pack_version", ("1.2.3", "9.9.9")), ("source_commit", ("aaaaaaa", "bbbbbbb"))],
+)
+def test_content_digest_ignores_build_identity(
+    src: Path, out: Path, field: str, values: tuple[str, str]
+) -> None:
+    """The consumer compares this digest to decide whether to raise a PR.
+
+    Folding either value into it would make every merge look like a content
+    change, so the sync would open a pull request with an empty diff.
+    """
+    first = build_pack(src, out, **{field: values[0]})
+    second = build_pack(src, out, **{field: values[1]})
+    assert first["content_digest"] == second["content_digest"]
+    assert first[field] != second[field]
+
+
+def test_content_digest_changes_when_a_skill_changes(src: Path, out: Path) -> None:
+    before = build_pack(src, out)["content_digest"]
+    (src / "opik" / "references" / "tracing.md").write_text("# Tracing v2\n", encoding="utf-8")
+    assert build_pack(src, out)["content_digest"] != before
+
+
+def test_readme_lists_every_skill_with_its_description(src: Path, out: Path) -> None:
+    build_pack(src, out)
+    readme = (out / "README.md").read_text(encoding="utf-8")
+    assert "`opik`" in readme
+    assert "`evaluate`" in readme
+    assert "Runs evals." in readme
+
+
+def test_readme_carries_the_install_command_the_product_shows(src: Path, out: Path) -> None:
+    """The product UI hardcodes this exact string; the README must not contradict it."""
+    build_pack(src, out)
+    readme = (out / "README.md").read_text(encoding="utf-8")
+    assert "npx skills add comet-ml/opik-skills -g --all" in readme
+
+
+def test_readme_warns_that_the_content_is_generated(src: Path, out: Path) -> None:
+    build_pack(src, out)
+    readme = (out / "README.md").read_text(encoding="utf-8")
+    assert "generated" in readme.lower()
+    assert "comet-ml/opik-mcp" in readme
+
+
+def test_readme_does_not_carry_retired_material(src: Path, out: Path) -> None:
+    """`AgentConfig` was retired in May; the hand-written README still sells it."""
+    build_pack(src, out)
+    assert "AgentConfig" not in (out / "README.md").read_text(encoding="utf-8")
+
+
+def test_readme_tree_does_not_churn_on_reference_renames(src: Path, out: Path) -> None:
+    """A rename must not produce README noise in the diff a human reviews each sync."""
+    build_pack(src, out)
+    before = (out / "README.md").read_text(encoding="utf-8")
+    (src / "opik" / "references" / "tracing.md").rename(src / "opik" / "references" / "trace.md")
+    build_pack(src, out)
+    assert (out / "README.md").read_text(encoding="utf-8") == before
+
+
+def test_adding_a_skill_changes_the_readme_and_manifest_and_nothing_else(
+    src: Path, out: Path
+) -> None:
+    build_pack(src, out)
+    generated = {"README.md", "index.json"}
+    before = {
+        p.relative_to(out): p.read_bytes()
+        for p in sorted(out.rglob("*"))
+        if p.is_file() and p.name not in generated
+    }
+
+    _write_skill(src, "instrument", description="Adds tracing. Use to instrument an app.")
+    build_pack(src, out)
+
+    after = {
+        p.relative_to(out): p.read_bytes()
+        for p in sorted(out.rglob("*"))
+        if p.is_file() and p.name not in generated
+    }
+    added = set(after) - set(before)
+    assert all(str(p).startswith("skills/instrument/") for p in added), added
+    assert {p: b for p, b in after.items() if p in before} == before
+    assert "instrument" in (out / "README.md").read_text(encoding="utf-8")
+
+
+def test_invalid_frontmatter_fails_the_build(src: Path, out: Path) -> None:
+    """A malformed pack must never be produced; the build stops instead."""
+    (src / "opik" / "SKILL.md").write_text(
+        "---\nname: opik\ndescription: x\nbogus: y\n---\n\nbody\n", encoding="utf-8"
+    )
+    with pytest.raises(PackBuildError, match="opik"):
+        build_pack(src, out)
+
+
+def test_name_not_matching_the_directory_fails_the_build(src: Path, out: Path) -> None:
+    """The installer keys on the directory name; a mismatch misroutes the skill."""
+    (src / "opik" / "SKILL.md").write_text(
+        "---\nname: something-else\ndescription: x\n---\n\nbody\n", encoding="utf-8"
+    )
+    with pytest.raises(PackBuildError, match="opik"):
+        build_pack(src, out)
+
+
+def test_a_source_without_skills_fails_the_build(tmp_path: Path, out: Path) -> None:
+    """An empty pack, published, would delete every skill from the public repo."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(PackBuildError, match="no skills"):
+        build_pack(empty, out)
+
+
+def test_every_emitted_skill_is_validated_not_only_the_source(src: Path, out: Path) -> None:
+    """Exclusion runs between reading and emitting, so the output is checked too."""
+    build_pack(src, out)
+    from skills_ref import validate  # local import: only this test needs it
+
+    for skill in ("opik", "evaluate"):
+        assert validate(out / "skills" / skill) == []
+
+
+def test_identical_input_produces_identical_output(src: Path, tmp_path: Path) -> None:
+    first, second = tmp_path / "a", tmp_path / "b"
+    build_pack(src, first)
+    build_pack(src, second)
+    assert _files_under(first) == _files_under(second)
+    for rel in sorted(_files_under(first)):
+        assert (first / rel).read_bytes() == (second / rel).read_bytes(), rel
+
+
+def test_rebuilding_over_a_previous_pack_drops_removed_skills(src: Path, out: Path) -> None:
+    """Stale output would be published as if it were current."""
+    _write_skill(src, "doomed")
+    build_pack(src, out)
+    assert (out / "skills" / "doomed").exists()
+
+    shutil_rmtree_equivalent = sorted((src / "doomed").rglob("*"), reverse=True)
+    for path in shutil_rmtree_equivalent:
+        path.unlink() if path.is_file() else path.rmdir()
+    (src / "doomed").rmdir()
+
+    build_pack(src, out)
+    assert not (out / "skills" / "doomed").exists()

--- a/tests/test_skills_spec_compliance.py
+++ b/tests/test_skills_spec_compliance.py
@@ -1,0 +1,73 @@
+"""Every authored skill must satisfy the agentskills.io specification (OPIK-7621).
+
+The skills are published as a public `npx skills add` pack and are read directly by
+~40 coding agents. A skill whose frontmatter the standard rejects is not a style
+nit: agents that use the reference parser drop the offending keys silently, so
+provenance vanishes without an error anywhere.
+
+Validation runs against `skills_ref` — the reference implementation of the spec —
+rather than a hand-rolled check, so "valid" here means exactly what an agent's own
+tooling means by it, with no second opinion to drift.
+
+The pack generator copies skill files verbatim, so this suite is what keeps the
+published pack compliant: there is no normalisation step downstream to fall back on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from skills_ref import read_properties, validate
+
+SKILLS_ROOT = Path(__file__).resolve().parent.parent / "src" / "opik_mcp" / "skills"
+
+
+def _skill_dirs() -> list[Path]:
+    """Every authored skill, discovered from the tree rather than hardcoded.
+
+    Four more skills have open scaffolding PRs (OPIK-7648/7649/7650/7651); a
+    hardcoded list would make each of them fail this suite on arrival.
+    """
+    return sorted(d for d in SKILLS_ROOT.iterdir() if d.is_dir() and (d / "SKILL.md").is_file())
+
+
+def _ids(dirs: list[Path]) -> list[str]:
+    return [d.name for d in dirs]
+
+
+def test_at_least_one_skill_is_discovered() -> None:
+    """Guard the parametrisation itself.
+
+    Every test below is parametrised over discovered directories, so a bad root
+    path would silently collect zero cases and the suite would pass while
+    checking nothing.
+    """
+    assert _skill_dirs(), f"no skills discovered under {SKILLS_ROOT}"
+
+
+@pytest.mark.parametrize("skill_dir", _skill_dirs(), ids=_ids(_skill_dirs()))
+def test_skill_satisfies_the_reference_validator(skill_dir: Path) -> None:
+    errors = validate(skill_dir)
+    assert not errors, f"{skill_dir.name} fails the agentskills.io spec: {errors}"
+
+
+@pytest.mark.parametrize("skill_dir", _skill_dirs(), ids=_ids(_skill_dirs()))
+def test_skill_name_matches_its_directory(skill_dir: Path) -> None:
+    """The spec requires it, and the installer keys on the directory name."""
+    assert read_properties(skill_dir).name == skill_dir.name
+
+
+@pytest.mark.parametrize("skill_dir", _skill_dirs(), ids=_ids(_skill_dirs()))
+def test_provenance_survives_the_reference_reader(skill_dir: Path) -> None:
+    """Provenance must live under `metadata`, where the spec can carry it.
+
+    Declared as top-level keys it parses "fine" and is then discarded by every
+    spec-compliant reader — the failure mode this asserts against. `source_commit`
+    stays unresolved until OPIK-7800 stamps a verified release; that it is a
+    placeholder is fine, that it is *reachable* is what matters here.
+    """
+    # `metadata` is None, not {}, when the mapping is absent entirely.
+    metadata = read_properties(skill_dir).metadata or {}
+    assert "last_updated" in metadata, f"{skill_dir.name} loses last_updated to the reader"
+    assert "source_commit" in metadata, f"{skill_dir.name} loses source_commit to the reader"

--- a/uv.lock
+++ b/uv.lock
@@ -480,6 +480,7 @@ dev = [
     { name = "pytest" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "skills-ref" },
 ]
 
 [package.metadata]
@@ -496,6 +497,7 @@ requires-dist = [
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "sentry-sdk", specifier = ">=2,<3" },
+    { name = "skills-ref", marker = "extra == 'dev'", specifier = ">=0.1.1,<0.2" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
 provides-extras = ["dev"]
@@ -658,6 +660,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -843,6 +857,28 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "skills-ref"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "strictyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/42/943d3ba8b097af7068b7178563a5062ad8a977982f4a7b4f67facfc575e9/skills_ref-0.1.1.tar.gz", hash = "sha256:6b400ca6e0049be62dca0167ff943ba2745fd67efb37fbba4d0ee341fccd2695", size = 93519, upload-time = "2026-01-10T13:23:41.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/25/36a43c3a61fb6cc3984e6ad5e556929b8ae71c95eba615dae4cf2f427964/skills_ref-0.1.1-py3-none-any.whl", hash = "sha256:d35db5bb8de71ae301daf5ca9cb71f8a555e8c6f83a6d40e46a5bc09f8f461b5", size = 12918, upload-time = "2026-01-10T13:23:40.106Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -874,6 +910,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Opik's onboarding tells every new user to run `npx skills add comet-ml/opik-skills -g --all`. The skills in that pack were last changed on **2026-05-27** — so users get content two and a half months behind this repo, missing five reference documents and the `evaluate` skill entirely.

This makes the pack a build artifact of this repo, instead of a second place skills get edited.

## What to look at

**`scripts/build_skills_pack.py`** — reads `src/opik_mcp/skills/`, copies each skill verbatim, renders the README from a template, emits `index.json`. It fails the build rather than publishing something questionable: invalid frontmatter, a name that doesn't match its directory, a reference that doesn't resolve, or an empty source tree.

**Frontmatter moves under `metadata:`** — `last_updated` and `source_commit` aren't spec fields, and the reference validator rejects both skills as they stand. Spec-compliant readers drop unknown keys silently, so that provenance was invisible to consumers. Values are unchanged, and the `source_commit` placeholder stays a placeholder (gated on OPIK-7800).

**Two CI jobs** — `skills-pack` builds the pack, installs it with the same `-g --all` the product uses, and diffs the installed tree against the pack. `publish-skills-pack` uploads those exact bytes as a rolling prerelease, on `main` only.

**`.claude-plugin/marketplace.json`** — installing from this repo already worked, but only through the installer's fallback, which breaks if an agent skills directory is ever committed: the installer then resolves unrelated third-party skills instead. Resolution is now explicit and those directories are ignored. Not advertised — the supported path stays the published pack.

## Two decisions worth a second look

`content_digest` deliberately excludes `pack_version` and `source_commit`. The consumer compares it to decide whether to raise a sync pull request; folding build identity in would open an empty-diff pull request on every merge.

Skills are copied byte for byte, with no normalisation. OPIK-7592 exports skills straight from the installed wheel and never runs this script, so normalising here would fix one distribution path and leave the other non-compliant.

## Not in this PR

Sync and guard workflows belong to comet-ml/opik-skills#18. The first cutover waits on #156, which restores `/instrument` — syncing before it merges would delete that skill from the public pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)