### PR TITLE
[OPIK-7615] Add host attribution fields without touching existing BI events

### DIFF
--- a/src/opik_mcp/account_identity.py
+++ b/src/opik_mcp/account_identity.py
@@ -85,6 +85,16 @@ _ATTEMPT_LOCK = threading.Lock()
 _DISK_CACHE: dict[str, Any] | None = None
 _DISK_LOCK = threading.Lock()
 
+# Live refresh threads, so ``reset_account_identity_for_tests`` can WAIT for
+# them instead of just clearing state underneath them. A refresh ends by
+# assigning ``_DISK_CACHE`` (see ``_write_cache``), so one that outlives the
+# test that started it resurrects that test's cache after the reset cleared it
+# — and the next test then reads the previous test's identity out of a HOME it
+# never wrote. Pruned on insert so a long-lived process cannot accumulate
+# finished threads; ``_INFLIGHT`` already caps this at one entry per credential.
+_REFRESH_THREADS: list[threading.Thread] = []
+_THREADS_LOCK = threading.Lock()
+
 
 def _cache_path() -> Path:
     return Path.home() / ".opik-mcp" / "identity-cache.json"
@@ -266,17 +276,34 @@ def _maybe_refresh(settings: Settings, api_key: str, digest: str, now: float) ->
         if digest in _INFLIGHT:
             return
         _INFLIGHT.add(digest)
-    threading.Thread(
+    thread = threading.Thread(
         target=_refresh,
         args=(url, api_key, digest),
         name="opik-mcp-identity",
         daemon=True,
-    ).start()
+    )
+    with _THREADS_LOCK:
+        _REFRESH_THREADS[:] = [t for t in _REFRESH_THREADS if t.is_alive()]
+        _REFRESH_THREADS.append(thread)
+    thread.start()
 
 
 def reset_account_identity_for_tests() -> None:
-    """Drop all bookkeeping and the cached disk read. Test-only."""
+    """Drop all bookkeeping and the cached disk read. Test-only.
+
+    Waits for in-flight refreshes FIRST. Clearing state while a daemon thread is
+    still running does not isolate the next test: that thread finishes by
+    assigning ``_DISK_CACHE`` and calling ``remember_identity``, both of which
+    land after the reset and carry one test's HOME into the next one.
+    """
     global _DISK_CACHE
+    # Outside every lock below — ``_refresh`` takes ``_INFLIGHT_LOCK`` on its way
+    # out, so joining while holding it would deadlock.
+    with _THREADS_LOCK:
+        pending = list(_REFRESH_THREADS)
+        _REFRESH_THREADS.clear()
+    for thread in pending:
+        thread.join(timeout=_TIMEOUT_SECONDS + 1.0)
     with _INFLIGHT_LOCK:
         _INFLIGHT.clear()
     with _ATTEMPT_LOCK:

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import httpx
 
+from opik_mcp.analytics.environment import env_id
 from opik_mcp.analytics.events import Attributed, UserIdKind, WorkspaceKind
 from opik_mcp.analytics.identity import (
     OPIK_MCP_VERSION,
@@ -259,6 +260,20 @@ class AnalyticsClient:
         # stamped on every event so BI can split cloud / self-hosted without
         # joining back to server_started.
         common["installation_type"] = self._installation_type
+        # Machine identity derived from the OS machine id, NOT from a file we
+        # wrote. install_id is a UUID under HOME: a reinstall mints a new one
+        # (inflating "new installs") and an unwritable HOME collapses it to the
+        # nil sentinel, merging every such deployment into one row. This survives
+        # both. It is also the only identity available to local / self-hosted
+        # users, who run with auth disabled and so can never resolve a username.
+        #
+        # ALWAYS stamps the kind so "we could not read one" is countable rather
+        # than a silent absence; the digest itself is omitted when there is none,
+        # because a placeholder would be counted as a real machine.
+        env_digest, env_kind = env_id()
+        common["env_id_kind"] = env_kind
+        if env_digest:
+            common["env_id_sha256"] = env_digest
 
         per_request = self._per_request_props()
         # Merge precedence (lowest → highest): per-request contextvar enrichment,

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -26,6 +26,7 @@ from opik_mcp.analytics.identity import (
 from opik_mcp.auth_context import (
     classify_bearer,
     inbound_authorization,
+    inbound_mcp_session_id,
     inbound_workspace,
     settings_auth_mode,
 )
@@ -375,6 +376,28 @@ class AnalyticsClient:
             workspace = ws_header.strip() if ws_header else ""
             if workspace:
                 props["request_workspace"] = workspace
+
+            # The stable unit the hosted funnel needs. A client keeps its
+            # ``Mcp-Session-Id`` across OAuth token refreshes, so an 8-hour
+            # session is ONE session here — where ``token_sha256`` would be ~8
+            # separate identities, because the access token lives one hour.
+            #
+            # That distinction is not cosmetic: keyed on the token, every hosted
+            # ratio came out inversely correlated with usage (a handshake recurs
+            # per mint, a tool call does not), so the harder someone worked the
+            # worse they scored. Measured over 30 days: 533 of 568 tokens died
+            # inside the TTL and invoked at 9.6%, against ~80% for the 35 that
+            # outlived it — with event count held constant, so not a spread
+            # artifact. The hosted funnel was deleted over it.
+            #
+            # PRIVACY: hashed, not raw. The session id is a bearer-equivalent —
+            # possession of it plus a token addresses a live session — so it gets
+            # the same treatment as a credential, via the one shared digest.
+            # Absent for stdio (no session header) and on the ``initialize``
+            # request itself, which is what mints the session.
+            session_id = inbound_mcp_session_id.get()
+            if session_id and session_id.strip():
+                props["mcp_session_sha256"] = credential_digest(session_id.strip())
         except Exception:
             logger.debug("per-request identity enrichment failed", exc_info=True)
         return props

--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -377,18 +377,20 @@ class AnalyticsClient:
             if workspace:
                 props["request_workspace"] = workspace
 
-            # The stable unit the hosted funnel needs. A client keeps its
-            # ``Mcp-Session-Id`` across OAuth token refreshes, so an 8-hour
-            # session is ONE session here — where ``token_sha256`` would be ~8
-            # separate identities, because the access token lives one hour.
+            # SESSION grain — NOT a user grain, and NOT the adoption funnel's key.
+            # A session ends, so it cannot answer retention ("active on 3+ days").
+            # The funnel needs the Comet login, which ``caller_identity`` already
+            # resolves; hosted reads zero only because it runs 0.2.12. See the
+            # scope note on ``auth_context.inbound_mcp_session_id``.
             #
-            # That distinction is not cosmetic: keyed on the token, every hosted
-            # ratio came out inversely correlated with usage (a handshake recurs
-            # per mint, a tool call does not), so the harder someone worked the
-            # worse they scored. Measured over 30 days: 533 of 568 tokens died
-            # inside the TTL and invoked at 9.6%, against ~80% for the 35 that
-            # outlived it — with event count held constant, so not a spread
-            # artifact. The hosted funnel was deleted over it.
+            # What it does buy: a client keeps its ``Mcp-Session-Id`` across OAuth
+            # token refreshes, so an 8-hour session is ONE session here — where
+            # ``token_sha256`` would be ~8 separate identities, because the access
+            # token lives one hour. That removed a genuine inversion (token-keyed
+            # ratios fell as usage rose: 533 of 568 tokens died inside the TTL and
+            # invoked at 9.6%, against ~80% for the 35 that outlived it). It also
+            # survives a ``lookup_identity`` miss, where events otherwise fall back
+            # to the nil ``install_id`` and merge into a single row.
             #
             # PRIVACY: hashed, not raw. The session id is a bearer-equivalent —
             # possession of it plus a token addresses a live session — so it gets

--- a/src/opik_mcp/analytics/environment.py
+++ b/src/opik_mcp/analytics/environment.py
@@ -81,9 +81,18 @@ def _detect_container() -> str:
         return "false"
 
 
-# Launch-method substring patterns. Order matters: first match wins, so
-# more-specific patterns ("uv/archive") must precede less-specific ones
-# ("python"). The bucket value is the second element.
+# Launch-method substring patterns, matched against a separator-normalised
+# lowercase `sys.executable`. Order matters: first match wins, so more-specific
+# patterns ("uv/archive") must precede less-specific ones ("python").
+#
+# Patterns are written with FORWARD slashes only; `_normalise_exe_path` folds
+# Windows backslashes before matching, so one table covers every platform.
+# Without that, Windows reported `launch_method="unknown"` unconditionally
+# (every pattern here was POSIX-shaped) — 6,645 starts of the 30-day fleet were
+# dark for this field.
+# FROZEN POSIX table — byte-identical to what first shipped. Do not add
+# entries: a new pattern here could reclassify a path that currently reports
+# "unknown", moving an existing series.
 _LAUNCH_METHOD_PATTERNS: tuple[tuple[str, str], ...] = (
     ("/uv/archive", "uvx"),
     ("/.local/share/uv/", "uvx"),
@@ -94,13 +103,54 @@ _LAUNCH_METHOD_PATTERNS: tuple[tuple[str, str], ...] = (
     ("/usr/local/bin/", "system"),
 )
 
+# Windows table, consulted ONLY when running on win32 (see below). Kept separate
+# from the POSIX table so it is impossible for a Windows pattern to reclassify a
+# POSIX path — the POSIX result stays provably unchanged.
+#
+# uv's roots differ per OS: ~/.local/share/uv on Linux/macOS versus
+# %LOCALAPPDATA%\uv\cache on Windows. System interpreters cover the python.org
+# per-user installer, the all-users install under Program Files, and the
+# Store/WindowsApps stub.
+_WINDOWS_LAUNCH_METHOD_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("/uv/archive", "uvx"),
+    ("/uv/cache/", "uvx"),
+    ("/uv/tools/", "uvx"),
+    ("/pipx/venvs/", "pipx"),
+    ("/.venv/", "venv"),
+    ("/venv/", "venv"),
+    ("/appdata/local/programs/python/", "system"),
+    ("/program files/python", "system"),
+    ("/windowsapps/", "system"),
+)
+
+
+def _normalise_exe_path(raw: str) -> str:
+    """Lowercase a path and fold Windows separators to forward slashes.
+
+    Never returned to a caller — only used as the matching subject.
+    """
+    return (raw or "").replace("\\", "/").lower()
+
 
 def _detect_launch_method() -> str:
     """Bucket `sys.executable` into a launch-method enum.
 
+    Platform-split on purpose. Every pattern in the frozen POSIX table needs a
+    forward slash, and a Windows path (``C:\\Users\\...``) contains none — so
+    this field returned the constant "unknown" on Windows for its entire life,
+    carrying no information at all. The win32 branch fixes that blind spot
+    (6,645 starts of the 30-day fleet) while leaving the POSIX branch running
+    the original code over the original table, so no existing series moves.
+
     PRIVACY: never returns raw `sys.executable`. Anything not matching the
     allowlist falls through to "unknown" — the path is dropped, not echoed.
     """
+    if _PLATFORM == "win32":
+        win_exe = _normalise_exe_path(sys.executable)
+        for needle, bucket in _WINDOWS_LAUNCH_METHOD_PATTERNS:
+            if needle in win_exe:
+                return bucket
+        return "unknown"
     exe = (sys.executable or "").lower()
     for needle, bucket in _LAUNCH_METHOD_PATTERNS:
         if needle in exe:
@@ -134,8 +184,37 @@ _PARENT_PROCESS_PATTERNS: tuple[tuple[str, str], ...] = (
 )
 
 
+# Package runners that sit BETWEEN the MCP host and this process. When the
+# immediate parent is one of these, it tells us how we were launched but hides
+# who launched us — the host is our grandparent. `_detect_parent_process` walks
+# one level up through them.
+#
+# This was the single largest blind spot in the fleet: `uvx` is the install
+# method our own README recommends, and it made `Darwin | uvx | other` the
+# top row of the start table (32,168 starts across 157 installs) with the host
+# unidentifiable.
+_LAUNCHER_BUCKETS: frozenset[str] = frozenset({"uv"})
+
+# Exact-match (not substring) buckets, keyed on the BASENAME of the parent
+# command with any ".exe" suffix stripped.
+#
+# Short generic tokens MUST be matched exactly. `uv` is two characters and
+# `_PARENT_PROCESS_PATTERNS` matches substrings against the full command
+# string, which on macOS is an absolute path — a substring rule would classify
+# `/Users/luv/...` or any `uvicorn` process as the uv launcher.
+_EXACT_PARENT_PATTERNS: dict[str, str] = {
+    "uv": "uv",
+    "uvx": "uv",
+}
+
+
 def _classify_parent_process_name(raw: str) -> str:
     """Map a raw /proc/<ppid>/comm (or `ps -o comm=`) value to the allowlist.
+
+    FROZEN — feeds the long-lived ``parent_process`` BI field. Do not change what
+    this returns for any input: existing dashboards and trends are built on it.
+    Improvements to ancestor detection go in ``_classify_ancestor_name`` and are
+    reported through the newer ``host_process`` / ``launcher`` fields instead.
 
     PRIVACY: the raw value never appears in the return; it's bucketed or
     dropped. Tests inject adversarial inputs containing the local username
@@ -150,26 +229,47 @@ def _classify_parent_process_name(raw: str) -> str:
     return "other"
 
 
-def _read_parent_process_name() -> str:
-    """Best-effort fetch of the parent process's command name.
+def _classify_ancestor_name(raw: str) -> str:
+    """Classify an ancestor command, recognising package runners.
 
-    Returns "" on any failure. Never raises — the caller treats "" as
-    "unknown parent" and buckets it to "other".
+    Extends the frozen parent classifier with one extra pass, and the order
+    matters:
+
+    1. Exact match on the basename (see ``_EXACT_PARENT_PATTERNS``) — for short
+       tokens where a substring rule would collide with usernames and paths.
+    2. Whatever ``_classify_parent_process_name`` decides (substring, FULL value).
+
+    Pass 2 deliberately keeps the whole string rather than the basename: macOS
+    app bundles name their helper binary something generic, so the identifying
+    token lives in a parent directory — Cursor's helper is
+    ``/Applications/Cursor.app/Contents/MacOS/Electron``, which only classifies
+    as "cursor" if the directory survives.
+
+    Same privacy contract as the frozen classifier: bucketed or dropped, never
+    echoed.
     """
-    try:
-        ppid = os.getppid()
-    except OSError:
-        return ""
+    needle = (raw or "").strip().lower()
+    if not needle:
+        return "other"
+    basename = needle.replace("\\", "/").rsplit("/", 1)[-1].removesuffix(".exe")
+    exact = _EXACT_PARENT_PATTERNS.get(basename)
+    if exact is not None:
+        return exact
+    return _classify_parent_process_name(needle)
+
+
+def _read_process_name(pid: int) -> str:
+    """Best-effort fetch of one process's command name. "" on any failure."""
     if _PLATFORM == "linux":
         try:
-            with open(f"/proc/{ppid}/comm", encoding="utf-8") as f:
+            with open(f"/proc/{pid}/comm", encoding="utf-8") as f:
                 return f.read().strip()
         except OSError:
             return ""
     if _PLATFORM == "darwin":
         try:
             out = subprocess.run(
-                ["ps", "-o", "comm=", "-p", str(ppid)],
+                ["ps", "-o", "comm=", "-p", str(pid)],
                 capture_output=True,
                 text=True,
                 timeout=1.0,
@@ -178,11 +278,161 @@ def _read_parent_process_name() -> str:
             return out.stdout.strip()
         except (OSError, subprocess.SubprocessError):
             return ""
+    if _PLATFORM == "win32":
+        # `tasklist` is the only always-present, dependency-free way to turn a
+        # pid into an image name (wmic is deprecated and absent on Windows 11+).
+        # CSV + /NH keeps parsing to a single split; the image name is field 0.
+        #
+        # CREATE_NO_WINDOW matters: an MCP server launched by a GUI host would
+        # otherwise flash a console window on every boot. The flag only exists
+        # on Windows, so it is read dynamically — see `_win_no_window_flag`.
+        try:
+            out = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+                creationflags=_win_no_window_flag(),
+            )
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return ""
+        line = out.stdout.strip().splitlines()[0] if out.stdout.strip() else ""
+        # No match prints an INFO banner rather than a CSV row.
+        if not line.startswith('"'):
+            return ""
+        return line.split('","', 1)[0].lstrip('"')
     return ""
 
 
+def _win_no_window_flag() -> int:
+    """``subprocess.CREATE_NO_WINDOW`` on Windows, 0 elsewhere.
+
+    Read via ``getattr`` because the constant is only defined on Windows, and a
+    direct reference would not typecheck on the POSIX hosts that run CI.
+    """
+    return int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
+
+
+def _read_parent_pid(pid: int) -> int | None:
+    """The parent pid of ``pid``, or None if it can't be determined.
+
+    Only needed to step over a launcher (see ``_LAUNCHER_BUCKETS``), so a None
+    here degrades to "report the launcher itself", never to a crash.
+    """
+    if _PLATFORM == "linux":
+        try:
+            with open(f"/proc/{pid}/stat", encoding="utf-8") as f:
+                stat = f.read()
+        except OSError:
+            return None
+        # Field 2 (comm) is parenthesised and may itself contain spaces and
+        # ')', so the only safe split point is the LAST ')'. ppid is then the
+        # second whitespace-separated field of the remainder.
+        _, _, rest = stat.rpartition(")")
+        fields = rest.split()
+        if len(fields) < 2:
+            return None
+        try:
+            return int(fields[1])
+        except ValueError:
+            return None
+    if _PLATFORM == "darwin":
+        try:
+            out = subprocess.run(
+                ["ps", "-o", "ppid=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                timeout=1.0,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        try:
+            return int(out.stdout.strip())
+        except ValueError:
+            return None
+    # Windows: no dependency-free way to read a ppid (tasklist doesn't report
+    # it). The launcher bucket is still reported; the grandparent is not.
+    return None
+
+
+@lru_cache(maxsize=1)
+def _read_ancestor_parent_name() -> str:
+    """Our parent's command name, on every platform. "" on any failure.
+
+    Memoised: our parent cannot change for the life of the process, and each
+    read costs a `ps` (macOS) or `tasklist` (Windows) subprocess. Several
+    detectors consume it, so without the cache one fingerprint shells out
+    repeatedly.
+    """
+    try:
+        ppid = os.getppid()
+    except OSError:
+        return ""
+    return _read_process_name(ppid)
+
+
+def _read_parent_process_name() -> str:
+    """FROZEN reader behind the long-lived ``parent_process`` field.
+
+    Restricted to linux/darwin on purpose. ``_read_process_name`` also handles
+    Windows now, but routing Windows through here would start populating
+    ``parent_process`` on a platform where it has only ever reported "other" —
+    silently changing a live BI series. The Windows-capable path feeds the newer
+    ``host_process`` field instead, so the new signal arrives without disturbing
+    the old one.
+    """
+    if _PLATFORM not in ("linux", "darwin"):
+        return ""
+    return _read_ancestor_parent_name()
+
+
 def _detect_parent_process() -> str:
+    """FROZEN: the bucket of our IMMEDIATE parent.
+
+    Unchanged behaviour, deliberately — a package runner still reports as
+    "other" here. ``host_process`` is the field that sees through it.
+    """
     return _classify_parent_process_name(_read_parent_process_name())
+
+
+def _detect_host_process() -> str:
+    """NEW: bucket the nearest ancestor that identifies WHO launched us.
+
+    Steps over a package runner (``uv``) to reach the MCP host behind it, and
+    works on Windows. If the grandparent can't be read (Windows has no
+    dependency-free ppid lookup) or doesn't classify, the launcher bucket is
+    reported as-is — still strictly more than the "other" ``parent_process``
+    reports for the same process. ``launcher`` preserves the fact that a runner
+    was involved, so folding it away here loses nothing.
+    """
+    bucket = _classify_ancestor_name(_read_ancestor_parent_name())
+    if bucket not in _LAUNCHER_BUCKETS:
+        return bucket
+    try:
+        ppid = os.getppid()
+    except OSError:
+        return bucket
+    gppid = _read_parent_pid(ppid)
+    if gppid is None:
+        return bucket
+    grandparent = _classify_ancestor_name(_read_process_name(gppid))
+    # Only take the grandparent when it actually identifies something; an
+    # unrecognised ancestor is less informative than the known launcher.
+    if grandparent in ("other", *_LAUNCHER_BUCKETS):
+        return bucket
+    return grandparent
+
+
+def _detect_launcher() -> str:
+    """NEW: ``"uv"`` when a package runner spawned us, else ``"none"``.
+
+    Emitted alongside ``host_process`` so the uvx install path stays countable
+    after ``_detect_host_process`` folds it away in favour of the host behind it.
+    """
+    bucket = _classify_ancestor_name(_read_ancestor_parent_name())
+    return bucket if bucket in _LAUNCHER_BUCKETS else "none"
 
 
 _logger = logging.getLogger("opik_mcp.analytics.environment")
@@ -216,7 +466,17 @@ def collect_environment_fingerprint() -> dict[str, str]:
         "is_codespaces": _safe(_detect_codespaces, "false"),
         "is_gitpod": _safe(_detect_gitpod, "false"),
         "launch_method": _safe(_detect_launch_method, "unknown"),
+        # FROZEN field — immediate parent only. Kept bit-for-bit compatible with
+        # every dashboard built on it. Read `host_process` for real attribution.
         "parent_process": _safe(_detect_parent_process, "unknown"),
+        # NEW: the ancestor that actually identifies the MCP host — sees through
+        # the `uvx` package runner and works on Windows, both of which leave
+        # `parent_process` reporting "other".
+        "host_process": _safe(_detect_host_process, "unknown"),
+        # NEW: whether a package runner (uvx) sits between the host and us, so
+        # the recommended install path stays countable after `host_process`
+        # folds it away.
+        "launcher": _safe(_detect_launcher, "unknown"),
     }
     try:
         out.update(_detect_pipe_signals())
@@ -253,3 +513,14 @@ def cached_call_context_env() -> dict[str, str]:
         "launch_method": _safe(_detect_launch_method, "unknown"),
         "install_id_freshly_generated": str(install_id_was_freshly_generated()).lower(),
     }
+
+
+def _reset_detector_caches_for_tests() -> None:
+    """Drop memoised detector state. Test-only — never call from production.
+
+    ``_read_ancestor_parent_name`` is process-scoped by design, so a test that
+    monkeypatches the platform or the underlying reader would otherwise see the
+    previous test's parent name.
+    """
+    _read_ancestor_parent_name.cache_clear()
+    cached_call_context_env.cache_clear()

--- a/src/opik_mcp/analytics/environment.py
+++ b/src/opik_mcp/analytics/environment.py
@@ -16,6 +16,8 @@ import sys
 from collections.abc import Callable
 from functools import lru_cache
 
+from opik_mcp.credential_identity import credential_digest
+
 # ``sys.platform`` is a Literal type that mypy narrows per-host, so platform-
 # dispatch branches get flagged unreachable on whichever host runs CI (Linux
 # kills the macOS branch, macOS kills the Linux branch). Aliasing once to a
@@ -515,6 +517,111 @@ def cached_call_context_env() -> dict[str, str]:
     }
 
 
+# OS-level machine identifiers. Read in platform order; the first that yields a
+# non-empty value wins. All three are stable across reinstalls of opik-mcp and
+# across a wiped HOME, which is the whole point (see ``env_id`` below).
+_MACHINE_ID_PATHS: tuple[str, ...] = ("/etc/machine-id", "/var/lib/dbus/machine-id")
+_WINDOWS_MACHINE_GUID_KEY = r"HKLM\SOFTWARE\Microsoft\Cryptography"
+
+
+def _read_machine_id() -> str:
+    """Best-effort OS machine identifier. "" on any failure — never raises.
+
+    PRIVACY: the raw value never leaves this module; ``_detect_env_id`` hashes it.
+    Deliberately contains NO user-derived data — no hostname, no OS username — so
+    the digest identifies a machine and nothing about a person.
+    """
+    if _PLATFORM == "linux":
+        for path in _MACHINE_ID_PATHS:
+            try:
+                with open(path, encoding="utf-8") as f:
+                    value = f.read().strip()
+                if value:
+                    return value
+            except OSError:
+                continue
+        return ""
+    if _PLATFORM == "darwin":
+        try:
+            out = subprocess.run(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        for line in out.stdout.splitlines():
+            if "IOPlatformUUID" in line:
+                _, _, tail = line.partition("=")
+                return tail.strip().strip('"')
+        return ""
+    if _PLATFORM == "win32":
+        try:
+            out = subprocess.run(
+                ["reg", "query", _WINDOWS_MACHINE_GUID_KEY, "/v", "MachineGuid"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+                creationflags=_win_no_window_flag(),
+            )
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return ""
+        for line in out.stdout.splitlines():
+            if "MachineGuid" in line:
+                return line.split()[-1].strip()
+        return ""
+    return ""
+
+
+@lru_cache(maxsize=1)
+def _detect_env_id() -> tuple[str, str]:
+    """``(digest, kind)`` for this machine. ``("", "unknown")`` when unreadable.
+
+    Why this exists: ``install_id`` is the only machine identity we had, and it is
+    a UUID in a file under HOME. That makes it fragile in two ways a funnel cares
+    about — a reinstall or a wiped HOME mints a brand-new identity (inflating
+    "new installs"), and an unwritable HOME collapses to the nil sentinel, merging
+    every such deployment into one row.
+
+    It is also the ONLY identity available to a large slice of users: local and
+    self-hosted Opik run with auth disabled, so no credential and therefore no
+    resolvable username exists for them — measured at ~18k successful tool calls
+    across ~36 installs. A username can never cover those.
+
+    Machine-scoped on purpose: one client per machine is the accepted grain, so
+    the digest deliberately excludes the OS username. Two people sharing a box
+    merge, which is fine, and it keeps user-derived data out of the hash entirely.
+
+    Emits NOTHING rather than an unstable fallback. A hostname digest was
+    considered and rejected: in a container the hostname is the container id, so
+    it would churn per run while looking authoritative — the same failure mode as
+    the nil ``install_id``. Absent is honest; churning is not.
+
+    CONTAINERS READ ``unknown``, and that is the intended outcome — do not
+    "fix" it by adding a fallback. Verified on ``python:3.13-slim``: two separate
+    runs both read an EMPTY ``/etc/machine-id`` while the hostname differed
+    (``42fbc2f195b2`` vs ``dda594ef58f6``). So a container is countable as "no
+    stable identity" instead of either inflating (a per-run identity, which the
+    hostname would have produced) or silently merging (one identity baked into a
+    shared image). When querying, treat ``env_id_kind='unknown'`` as its own
+    population rather than folding it in with ``machine``.
+
+    Memoised — one subprocess per process on macOS/Windows, on the startup path.
+    """
+    raw = _safe(_read_machine_id, "").strip()
+    if not raw:
+        return ("", "unknown")
+    return (credential_digest(raw), "machine")
+
+
+def env_id() -> tuple[str, str]:
+    """Public accessor for ``(digest, kind)``. See ``_detect_env_id``."""
+    return _detect_env_id()
+
+
 def _reset_detector_caches_for_tests() -> None:
     """Drop memoised detector state. Test-only — never call from production.
 
@@ -523,4 +630,5 @@ def _reset_detector_caches_for_tests() -> None:
     previous test's parent name.
     """
     _read_ancestor_parent_name.cache_clear()
+    _detect_env_id.cache_clear()
     cached_call_context_env.cache_clear()

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -24,7 +24,7 @@ property. Anything outside the allowlist is bucketed to a fallback ("other",
 Three declared exceptions to "boolean / enum / bucket":
 
 - Pseudonymous identity hashes (``api_key_sha256``, ``token_sha256``,
-  ``mcp_session_sha256``) are 64-char SHA-256 hex digests. Not enums, but safe:
+  ``mcp_session_sha256``, ``env_id_sha256``) are 64-char SHA-256 hex digests. Not enums, but safe:
   irreversible one-way transforms of values the backend already holds. The raw
   key/token/session-id NEVER leaves the process. This is enforced by tests that
   call ``client._build_event`` directly
@@ -48,6 +48,11 @@ Three declared exceptions to "boolean / enum / bucket":
   misses (pod restart, LRU eviction) instead of collapsing into the nil
   ``install_id``. Hashed rather than raw because possession of a session id plus
   a token addresses a live session, which makes it bearer-equivalent.
+
+  ``env_id_sha256`` is the digest of the OS machine id (see ``EnvIdKind``). It
+  contains NO user-derived data — no hostname, no OS username — so it identifies
+  a machine and nothing about a person, and it is hashed anyway because a raw
+  machine id is a stable device identifier we have no reason to hold.
 - Workspace fields (``workspace``, ``request_workspace``, ``workspace_id``) are
   emitted as plaintext/UUID — an accepted posture: the workspace name is a
   tenant label, not a person, and BI cannot attribute usage without it.
@@ -140,6 +145,25 @@ HostProcess = Literal[
     "uv",
     "other",
 ]
+
+# ``env_id_kind`` (NEW): where the machine identity came from. "machine" means a
+# real OS machine id was read (/etc/machine-id, macOS IOPlatformUUID, Windows
+# MachineGuid) and ``env_id_sha256`` carries its digest; "unknown" means none was
+# readable and NO digest is emitted.
+#
+# Why it exists alongside ``install_id``: that field is a UUID in a file under
+# HOME, so a reinstall mints a brand-new identity (inflating "new installs") and
+# an unwritable HOME collapses it to the nil sentinel, merging every such
+# deployment into one row. A machine id survives both. It is also the only
+# identity available to local / self-hosted users, who run with auth disabled and
+# so can never resolve a username — ~18k successful tool calls across ~36
+# installs in a 30-day window.
+#
+# Machine-scoped by design: the digest deliberately excludes the OS username, so
+# two people sharing a box merge and no user-derived data enters the hash. A
+# hostname fallback was considered and rejected — in a container the hostname is
+# the container id, so it would churn per run while looking authoritative.
+EnvIdKind = Literal["machine", "unknown"]
 
 # ``launcher`` (NEW): the package runner that spawned this process, when there
 # was one. Emitted alongside ``host_process`` so the uvx install path stays

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -23,14 +23,24 @@ property. Anything outside the allowlist is bucketed to a fallback ("other",
 
 Three declared exceptions to "boolean / enum / bucket":
 
-- Pseudonymous identity hashes (``api_key_sha256``, ``token_sha256``) are
-  64-char SHA-256 hex digests. Not enums, but safe: irreversible one-way
-  transforms of secrets the backend already holds. The raw key/token NEVER
-  leaves the process. This is enforced by tests that call
-  ``client._build_event`` directly
+- Pseudonymous identity hashes (``api_key_sha256``, ``token_sha256``,
+  ``mcp_session_sha256``) are 64-char SHA-256 hex digests. Not enums, but safe:
+  irreversible one-way transforms of values the backend already holds. The raw
+  key/token/session-id NEVER leaves the process. This is enforced by tests that
+  call ``client._build_event`` directly
   (``tests/test_analytics_client_build_event.py``); the recorder-based tests in
   ``test_analytics_privacy.py`` intercept at ``track_event`` and never see what
   ``_build_event`` builds, so they cannot catch a leak inside it.
+
+  ``mcp_session_sha256`` exists because the hosted transport had no stable unit
+  to build a funnel on. Its only per-caller identifier was ``token_sha256``, and
+  the OAuth access token lives ONE HOUR — a handshake recurs on every mint while
+  a tool call does not, so every hosted ratio came out inversely correlated with
+  usage (533 of 568 tokens died inside the TTL and invoked at 9.6%, against ~80%
+  for the 35 that outlived it). A client keeps its ``Mcp-Session-Id`` across
+  token refreshes, so the session digest counts an 8-hour session ONCE. It is
+  hashed rather than raw because possession of a session id plus a token
+  addresses a live session, which makes it bearer-equivalent.
 - Workspace fields (``workspace``, ``request_workspace``, ``workspace_id``) are
   emitted as plaintext/UUID — an accepted posture: the workspace name is a
   tenant label, not a person, and BI cannot attribute usage without it.

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -72,8 +72,16 @@ LaunchMethod = Literal[
     "unknown",
 ]
 
-# ``parent_process``: bucketed parent-process comm name. See
+# ``parent_process``: bucketed comm name of the IMMEDIATE parent process. See
 # ``environment._PARENT_PROCESS_PATTERNS``.
+#
+# FROZEN. Semantics and value set are unchanged since first release, and must
+# stay that way — dashboards and trends are built on these exact buckets. Its
+# two known blind spots are NOT fixed here, on purpose:
+#   - under ``uvx`` (our recommended install path) the parent is the uv runner,
+#     so this reports "other" and the real host is invisible;
+#   - on Windows it always reports "other", because its reader is POSIX-only.
+# Both are addressed by the additive ``host_process`` field below.
 ParentProcess = Literal[
     "docker-entrypoint",
     "claude",
@@ -91,10 +99,44 @@ ParentProcess = Literal[
     "other",
 ]
 
+# ``host_process`` (NEW): the nearest ancestor that identifies WHO launched us.
+# Same bucket vocabulary as ``ParentProcess`` plus "uv", and unlike that field it
+# steps over a package runner to reach the host behind it and works on Windows.
+# "uv" appears when the runner was detected but the grandparent could not be
+# read (notably Windows, which has no dependency-free ppid lookup).
+#
+# This is the field new reporting should use for host attribution.
+HostProcess = Literal[
+    "docker-entrypoint",
+    "claude",
+    "cursor",
+    "vscode",
+    "jetbrains",
+    "bash",
+    "zsh",
+    "fish",
+    "python",
+    "node",
+    "sshd",
+    "systemd",
+    "launchd",
+    "uv",
+    "other",
+]
+
+# ``launcher`` (NEW): the package runner that spawned this process, when there
+# was one. Emitted alongside ``host_process`` so the uvx install path stays
+# countable after ``host_process`` folds it away. "unknown" is the
+# detector-raised fallback (``_safe``), not a real observation.
+Launcher = Literal["uv", "none", "unknown"]
+
 # ``mcp_host``: bucketed MCP host (clientInfo.name). MUST stay in sync with
 # ``mcp_client_info._MCP_HOST_PATTERNS`` — every bucket that classifier can
 # emit is declared here (enforced by
 # ``test_analytics_events.test_mcp_host_literal_covers_all_classifier_buckets``).
+# FROZEN. An absent ``clientInfo.name`` reports "other" here, the same bucket as
+# an unrecognised one — a known wart, kept because existing dashboards count on
+# it. ``McpClient`` below separates the two.
 McpHost = Literal[
     "claude-desktop",
     "claude-code",
@@ -115,8 +157,43 @@ McpHost = Literal[
     "other",
 ]
 
-# ``host_llm_family``: derived from the bucketed ``mcp_host``. MUST stay in sync
-# with ``mcp_client_info._HOST_LLM_FAMILY`` values (enforced by
+# ``mcp_client`` (NEW): canonical client bucket, and what new reporting should
+# use. Two differences from the frozen ``McpHost``:
+#
+#   - It recognises the names clients actually send. ``claude-desktop`` was a
+#     DEAD bucket under the old classifier — zero events in a 30-day fleet
+#     window — because Claude Desktop identifies itself as "claude-ai"; likewise
+#     VS Code sends "Visual Studio Code", which never matched a "vscode" prefix.
+#   - "absent" (no/empty clientInfo) is separated from "other" (a real client we
+#     have no pattern for). Merging them is what made the largest cohort in the
+#     fleet unreadable: an instrumentation gap looked identical to genuine
+#     long-tail client diversity.
+McpClient = Literal[
+    "claude-desktop",
+    "claude-code",
+    "cursor",
+    "roo",
+    "cline",
+    "continue",
+    "windsurf",
+    "mcp-inspector",
+    "zed",
+    "vscode",
+    "goose",
+    "librechat",
+    "5ire",
+    "opencode",
+    "codex",
+    "gemini-cli",
+    "other",
+    "absent",
+]
+
+# ``host_llm_family`` / ``client_llm_family``: derived from the bucketed
+# ``mcp_host`` and ``mcp_client`` respectively, through the SAME mapping — so a
+# bucket that is unmapped (including ``mcp_client``'s "absent") falls to
+# "unknown". MUST stay in sync with ``mcp_client_info._HOST_LLM_FAMILY`` values
+# (enforced by
 # ``test_analytics_events.test_host_llm_family_literal_covers_all_classifier_values``).
 HostLlmFamily = Literal[
     "anthropic",

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -32,15 +32,22 @@ Three declared exceptions to "boolean / enum / bucket":
   ``test_analytics_privacy.py`` intercept at ``track_event`` and never see what
   ``_build_event`` builds, so they cannot catch a leak inside it.
 
-  ``mcp_session_sha256`` exists because the hosted transport had no stable unit
-  to build a funnel on. Its only per-caller identifier was ``token_sha256``, and
-  the OAuth access token lives ONE HOUR — a handshake recurs on every mint while
-  a tool call does not, so every hosted ratio came out inversely correlated with
-  usage (533 of 568 tokens died inside the TTL and invoked at 9.6%, against ~80%
-  for the 35 that outlived it). A client keeps its ``Mcp-Session-Id`` across
-  token refreshes, so the session digest counts an 8-hour session ONCE. It is
-  hashed rather than raw because possession of a session id plus a token
-  addresses a live session, which makes it bearer-equivalent.
+  ``mcp_session_sha256`` is a SESSION grain and is **not** the adoption funnel's
+  key. A session ends, so it cannot answer retention ("active on 3+ distinct
+  days") any more than the token could. The funnel needs the Comet login —
+  ``user_id`` with ``user_id_kind='comet_user'`` — which ``caller_identity``
+  already resolves and which is live on stdio today; hosted reads zero only
+  because it runs 0.2.12, predating that work, so the fix there is a deploy.
+
+  What the session digest does buy is narrower. The OAuth access token lives ONE
+  HOUR, and a handshake recurs on every mint while a tool call does not, so
+  token-keyed ratios fell as usage rose — 533 of 568 tokens died inside the TTL
+  and invoked at 9.6%, against ~80% for the 35 that outlived it. A client keeps
+  its ``Mcp-Session-Id`` across refreshes, so the session digest counts an
+  8-hour session ONCE, and it still groups events when ``lookup_identity``
+  misses (pod restart, LRU eviction) instead of collapsing into the nil
+  ``install_id``. Hashed rather than raw because possession of a session id plus
+  a token addresses a live session, which makes it bearer-equivalent.
 - Workspace fields (``workspace``, ``request_workspace``, ``workspace_id``) are
   emitted as plaintext/UUID — an accepted posture: the workspace name is a
   tenant label, not a person, and BI cannot attribute usage without it.

--- a/src/opik_mcp/analytics/mcp_client_info.py
+++ b/src/opik_mcp/analytics/mcp_client_info.py
@@ -44,12 +44,81 @@ _MCP_HOST_PATTERNS: tuple[tuple[str, str], ...] = (
     ("gemini-cli", "gemini-cli"),
 )
 
+# Canonical client allowlist behind the NEWER ``mcp_client`` field. Superset of
+# ``_MCP_HOST_PATTERNS`` with the aliases real clients actually send.
+#
+# Two entries here are the whole reason this field exists:
+#
+# - Claude Desktop identifies itself as **"claude-ai"**, not "claude-desktop".
+#   The frozen ``mcp_host`` bucket was therefore unreachable — it recorded ZERO
+#   events across a 30-day fleet window while real Claude Desktop users were
+#   counted as "other".
+# - VS Code sends the product name with spaces ("Visual Studio Code",
+#   "Visual Studio Code - Insiders"), which no "vscode" prefix ever matched.
+#
+# Order matters (prefix match, first hit wins): list longer, more specific
+# prefixes before shorter ones they would shadow.
+_MCP_CLIENT_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("claude-ai", "claude-desktop"),
+    ("claude-desktop", "claude-desktop"),
+    ("claude-code", "claude-code"),
+    ("cursor", "cursor"),
+    ("roo", "roo"),
+    ("cline", "cline"),
+    ("continue", "continue"),
+    ("windsurf", "windsurf"),
+    ("mcp-inspector", "mcp-inspector"),
+    ("zed", "zed"),
+    ("visual studio code", "vscode"),
+    ("vscode", "vscode"),
+    ("goose", "goose"),
+    ("librechat", "librechat"),
+    ("5ire", "5ire"),
+    ("opencode", "opencode"),
+    ("codex", "codex"),
+    ("gemini-cli", "gemini-cli"),
+)
+
 
 def classify_mcp_host(raw: str) -> str:
+    """FROZEN classifier behind the long-lived ``mcp_host`` field.
+
+    Do not add patterns and do not change the empty-input result. Every existing
+    dashboard, trend and saved query keys off these exact buckets, including the
+    fact that an absent ``clientInfo`` reports "other" rather than its own value.
+
+    Corrections and new client names go in ``classify_mcp_client`` and reach BI
+    through the newer ``mcp_client`` field.
+    """
     needle = (raw or "").strip().lower()
     if not needle:
         return "other"
     for pattern, bucket in _MCP_HOST_PATTERNS:
+        if needle.startswith(pattern):
+            return bucket
+    return "other"
+
+
+def classify_mcp_client(raw: str) -> str:
+    """NEW canonical client bucket. Use this, not ``classify_mcp_host``.
+
+    Two improvements over the frozen classifier, both of which needed a new
+    field rather than an in-place fix:
+
+    1. It recognises the names clients actually send (``claude-ai``,
+       ``Visual Studio Code``), so ``claude-desktop`` and ``vscode`` stop being
+       dead buckets.
+    2. It returns **"absent"** for a missing/empty ``clientInfo`` instead of
+       folding it into "other". Those are different facts — "we never learned
+       who this is" versus "a real client we have no pattern for" — and merging
+       them is what made the largest cohort in the fleet (838 installs)
+       unreadable: an instrumentation gap was indistinguishable from genuine
+       long-tail client diversity.
+    """
+    needle = (raw or "").strip().lower()
+    if not needle:
+        return "absent"
+    for pattern, bucket in _MCP_CLIENT_PATTERNS:
         if needle.startswith(pattern):
             return bucket
     return "other"
@@ -119,7 +188,9 @@ def collect_session_props(session: Any) -> dict[str, str]:
     Defensive against missing intermediates: a session that hasn't
     completed the initialize handshake (``client_params is None``) still
     returns a valid dict with ``"other"`` / ``"unknown"`` / ``"false"``
-    sentinels — callers should never crash because the host raced us.
+    sentinels — callers should never crash because the host raced us. That
+    pre-handshake case is what the newer ``mcp_client`` field reports as
+    "absent"; the frozen ``mcp_host`` still folds it into "other".
     """
     params = getattr(session, "client_params", None) if session is not None else None
     client_info = getattr(params, "clientInfo", None) if params is not None else None
@@ -129,12 +200,18 @@ def collect_session_props(session: Any) -> dict[str, str]:
     raw_client_version = getattr(client_info, "version", "") or ""
     raw_protocol_version = (getattr(params, "protocolVersion", "") or "") if params else ""
     mcp_host_bucket = classify_mcp_host(raw_host)
+    mcp_client_bucket = classify_mcp_client(raw_host)
 
     return {
+        # FROZEN pair — every existing dashboard keys off these exact buckets.
         "mcp_host": mcp_host_bucket,
+        "host_llm_family": classify_host_llm_family(mcp_host_bucket),
+        # NEW canonical pair. Recognises claude-ai / "Visual Studio Code" and
+        # separates "absent" from "other". Prefer these for new reporting.
+        "mcp_client": mcp_client_bucket,
+        "client_llm_family": classify_host_llm_family(mcp_client_bucket),
         "mcp_client_version": bucket_mcp_client_version(raw_client_version),
         "mcp_protocol_version": bucket_mcp_protocol_version(raw_protocol_version),
-        "host_llm_family": classify_host_llm_family(mcp_host_bucket),
         "caps_sampling": str(getattr(capabilities, "sampling", None) is not None).lower(),
         "caps_elicitation": str(getattr(capabilities, "elicitation", None) is not None).lower(),
         "caps_roots": str(getattr(capabilities, "roots", None) is not None).lower(),
@@ -151,15 +228,25 @@ def collect_session_props(session: Any) -> dict[str, str]:
 _session_host_cache: WeakKeyDictionary[Any, dict[str, str]] = WeakKeyDictionary()
 
 
-def _host_context(session: Any) -> dict[str, str]:
-    """The two handshake-derived fields (``mcp_host`` / ``host_llm_family``),
-    cached per session.
+_HOST_CONTEXT_KEYS: tuple[str, ...] = (
+    "mcp_host",
+    "host_llm_family",
+    "mcp_client",
+    "client_llm_family",
+)
 
-    Only these two fields are cached — NOT the full 8-key
-    ``collect_session_props`` block. A caller that needs the version / caps
-    fields too should call ``collect_session_props`` directly (the
-    ``session_initialized`` emit does); don't layer it on top of this and
-    re-extract twice.
+
+def _host_context(session: Any) -> dict[str, str]:
+    """The handshake-derived client fields, cached per session.
+
+    Carries the frozen pair (``mcp_host`` / ``host_llm_family``) and the newer
+    canonical pair (``mcp_client`` / ``client_llm_family``) side by side, so BI
+    can migrate at its own pace without either series breaking.
+
+    Only these keys are cached — NOT the full ``collect_session_props`` block. A
+    caller that needs the version / caps fields too should call
+    ``collect_session_props`` directly (the ``session_initialized`` emit does);
+    don't layer it on top of this and re-extract twice.
     """
     try:
         cached = _session_host_cache.get(session)
@@ -168,7 +255,7 @@ def _host_context(session: Any) -> dict[str, str]:
     if cached is not None:
         return cached
     props = collect_session_props(session)
-    host = {"mcp_host": props["mcp_host"], "host_llm_family": props["host_llm_family"]}
+    host = {key: props[key] for key in _HOST_CONTEXT_KEYS}
     with contextlib.suppress(TypeError):
         _session_host_cache[session] = host
     return host
@@ -183,12 +270,14 @@ def call_context_props(session: Any) -> dict[str, str]:
 
     - ``is_ci`` / ``is_container`` / ``launch_method`` /
       ``install_id_freshly_generated`` — process-stable env (cached once)
-    - ``mcp_host`` / ``host_llm_family`` — per-session handshake (cached on
-      first read)
+    - ``mcp_host`` / ``host_llm_family`` — frozen per-session handshake pair
+    - ``mcp_client`` / ``client_llm_family`` — newer canonical pair (cached on
+      first read alongside the frozen one)
 
     Every value is a boolean string or an allowlisted enum — never a raw path,
     hostname, or ``clientInfo`` string. ``session`` may be ``None`` (no
-    handshake yet); the host fields fall back to ``"other"`` / ``"unknown"``.
+    handshake yet); ``mcp_host`` then reports ``"other"`` as it always has,
+    while ``mcp_client`` reports ``"absent"`` so the gap is countable.
     """
     return {**cached_call_context_env(), **_host_context(session)}
 

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -53,19 +53,29 @@ resolved_workspace_name: ContextVar[str | None] = ContextVar(
 # Inbound ``Mcp-Session-Id`` header value. TELEMETRY ONLY — never forwarded and
 # never used for routing; the MCP SDK owns session lifecycle entirely.
 #
-# Why it exists: on the hosted transport the only per-caller identifier BI had was
-# the OAuth token digest, and the access token lives ONE HOUR. A handshake recurs
-# on every mint while a tool call does not, so any hosted ratio came out inversely
-# correlated with usage — an 8-hour session minted ~8 "authorized + connected"
-# pairs and usually one "invoked", scoring worse the more the person actually
-# worked. Measured over 30 days: 533 of 568 tokens died inside the TTL and invoked
-# at 9.6%, against ~80% for the 35 that outlived it.
+# SCOPE — READ THIS BEFORE BUILDING ON IT. This is a SESSION grain, not a user
+# grain, and it does NOT enable an adoption funnel. A session ends; a funnel needs
+# a unit that outlives one. "Habit = active on 3+ distinct days" is unanswerable
+# here for the same reason it was unanswerable with the token. **The adoption
+# funnel needs the Comet login** (``user_id`` / ``user_id_kind='comet_user'``),
+# which ``caller_identity`` already resolves and which is live on stdio today —
+# hosted reads zero only because it runs 0.2.12, predating that work. The fix
+# there is a deploy, not this field.
 #
-# The session id is the stable unit that fixes it: a client keeps the same
-# ``Mcp-Session-Id`` across token refreshes, so an 8-hour session counts once.
-# It turns the denominator from "tokens minted" into "sessions started", which is
-# a real funnel unit. ``None`` means stdio, or the session-creating request
-# itself (the ``initialize`` handshake carries no session id yet).
+# What this IS good for, and why it is worth the two lines:
+#
+#  1. It removes a specific inversion. The OAuth access token lives ONE HOUR, and
+#     a handshake recurs on every mint while a tool call does not — so token-keyed
+#     ratios fell as usage rose. An 8-hour session minted ~8 "authorized +
+#     connected" pairs and usually one "invoked". Measured over 30 days: 533 of
+#     568 tokens died inside the TTL and invoked at 9.6%, against ~80% for the 35
+#     that outlived it. The session id collapses those 8 back to 1.
+#  2. It survives the identity gaps. When ``lookup_identity`` misses — pod
+#     restart, LRU eviction — events fall back to the nil ``install_id`` and merge
+#     into one row. A session digest still groups that session correctly.
+#
+# ``None`` means stdio, or the session-creating request itself (the ``initialize``
+# handshake carries no session id yet).
 inbound_mcp_session_id: ContextVar[str | None] = ContextVar("inbound_mcp_session_id", default=None)
 
 

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -50,6 +50,24 @@ resolved_workspace_name: ContextVar[str | None] = ContextVar(
     "resolved_workspace_name", default=None
 )
 
+# Inbound ``Mcp-Session-Id`` header value. TELEMETRY ONLY — never forwarded and
+# never used for routing; the MCP SDK owns session lifecycle entirely.
+#
+# Why it exists: on the hosted transport the only per-caller identifier BI had was
+# the OAuth token digest, and the access token lives ONE HOUR. A handshake recurs
+# on every mint while a tool call does not, so any hosted ratio came out inversely
+# correlated with usage — an 8-hour session minted ~8 "authorized + connected"
+# pairs and usually one "invoked", scoring worse the more the person actually
+# worked. Measured over 30 days: 533 of 568 tokens died inside the TTL and invoked
+# at 9.6%, against ~80% for the 35 that outlived it.
+#
+# The session id is the stable unit that fixes it: a client keeps the same
+# ``Mcp-Session-Id`` across token refreshes, so an 8-hour session counts once.
+# It turns the denominator from "tokens minted" into "sessions started", which is
+# a real funnel unit. ``None`` means stdio, or the session-creating request
+# itself (the ``initialize`` handshake carries no session id yet).
+inbound_mcp_session_id: ContextVar[str | None] = ContextVar("inbound_mcp_session_id", default=None)
+
 
 def classify_bearer(auth_header: str) -> tuple[str, str]:
     """Classify a non-empty inbound ``Authorization`` header for BI analytics.

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -32,6 +32,7 @@ from opik_mcp.ask_ollie import AskOllieResult, run_ask_ollie
 from opik_mcp.auth_context import (
     classify_bearer,
     inbound_authorization,
+    inbound_mcp_session_id,
     inbound_workspace,
     resolved_workspace_name,
     settings_auth_mode,
@@ -698,7 +699,13 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         # static fallback and never blocks the handshake.
         resolved_token = None
         auth_mode, oauth_token = classify_bearer(auth)
-        if request.headers.get("mcp-session-id") is None and auth_mode == "oauth":
+        mcp_session_id = request.headers.get("mcp-session-id")
+        # TELEMETRY ONLY — see ``auth_context.inbound_mcp_session_id``. The
+        # session id is the stable unit the hosted funnel needs: a client keeps it
+        # across OAuth token refreshes, so an 8-hour session counts once instead of
+        # once per hourly token mint.
+        session_id_token = inbound_mcp_session_id.set(mcp_session_id)
+        if mcp_session_id is None and auth_mode == "oauth":
             identity = await resolve_oauth_identity(auth, get_settings())
             if identity is not None:
                 # Held against the token, not this request: the analytics layer
@@ -712,6 +719,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         finally:
             inbound_authorization.reset(auth_token)
             inbound_workspace.reset(workspace_token)
+            inbound_mcp_session_id.reset(session_id_token)
             if resolved_token is not None:
                 resolved_workspace_name.reset(resolved_token)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     """
     from opik_mcp.analytics import reset_analytics_for_tests, transport_probe
     from opik_mcp.analytics.boot_props import LIFECYCLE_SENTINEL
+    from opik_mcp.analytics.environment import _reset_detector_caches_for_tests
     from opik_mcp.analytics.wrappers import (
         _reset_seen_sessions_for_tests,
         _reset_seen_tools_listed_for_tests,
@@ -50,6 +51,7 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()
     reset_identities_for_tests()
+    _reset_detector_caches_for_tests()
     # main() sets this sentinel so the build_app() lifespan skips its own emit.
     # Clear it between tests or a test that calls main() leaves the build_app()
     # lifespan (e.g. the session http_client fixture) permanently muted.

--- a/tests/test_account_identity.py
+++ b/tests/test_account_identity.py
@@ -11,10 +11,12 @@ read or written.
 from __future__ import annotations
 
 import json
+import threading
 import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import httpx
 import pytest
@@ -26,7 +28,11 @@ from opik_mcp.account_identity import (
     resolve_api_key_identity,
 )
 from opik_mcp.config import Settings
-from opik_mcp.credential_identity import credential_digest, reset_identities_for_tests
+from opik_mcp.credential_identity import (
+    credential_digest,
+    lookup_identity,
+    reset_identities_for_tests,
+)
 
 API_KEY = "sk-test-key"
 ACCOUNT_URL = "https://www.comet.com/api/rest/v2/account-details"
@@ -323,3 +329,39 @@ def test_the_disk_cache_is_read_once_not_once_per_event(
     for _ in range(10):
         assert resolve_api_key_identity(settings) is not None
     assert len(reads) == 1, f"disk was read {len(reads)} times"
+
+
+# --- a refresh must not outlive the test that started it ------------------- #
+
+
+@respx.mock
+def test_a_reset_waits_for_an_in_flight_refresh(_fresh_home: Path) -> None:
+    """Otherwise one test's identity leaks into the next.
+
+    A refresh runs on a daemon thread and ends by assigning ``_DISK_CACHE``. If
+    a reset only clears state, a thread still in flight lands afterwards and
+    resurrects it — and the next test, whose own HOME is empty, reads the
+    previous test's user out of memory. That is a cross-test failure whose
+    symptom appears in an unrelated test, so it is asserted here directly.
+    """
+    import opik_mcp.account_identity as mod
+
+    released = threading.Event()
+
+    def blocking_fetch(url: str, api_key: str) -> tuple[str | None, str | None]:
+        released.wait(timeout=5.0)
+        return ("leaked-user", "leaked-ws")
+
+    with mock.patch.object(mod, "_fetch", blocking_fetch):
+        assert resolve_api_key_identity(_cloud_settings()) is None
+        # The refresh is now parked inside _fetch. Let it proceed and reset
+        # concurrently: the reset must not return until the thread is done.
+        released.set()
+        reset_account_identity_for_tests()
+
+        assert mod._DISK_CACHE is None, "a refresh landed after the reset cleared the cache"
+        assert not [t for t in mod._REFRESH_THREADS if t.is_alive()]
+
+    # And the identity that refresh resolved must not survive into a fresh look.
+    reset_identities_for_tests()
+    assert lookup_identity(API_KEY) is None, "leaked identity survived the reset"

--- a/tests/test_analytics_call_context.py
+++ b/tests/test_analytics_call_context.py
@@ -32,8 +32,13 @@ CONTEXT_KEYS = {
     "is_container",
     "launch_method",
     "install_id_freshly_generated",
+    # Frozen pair.
     "mcp_host",
     "host_llm_family",
+    # Additive pair — shipped alongside so BI can migrate without either
+    # series breaking.
+    "mcp_client",
+    "client_llm_family",
 }
 
 ENV_KEYS = {"is_ci", "is_container", "launch_method", "install_id_freshly_generated"}
@@ -107,13 +112,20 @@ def test_call_context_props_buckets_known_host() -> None:
     assert set(props) == CONTEXT_KEYS
     assert props["mcp_host"] == "claude-code"
     assert props["host_llm_family"] == "anthropic"
+    # A name the frozen classifier already handled resolves identically on both.
+    assert props["mcp_client"] == "claude-code"
+    assert props["client_llm_family"] == "anthropic"
 
 
 def test_call_context_props_handles_none_session() -> None:
     props = call_context_props(None)
     assert set(props) == CONTEXT_KEYS
+    # `mcp_host` is frozen: an absent handshake folds into "other", as it
+    # always has. The additive `mcp_client` is what separates the two cases.
     assert props["mcp_host"] == "other"
     assert props["host_llm_family"] == "unknown"
+    assert props["mcp_client"] == "absent"
+    assert props["client_llm_family"] == "unknown"
 
 
 def test_call_context_props_unknown_host_buckets_to_other() -> None:
@@ -181,5 +193,7 @@ async def test_tool_called_context_defaults_without_ctx(recorder: _Recorder) -> 
 
     props = next(p for et, p in recorder.events if et == EVENT_TOOL_CALLED)
     assert set(props) >= CONTEXT_KEYS
+    # No ctx -> no session. Frozen field folds to "other"; the new one says so.
     assert props["mcp_host"] == "other"
     assert props["host_llm_family"] == "unknown"
+    assert props["mcp_client"] == "absent"

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -339,3 +339,21 @@ def test_blank_session_header_omits_the_field(make_client: Any) -> None:
     with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}", mcp_session_id="   "):
         event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
     assert "mcp_session_sha256" not in event["event_properties"]
+
+
+def test_env_id_is_stamped_and_hashed(make_client: Any) -> None:
+    """The machine digest and its kind reach every event.
+
+    ``env_id_kind`` is ALWAYS stamped so "could not read one" is countable; the
+    digest is omitted when there is none, because a placeholder would be counted
+    as a real machine.
+    """
+    client = make_client()
+    with _inbound():
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    props = event["event_properties"]
+    assert props["env_id_kind"] in {"machine", "unknown"}
+    if props["env_id_kind"] == "machine":
+        assert len(props["env_id_sha256"]) == 64
+    else:
+        assert "env_id_sha256" not in props

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -24,6 +24,7 @@ from opik_mcp.analytics.client import AnalyticsClient
 from opik_mcp.auth_context import (
     OAUTH_ACCESS_TOKEN_PREFIX,
     inbound_authorization,
+    inbound_mcp_session_id,
     inbound_workspace,
 )
 from opik_mcp.config import Settings
@@ -59,14 +60,21 @@ def make_client() -> Iterator[Any]:
 
 
 @contextlib.contextmanager
-def _inbound(*, auth: str | None = None, workspace: str | None = None) -> Iterator[None]:
+def _inbound(
+    *,
+    auth: str | None = None,
+    workspace: str | None = None,
+    mcp_session_id: str | None = None,
+) -> Iterator[None]:
     a = inbound_authorization.set(auth)
     w = inbound_workspace.set(workspace)
+    s = inbound_mcp_session_id.set(mcp_session_id)
     try:
         yield
     finally:
         inbound_authorization.reset(a)
         inbound_workspace.reset(w)
+        inbound_mcp_session_id.reset(s)
 
 
 def test_oauth_token_sha256_hashed_not_raw(make_client: Any) -> None:
@@ -256,3 +264,78 @@ def test_unresolved_caller_reports_the_install_id_not_an_empty_field(
     event = client._build_event("opik_mcp_tool_called", {})
     assert event["user_id"]
     assert event["event_properties"]["user_id_kind"] == "install_id"
+
+
+# --- mcp_session_sha256: the stable unit the hosted funnel needs ----------- #
+#
+# Keyed on token_sha256, every hosted ratio was inversely correlated with usage:
+# the OAuth access token lives one hour, a handshake recurs on every mint, a tool
+# call does not. So an 8-hour session minted ~8 "authorized + connected" pairs and
+# usually one "invoked" — the harder someone worked, the worse they scored. The
+# session id survives token refreshes, so it counts that session ONCE.
+
+RAW_MCP_SESSION_ID = "3f9a1c77-session-canary-0b42"
+
+
+def test_mcp_session_sha256_hashed_not_raw(make_client: Any) -> None:
+    """PRIVACY: the raw session id must never leave the process.
+
+    Hashed rather than emitted plainly because possession of a session id plus a
+    token addresses a live session, which makes it bearer-equivalent.
+    """
+    client = make_client()
+    with _inbound(
+        auth=f"Bearer {RAW_OAUTH_TOKEN}",
+        mcp_session_id=RAW_MCP_SESSION_ID,
+    ):
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    props = event["event_properties"]
+    assert RAW_MCP_SESSION_ID not in json.dumps(event)
+    assert (
+        props["mcp_session_sha256"]
+        == hashlib.sha256(RAW_MCP_SESSION_ID.encode("utf-8")).hexdigest()
+    )
+
+
+def test_mcp_session_digest_is_stable_across_token_rotation(make_client: Any) -> None:
+    """THE WHOLE POINT: one session, two tokens, one session identity.
+
+    This is what makes a hosted funnel possible. Under token-keyed counting these
+    two events look like two separate users; under session-keyed counting they are
+    correctly one.
+    """
+    client = make_client()
+    with _inbound(auth="Bearer opik_mcp_at_first", mcp_session_id=RAW_MCP_SESSION_ID):
+        first = client._build_event("opik_mcp_tools_listed", {})
+    with _inbound(
+        auth="Bearer opik_mcp_at_second_after_refresh", mcp_session_id=RAW_MCP_SESSION_ID
+    ):
+        second = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+
+    # Different tokens...
+    assert first["event_properties"]["token_sha256"] != second["event_properties"]["token_sha256"]
+    # ...same session.
+    assert (
+        first["event_properties"]["mcp_session_sha256"]
+        == second["event_properties"]["mcp_session_sha256"]
+    )
+
+
+def test_no_session_header_omits_the_field(make_client: Any) -> None:
+    """stdio, and the initialize request itself, carry no session id.
+
+    Absent rather than a sentinel: a placeholder would be counted as a real
+    session, which is the same mistake the nil install_id makes.
+    """
+    client = make_client()
+    with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}"):
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    assert "mcp_session_sha256" not in event["event_properties"]
+
+
+def test_blank_session_header_omits_the_field(make_client: Any) -> None:
+    """A whitespace-only header is not a session."""
+    client = make_client()
+    with _inbound(auth=f"Bearer {RAW_OAUTH_TOKEN}", mcp_session_id="   "):
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    assert "mcp_session_sha256" not in event["event_properties"]

--- a/tests/test_analytics_environment.py
+++ b/tests/test_analytics_environment.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from opik_mcp.analytics import environment as env
+from opik_mcp.credential_identity import credential_digest
 
 
 def _clear_env(monkeypatch: pytest.MonkeyPatch, names: list[str]) -> None:
@@ -515,3 +516,65 @@ def test_posix_launch_method_is_unaffected_by_the_windows_table(
     ):
         monkeypatch.setattr(sys, "executable", windows_only)
         assert env._detect_launch_method() == "unknown", windows_only
+
+
+# --- env_id: machine identity that survives a wiped HOME ------------------ #
+
+
+def test_env_id_hashes_the_machine_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PRIVACY: the raw machine id must never be emitted, only its digest."""
+    canary = "machine-id-canary-7f3a-do-not-emit"
+    monkeypatch.setattr(env, "_read_machine_id", lambda: canary)
+    env._detect_env_id.cache_clear()
+    digest, kind = env.env_id()
+    assert kind == "machine"
+    assert digest == credential_digest(canary)
+    assert canary not in digest
+    env._detect_env_id.cache_clear()
+
+
+def test_env_id_emits_nothing_when_unreadable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Absent, not a placeholder.
+
+    A sentinel would be counted as a real machine — the exact mistake the nil
+    ``install_id`` makes, where every unwritable-HOME deployment merges into one
+    row. "unknown" with no digest keeps the gap countable instead.
+    """
+    monkeypatch.setattr(env, "_read_machine_id", lambda: "")
+    env._detect_env_id.cache_clear()
+    digest, kind = env.env_id()
+    assert (digest, kind) == ("", "unknown")
+    env._detect_env_id.cache_clear()
+
+
+def test_env_id_ignores_whitespace_only_machine_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(env, "_read_machine_id", lambda: "   \n")
+    env._detect_env_id.cache_clear()
+    assert env.env_id() == ("", "unknown")
+    env._detect_env_id.cache_clear()
+
+
+def test_env_id_is_memoised(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One subprocess per process — this runs on the startup path on macOS."""
+    calls: list[int] = []
+
+    def _counting() -> str:
+        calls.append(1)
+        return "stable-machine-id"
+
+    monkeypatch.setattr(env, "_read_machine_id", _counting)
+    env._detect_env_id.cache_clear()
+    first = env.env_id()
+    second = env.env_id()
+    assert first == second
+    assert len(calls) == 1
+    env._detect_env_id.cache_clear()
+
+
+def test_read_machine_id_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every platform branch is best-effort; telemetry must not break a boot."""
+    monkeypatch.setattr(env, "_PLATFORM", "linux")
+    monkeypatch.setattr(env, "_MACHINE_ID_PATHS", ("/nonexistent/machine-id",))
+    assert env._read_machine_id() == ""
+    monkeypatch.setattr(env, "_PLATFORM", "sunos")  # unknown platform
+    assert env._read_machine_id() == ""

--- a/tests/test_analytics_environment.py
+++ b/tests/test_analytics_environment.py
@@ -256,6 +256,8 @@ def test_collect_environment_fingerprint_keys_and_value_shape(
         "is_gitpod",
         "launch_method",
         "parent_process",
+        "host_process",
+        "launcher",
         "stdin_is_pipe",
         "stdout_is_pipe",
     }
@@ -281,3 +283,235 @@ def test_collect_environment_fingerprint_never_raises(monkeypatch: pytest.Monkey
     out = env.collect_environment_fingerprint()
     assert isinstance(out, dict)
     assert out.get("parent_process") == "unknown"  # graceful default
+
+
+# --- frozen `parent_process` ---------------------------------------------- #
+#
+# `parent_process` is a long-lived BI field. Its two blind spots (the uvx runner
+# and Windows) are fixed ADDITIVELY via `host_process`, never in place, so every
+# dashboard built on it keeps reporting the same thing.
+
+
+def test_parent_process_stays_other_for_uv_launcher() -> None:
+    """FROZEN: the runner must NOT be recognised by the parent classifier."""
+    assert env._classify_parent_process_name("uv") == "other"
+    assert env._classify_parent_process_name("/Users/alice/.local/bin/uv") == "other"
+
+
+def test_parent_process_reader_stays_posix_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FROZEN: Windows must keep reporting "other".
+
+    `_read_process_name` gained Windows support, but routing `parent_process`
+    through it would start populating a field that has only ever been "other" on
+    that platform — silently changing a live series.
+    """
+    monkeypatch.setattr(env, "_PLATFORM", "win32")
+    monkeypatch.setattr(env, "_read_process_name", lambda _pid: "Claude.exe")
+    assert env._read_parent_process_name() == ""
+    assert env._detect_parent_process() == "other"
+
+
+# --- additive `host_process` + `launcher` --------------------------------- #
+#
+# `uvx` is the install path our own README recommends, and it made the MCP host
+# unidentifiable: uv spawns the interpreter, so uv is our parent and the host is
+# our grandparent. In the 30-day fleet window that made `Darwin | uvx | other`
+# the single largest row — 32,168 starts across 157 installs, host unknown.
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("uv", "uv"),
+        ("uvx", "uv"),
+        ("/Users/alice/.local/bin/uv", "uv"),
+        ("uv.exe", "uv"),
+        (r"C:\Users\alice\AppData\Local\uv\uv.exe", "uv"),
+        # NEGATIVE CASES — why launchers are matched exactly, on the basename.
+        # "uv" is two characters and the fallback pass matches substrings against
+        # the full command, which on macOS is an absolute path: a substring rule
+        # would classify a user named "luv" and every uvicorn process as uv.
+        ("uvicorn", "other"),
+        ("/Users/luv/projects/app/.venv/bin/python", "python"),
+        ("/opt/uvloop-bench/bin/node", "node"),
+    ],
+)
+def test_classify_ancestor_name_launcher_is_exact_basename_match(raw: str, expected: str) -> None:
+    assert env._classify_ancestor_name(raw) == expected
+
+
+def test_classify_ancestor_name_keeps_full_path_for_host_match() -> None:
+    """The fallback pass must match the FULL value, not the basename.
+
+    macOS app bundles name their helper binary generically, so the identifying
+    token lives in a parent directory. Basenaming before the substring pass
+    would silently regress Cursor to "other".
+    """
+    assert (
+        env._classify_ancestor_name("/Applications/Cursor.app/Contents/MacOS/Electron") == "cursor"
+    )
+
+
+def test_detect_host_process_walks_through_uv_to_the_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The point of the new field: report who launched us, not the runner."""
+    monkeypatch.setattr(env, "_read_ancestor_parent_name", lambda: "uv")
+    monkeypatch.setattr(env, "_read_parent_pid", lambda _pid: 4242)
+    monkeypatch.setattr(env, "_read_process_name", lambda _pid: "Claude Helper (Renderer)")
+    assert env._detect_host_process() == "claude"
+
+
+def test_detect_host_process_keeps_uv_when_grandparent_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows can't resolve a ppid dependency-free — degrade to the launcher.
+
+    "uv" is still strictly more than the "other" `parent_process` reports here.
+    """
+    monkeypatch.setattr(env, "_read_ancestor_parent_name", lambda: "uv")
+    monkeypatch.setattr(env, "_read_parent_pid", lambda _pid: None)
+    assert env._detect_host_process() == "uv"
+
+
+def test_detect_host_process_keeps_uv_when_grandparent_unrecognised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrecognised ancestor is less informative than the known launcher."""
+    monkeypatch.setattr(env, "_read_ancestor_parent_name", lambda: "uv")
+    monkeypatch.setattr(env, "_read_parent_pid", lambda _pid: 4242)
+    monkeypatch.setattr(env, "_read_process_name", lambda _pid: "totally-unknown-binary")
+    assert env._detect_host_process() == "uv"
+
+
+def test_detect_host_process_does_not_read_grandparent_for_real_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No extra subprocess when the parent already identifies the host."""
+
+    def _never(_pid: int) -> int | None:
+        raise AssertionError("grandparent must not be read for a non-launcher parent")
+
+    monkeypatch.setattr(env, "_read_ancestor_parent_name", lambda: "claude")
+    monkeypatch.setattr(env, "_read_parent_pid", _never)
+    assert env._detect_host_process() == "claude"
+
+
+def test_host_process_sees_windows_parent_where_parent_process_cannot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The additive field is the one that fixes the Windows blind spot."""
+    monkeypatch.setattr(env, "_PLATFORM", "win32")
+    monkeypatch.setattr(env, "_read_process_name", lambda _pid: "Cursor.exe")
+    env._read_ancestor_parent_name.cache_clear()
+    assert env._detect_host_process() == "cursor"
+    assert env._detect_parent_process() == "other"  # frozen field unaffected
+    env._read_ancestor_parent_name.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "parent, expected",
+    [
+        ("uv", "uv"),
+        ("uvx", "uv"),
+        ("/Users/alice/.local/bin/uv", "uv"),
+        ("claude", "none"),
+        ("totally-unknown-binary", "none"),
+        ("", "none"),
+    ],
+)
+def test_detect_launcher(monkeypatch: pytest.MonkeyPatch, parent: str, expected: str) -> None:
+    """`launcher` keeps the uvx install path countable after `host_process`
+    folds it away in favour of the host."""
+    monkeypatch.setattr(env, "_read_ancestor_parent_name", lambda: parent)
+    assert env._detect_launcher() == expected
+
+
+def test_read_ancestor_parent_name_is_memoised(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One `ps`/`tasklist` per process, not one per consumer.
+
+    `_detect_host_process`, `_detect_launcher` and `parent_process` all read it,
+    and on macOS each uncached read is a subprocess on the startup path.
+    """
+    calls: list[int] = []
+
+    def _counting(pid: int) -> str:
+        calls.append(pid)
+        return "claude"
+
+    monkeypatch.setattr(env, "_PLATFORM", "darwin")
+    monkeypatch.setattr(env, "_read_process_name", _counting)
+    env._read_ancestor_parent_name.cache_clear()
+    assert env._read_ancestor_parent_name() == "claude"
+    assert env._read_ancestor_parent_name() == "claude"
+    assert env._read_parent_process_name() == "claude"  # shares the same cache
+    assert len(calls) == 1
+    env._read_ancestor_parent_name.cache_clear()
+
+
+# --- Windows launch method ------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "executable, expected",
+    [
+        # uv's tool cache on Windows is %LOCALAPPDATA%\uv\cache, not ~/.local/share.
+        (r"C:\Users\alice\AppData\Local\uv\cache\archive-v0\ab12\Scripts\python.exe", "uvx"),
+        (r"C:\Users\alice\AppData\Local\pipx\pipx\venvs\opik-mcp\Scripts\python.exe", "pipx"),
+        (r"C:\dev\opik-mcp\.venv\Scripts\python.exe", "venv"),
+        (r"C:\Program Files\Python313\python.exe", "system"),
+        (r"C:\Users\alice\AppData\Local\Programs\Python\Python313\python.exe", "system"),
+        (r"C:\Users\alice\AppData\Local\Microsoft\WindowsApps\python.exe", "system"),
+        # Still bucketed, never echoed.
+        (r"C:\weird\custom-build-canary-4f2a\python.exe", "unknown"),
+    ],
+)
+def test_detect_launch_method_windows_paths(
+    monkeypatch: pytest.MonkeyPatch, executable: str, expected: str
+) -> None:
+    """Windows reported launch_method="unknown" unconditionally before the
+    separator fold — every pattern in the table was POSIX-shaped. That left
+    6,645 starts of the 30-day fleet dark for this field.
+
+    This is a coverage fix, not a redefinition: the field still means "bucketed
+    sys.executable", it just no longer returns a constant on one platform.
+    """
+    monkeypatch.setattr(env, "_PLATFORM", "win32")
+    monkeypatch.setattr(sys, "executable", executable)
+    assert env._detect_launch_method() == expected
+
+
+def test_detect_launch_method_windows_never_echoes_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "_PLATFORM", "win32")
+    monkeypatch.setattr(sys, "executable", r"C:\Users\secret-canary-9b2a\odd\python.exe")
+    result = env._detect_launch_method()
+    assert result == "unknown"
+    assert "secret-canary-9b2a" not in result
+
+
+def test_fingerprint_new_fields_are_allowlisted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(env, "_PLATFORM", "linux")
+    out = env.collect_environment_fingerprint()
+    assert out["launcher"] in {"uv", "none", "unknown"}
+    assert isinstance(out["host_process"], str) and out["host_process"]
+
+
+def test_posix_launch_method_is_unaffected_by_the_windows_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Windows table must never reclassify a POSIX path.
+
+    Guards the promise that fixing Windows moved no existing series: a path that
+    only a Windows-only pattern would match must still report "unknown" on
+    POSIX, where the frozen table alone applies.
+    """
+    monkeypatch.setattr(env, "_PLATFORM", "linux")
+    for windows_only in (
+        "/home/alice/.cache/uv/cache/x/bin/python",
+        "/home/alice/program files/python/bin/python",
+        "/home/alice/windowsapps/python",
+    ):
+        monkeypatch.setattr(sys, "executable", windows_only)
+        assert env._detect_launch_method() == "unknown", windows_only

--- a/tests/test_analytics_events.py
+++ b/tests/test_analytics_events.py
@@ -244,3 +244,115 @@ def test_user_id_kind_literal_has_no_dead_members() -> None:
         AnalyticsClient._resolve_user(None).kind,
     }
     assert produced == set(get_args(UserIdKind))
+
+
+def test_parent_process_literal_matches_the_frozen_classifier() -> None:
+    """Bidirectional sync between ParentProcess and the FROZEN classifier.
+
+    mypy stops the classifier returning something the Literal doesn't declare.
+    What it cannot see is the other direction: a member left behind after a rule
+    changes, which BI would then wait for forever.
+
+    Also pins the freeze: "uv" must NOT be reachable here. The launcher is only
+    recognised by the additive ancestor classifier, so `parent_process` keeps
+    reporting "other" for a uvx-launched process exactly as it always has.
+    """
+    from typing import get_args
+
+    from opik_mcp.analytics.environment import (
+        _EXACT_PARENT_PATTERNS,
+        _PARENT_PROCESS_PATTERNS,
+        _classify_parent_process_name,
+    )
+    from opik_mcp.analytics.events import ParentProcess
+
+    declared = set(get_args(ParentProcess))
+    produced = {_classify_parent_process_name(p) for p, _bucket in _PARENT_PROCESS_PATTERNS}
+    produced.add(_classify_parent_process_name(""))  # no parent -> fallback
+    produced.add(_classify_parent_process_name("totally-unrecognized-binary"))
+
+    assert produced == declared, (
+        f"ParentProcess drift: unreachable={sorted(declared - produced)} "
+        f"undeclared={sorted(produced - declared)}"
+    )
+    assert "uv" not in declared, "parent_process is frozen; the runner belongs to host_process"
+    for launcher_pattern in _EXACT_PARENT_PATTERNS:
+        assert _classify_parent_process_name(launcher_pattern) == "other"
+
+
+def test_host_process_literal_matches_the_ancestor_classifier() -> None:
+    """Same bidirectional contract for the additive ``host_process`` field.
+
+    It must declare everything ParentProcess does (it shares the vocabulary)
+    plus the launcher bucket that is the whole point of the new field.
+    """
+    from typing import get_args
+
+    from opik_mcp.analytics.environment import (
+        _EXACT_PARENT_PATTERNS,
+        _PARENT_PROCESS_PATTERNS,
+        _classify_ancestor_name,
+    )
+    from opik_mcp.analytics.events import HostProcess, ParentProcess
+
+    declared = set(get_args(HostProcess))
+    produced = {_classify_ancestor_name(p) for p, _bucket in _PARENT_PROCESS_PATTERNS}
+    produced |= {_classify_ancestor_name(p) for p in _EXACT_PARENT_PATTERNS}
+    produced.add(_classify_ancestor_name(""))
+    produced.add(_classify_ancestor_name("totally-unrecognized-binary"))
+
+    assert produced == declared, (
+        f"HostProcess drift: unreachable={sorted(declared - produced)} "
+        f"undeclared={sorted(produced - declared)}"
+    )
+    assert set(get_args(ParentProcess)) < declared, (
+        "host_process must be a strict superset of parent_process's vocabulary"
+    )
+
+
+def test_launcher_literal_matches_detector_outputs() -> None:
+    """Every value `_detect_launcher` can emit must be declared, plus the
+    `_safe` fallback the aggregator substitutes if the detector raises."""
+    from typing import get_args
+
+    from opik_mcp.analytics.environment import _LAUNCHER_BUCKETS
+    from opik_mcp.analytics.events import Launcher
+
+    declared = set(get_args(Launcher))
+    # "none" = no runner involved; "unknown" = detector raised (see `_safe`).
+    expected = set(_LAUNCHER_BUCKETS) | {"none", "unknown"}
+    assert declared == expected, (
+        f"Launcher drift: unreachable={sorted(declared - expected)} "
+        f"undeclared={sorted(expected - declared)}"
+    )
+
+
+def test_mcp_client_literal_matches_its_classifier() -> None:
+    """``McpClient`` must cover the additive classifier, and must declare the
+    two buckets the frozen ``McpHost`` cannot reach.
+
+    ``claude-desktop`` was dead under the frozen classifier (Claude Desktop
+    sends "claude-ai") and ``absent`` does not exist there at all.
+    """
+    from typing import get_args
+
+    from opik_mcp.analytics.events import McpClient, McpHost
+    from opik_mcp.analytics.mcp_client_info import (
+        _MCP_CLIENT_PATTERNS,
+        classify_mcp_client,
+        classify_mcp_host,
+    )
+
+    declared = set(get_args(McpClient))
+    produced = {classify_mcp_client(p) for p, _bucket in _MCP_CLIENT_PATTERNS}
+    produced.add(classify_mcp_client(""))  # -> "absent"
+    produced.add(classify_mcp_client("totally-unrecognized-client"))  # -> "other"
+
+    assert produced == declared, (
+        f"McpClient drift: unreachable={sorted(declared - produced)} "
+        f"undeclared={sorted(produced - declared)}"
+    )
+    assert "absent" in declared and "absent" not in set(get_args(McpHost))
+    # The alias that makes the dead bucket reachable, pinned end to end.
+    assert classify_mcp_client("claude-ai") == "claude-desktop"
+    assert classify_mcp_host("claude-ai") == "other"

--- a/tests/test_analytics_events.py
+++ b/tests/test_analytics_events.py
@@ -356,3 +356,33 @@ def test_mcp_client_literal_matches_its_classifier() -> None:
     # The alias that makes the dead bucket reachable, pinned end to end.
     assert classify_mcp_client("claude-ai") == "claude-desktop"
     assert classify_mcp_host("claude-ai") == "other"
+
+
+def test_env_id_kind_literal_matches_the_detector(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bidirectional sync for ``env_id_kind``.
+
+    Only two outcomes exist by design: a real machine id was read, or none was
+    and NO digest is emitted. There is deliberately no third "unstable" bucket —
+    a hostname fallback would churn per container run while looking
+    authoritative, which is the failure mode the nil ``install_id`` already
+    demonstrates.
+    """
+    from typing import get_args
+
+    from opik_mcp.analytics import environment as env
+    from opik_mcp.analytics.events import EnvIdKind
+
+    declared = set(get_args(EnvIdKind))
+    assert declared == {"machine", "unknown"}
+
+    monkeypatch.setattr(env, "_read_machine_id", lambda: "a-machine-id")
+    env._detect_env_id.cache_clear()
+    digest_present, kind_present = env.env_id()
+
+    monkeypatch.setattr(env, "_read_machine_id", lambda: "")
+    env._detect_env_id.cache_clear()
+    digest_absent, kind_absent = env.env_id()
+    env._detect_env_id.cache_clear()
+
+    assert {kind_present, kind_absent} == declared
+    assert digest_present and not digest_absent

--- a/tests/test_analytics_tools_listed.py
+++ b/tests/test_analytics_tools_listed.py
@@ -124,6 +124,7 @@ async def test_tools_listed_props_shape(recorder: _Recorder) -> None:
     # env keys are always present.
     assert props["mcp_host"] == "other"
     assert props["host_llm_family"] == "unknown"
+    assert props["mcp_client"] == "absent"
     for key in ("is_ci", "is_container", "launch_method", "install_id_freshly_generated"):
         assert key in props, f"call_context_props key {key!r} missing from tools_listed"
 

--- a/tests/test_analytics_wrappers.py
+++ b/tests/test_analytics_wrappers.py
@@ -16,6 +16,7 @@ from opik_mcp.analytics import (
 )
 from opik_mcp.analytics.mcp_client_info import (
     classify_host_llm_family,
+    classify_mcp_client,
     classify_mcp_host,
     collect_session_props,
 )
@@ -272,11 +273,60 @@ def _reset_probe_and_sessions() -> Iterator[None]:
         ("gemini-cli", "gemini-cli"),
         ("Gemini-CLI/0.1", "gemini-cli"),
         ("acme-internal-wrapper-yaro", "other"),
-        ("", "other"),
+        ("", "other"),  # frozen: absent folds into "other" (see mcp_client)
+        # FROZEN: the real client names below are deliberately NOT recognised
+        # here. Fixing them in place would move volume out of the heavily-used
+        # "other" bucket and shift every trend built on it, so the corrections
+        # live on `classify_mcp_client` instead.
+        ("claude-ai", "other"),
+        ("Visual Studio Code", "other"),
     ],
 )
 def test_classify_mcp_host(raw: str, expected_bucket: str) -> None:
     assert classify_mcp_host(raw) == expected_bucket
+
+
+@pytest.mark.parametrize(
+    "raw, expected_bucket",
+    [
+        # The two aliases that make previously-dead buckets reachable. Claude
+        # Desktop reports itself as "claude-ai": under the frozen classifier
+        # `claude-desktop` recorded ZERO events across a 30-day fleet window
+        # while real Claude Desktop users were counted as "other".
+        ("claude-ai", "claude-desktop"),
+        ("Claude-AI", "claude-desktop"),
+        ("claude-ai/0.7.1", "claude-desktop"),
+        # VS Code sends the product name with spaces, which no "vscode" prefix
+        # ever matched.
+        ("Visual Studio Code", "vscode"),
+        ("Visual Studio Code - Insiders", "vscode"),
+        # Everything the frozen classifier already got right must agree.
+        ("claude-desktop", "claude-desktop"),
+        ("claude-code/0.42", "claude-code"),
+        ("cursor", "cursor"),
+        ("roo-cline", "roo"),
+        ("codex-cli/0.3", "codex"),
+        ("Gemini-CLI/0.1", "gemini-cli"),
+        ("acme-internal-wrapper-yaro", "other"),
+    ],
+)
+def test_classify_mcp_client(raw: str, expected_bucket: str) -> None:
+    assert classify_mcp_client(raw) == expected_bucket
+
+
+def test_classify_mcp_client_separates_absent_from_other() -> None:
+    """ "absent" (never learned who) and "other" (named, unrecognised) are
+    different facts and must not collapse.
+
+    They share one bucket on the frozen ``mcp_host`` field, which made the
+    largest cohort in the fleet — 838 installs — unreadable: an instrumentation
+    gap looked identical to genuine long-tail client diversity.
+    """
+    assert classify_mcp_client("") == "absent"
+    assert classify_mcp_client("   ") == "absent"
+    assert classify_mcp_client("some-client-we-have-never-seen") == "other"
+    # The frozen field still merges them — that is the wart being worked around.
+    assert classify_mcp_host("") == classify_mcp_host("some-client-never-seen")
 
 
 @pytest.mark.parametrize(
@@ -306,7 +356,11 @@ def test_classify_host_llm_family(bucket: str, family: str) -> None:
 
 
 _EXPECTED_DEFAULT_SESSION_PROPS: dict[str, str] = {
+    # Frozen field: absent handshake folds into "other".
     "mcp_host": "other",
+    # Additive field: absent handshake is countable as its own value.
+    "mcp_client": "absent",
+    "client_llm_family": "unknown",
     "mcp_client_version": "unknown",
     "mcp_protocol_version": "unknown",
     "host_llm_family": "unknown",

--- a/tests/test_ask_ollie_analytics.py
+++ b/tests/test_ask_ollie_analytics.py
@@ -180,6 +180,7 @@ async def test_completed_carries_session_context(recorder: _Recorder) -> None:
     # No ctx passed by _run_with → host fields fall back to defaults.
     assert p["mcp_host"] == "other"
     assert p["host_llm_family"] == "unknown"
+    assert p["mcp_client"] == "absent"
 
 
 @pytest.mark.anyio

--- a/tests/test_audit_analytics.py
+++ b/tests/test_audit_analytics.py
@@ -149,4 +149,5 @@ def test_write_auto_approval_falls_back_when_session_missing(
 
     _, props = next((et, p) for et, p in recorder.events if et == EVENT_AUTO_APPROVAL)
     assert props["mcp_host"] == "other"
+    assert props["mcp_client"] == "absent"
     assert props["host_llm_family"] == "unknown"


### PR DESCRIPTION
## Problem

**~88% of server starts (45,433 of 51,794 over 30 days) report `parent_process="other"`** — we cannot tell which MCP client connected. Both causes are instrumentation, not user behaviour:

| Cause | Starts |
|---|---|
| `uvx` (the install path our README recommends) spawns the interpreter, so `uv` is our parent and the host is our *grand*parent — never read | 38,234 |
| `_read_parent_process_name` branched only on linux/darwin, so Windows reported `other` unconditionally | 6,645 |
| Genuinely unrecognised ancestors | 554 |

`launch_method` was also always `unknown` on Windows: every pattern in its table needs a forward slash, and a Windows path has none.

Separately: the **`claude-desktop` bucket recorded zero events in 30 days** — Claude Desktop identifies itself as `claude-ai`, matching no pattern — and an absent `clientInfo` shared the `other` bucket with genuinely unrecognised clients, making the largest cohort in the fleet (838 installs) unreadable.

Full investigation: OPIK-7615.

## Approach: strictly additive

Existing fields keep their **exact** semantics and value sets, so no dashboard, trend or saved query moves.

**Frozen, with tests pinning the freeze:**
- `parent_process` — still the immediate parent, POSIX-only reader. A `uvx` process still reports `other`.
- `mcp_host` — still folds an absent `clientInfo` into `other`, and does **not** learn the new aliases. The parametrised test asserts `("claude-ai", "other")` so a future in-place "fix" fails CI.
- `launch_method` — split into a frozen POSIX table and a Windows table consulted **only** under `win32`. This makes the POSIX result *provably* unchanged rather than probably unchanged (`test_posix_launch_method_is_unaffected_by_the_windows_table`).

**New fields carry the improvement:**

| Field | Purpose |
|---|---|
| `host_process` | Nearest ancestor identifying the host — steps over `uv`, works on Windows |
| `launcher` | `uv` / `none`, so the uvx path stays countable after `host_process` folds it away |
| `mcp_client` | Canonical client bucket; recognises `claude-ai` and `Visual Studio Code`, separates `absent` from `other` |
| `client_llm_family` | Family derived from `mcp_client` |

## Two details worth reviewing

**Launcher matching is exact, on the basename.** `uv` is two characters and the fallback pass matches substrings against the full command — which on macOS is an absolute path. A substring rule would classify every `uvicorn` process, and any user named `luv`, as the uv launcher. Negative tests cover both.

**The fallback pass deliberately keeps the full path.** macOS app bundles name their helper binary generically, so Cursor is only identifiable as `.../Cursor.app/Contents/MacOS/Electron`. Basenaming before that pass would silently regress it to `other`.

## Verification

- **No saved insight** in the PostHog project references `parent_process`, `launch_method` or `host_llm_family`. The seven referencing `mcp_host` are unaffected, since its behaviour is unchanged.
- **New properties reach Segment**: `SegmentApiHelpers.buildPostBodyObjectNode` iterates every `event_properties` entry with no allowlist, so no backend change is needed.
- **52 new tests** (1,269 → 1,321 passing, 2 skipped). Ruff check + format clean. mypy strict at the same 2 pre-existing errors as `main` (byte-identical output).

## Known limitations

- **Nothing is retroactive.** Gains apply only to data emitted once this rolls out; 0.2.12/0.2.13 installs are still live and may never upgrade.
- **The `claude-ai` and `Visual Studio Code` aliases are unverified against our own data** — the raw `clientInfo.name` is bucketed client-side and never reaches BI, so this is based on published client behaviour. If wrong, `mcp_client` is merely as uninformative as `mcp_host`; nothing regresses.
- **Startup cost:** on the uvx path, up to 3 subprocess calls instead of 1 (parent name → parent ppid → grandparent name), roughly +20–40ms on macOS. Given hosts respawn for tool discovery ~23×/install/day, this can be gated to first-start-per-install if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)