### PR TITLE
docs(README) - Update telemetry section for Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,17 +354,17 @@ Keep the default `127.0.0.1` bind (and prefer stdio) on shared networks.
 
 Anonymous usage events (event type + timing only — no query content). A SHA-256
 digest of your API key is included so support can find your account; the raw
-key never leaves the process. **Opt out:** `OPIK_MCP_ANALYTICS_ENABLED=false`.
+key never leaves the process. **Opt out:** `OPIK_MCP_ANALYTICS_ENABLED=false` + `OPIK_MCP_SENTRY_ENABLED=false`.
 
 | Variable | Default | Notes |
 |---|---|---|
-| `OPIK_MCP_ANALYTICS_ENABLED` | `true` | Set to `false` to disable all telemetry. |
+| `OPIK_MCP_ANALYTICS_ENABLED` | `true` | Set to `false` to disable all non-Sentry telemetry. |
 | `OPIK_MCP_ANALYTICS_URL` | `https://stats.comet.com/notify/event/` | Override for staging. |
 | `OPIK_MCP_ANALYTICS_ENVIRONMENT` | `prod` | Tag on every event (`prod` / `staging` / `dev`). |
 | `OPIK_MCP_ANALYTICS_SOURCE` | `comet.com` | Receiver uses this to mark `on_prem=False`. On-prem installs should override to `""` or their own domain. |
 | `OPIK_MCP_ANALYTICS_CONNECT_TIMEOUT_S` | `5.0` | HTTP connect timeout. |
 | `OPIK_MCP_ANALYTICS_TOTAL_TIMEOUT_S` | `10.0` | HTTP total request timeout. |
-
+| `OPIK_MCP_SENTRY_ENABLED` | `true` | Set to `false` to disable all Sentry telemetry. |
 ---
 
 ## Known host limits


### PR DESCRIPTION
README currently lists OPIK_MCP_ANALYTICS_ENABLED as a full opt-out from telemetry, but Sentry needs to be disabled by a second undocumented OPIK_MCP_SENTRY_ENABLED flag. This adds OPIK_MCP_SENTRY_ENABLED to the TELEMETRY section of the README.