### PR TITLE
fix(analytics): make mcp_session_sha256 actually land on hosted events

### DIFF
--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -38,7 +38,11 @@ from opik_mcp.config import (
     installation_type,
     looks_unsubstituted,
 )
-from opik_mcp.credential_identity import ResolvedIdentity, credential_digest
+from opik_mcp.credential_identity import (
+    ResolvedIdentity,
+    credential_digest,
+    lookup_session_digest,
+)
 
 logger = logging.getLogger("opik_mcp.analytics")
 
@@ -412,9 +416,21 @@ class AnalyticsClient:
             # the same treatment as a credential, via the one shared digest.
             # Absent for stdio (no session header) and on the ``initialize``
             # request itself, which is what mints the session.
+            # Two sources, because neither covers the whole surface. The
+            # ContextVar is right for events emitted inside a request (e.g.
+            # auth_rejected), but it reads None in the MCP session task — that
+            # task is forked from `initialize`, before any session id exists, and
+            # the later requests that do carry the header build no events. Tool
+            # events come from that task, so they rely on the credential-keyed
+            # pairing recorded by `remember_session`. Absent for stdio (no
+            # session at all) and on the initialize request itself.
             session_id = inbound_mcp_session_id.get()
             if session_id and session_id.strip():
                 props["mcp_session_sha256"] = credential_digest(session_id.strip())
+            elif inbound_auth:
+                session_digest = lookup_session_digest(inbound_auth)
+                if session_digest:
+                    props["mcp_session_sha256"] = session_digest
         except Exception:
             logger.debug("per-request identity enrichment failed", exc_info=True)
         return props

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -74,6 +74,16 @@ resolved_workspace_name: ContextVar[str | None] = ContextVar(
 #     restart, LRU eviction — events fall back to the nil ``install_id`` and merge
 #     into one row. A session digest still groups that session correctly.
 #
+# NOT SUFFICIENT ON ITS OWN — do not build on this var alone. Tool events are
+# built in the MCP session task, which is forked from the ``initialize`` request
+# and whose context is frozen BEFORE a session id exists; the later requests that
+# do carry ``Mcp-Session-Id`` build no events of their own. So this var reads
+# ``None`` for every tool event, which is why the field silently never appeared
+# in production despite tests that set the var directly. The working path is
+# ``credential_identity.remember_session`` / ``lookup_session_digest``, keyed by
+# the credential — the only value in scope on both sides. This var still serves
+# events emitted inside a request, such as ``auth_rejected``.
+#
 # ``None`` means stdio, or the session-creating request itself (the ``initialize``
 # handshake carries no session id yet).
 inbound_mcp_session_id: ContextVar[str | None] = ContextVar("inbound_mcp_session_id", default=None)

--- a/src/opik_mcp/credential_identity.py
+++ b/src/opik_mcp/credential_identity.py
@@ -94,10 +94,73 @@ def lookup_identity(credential: str) -> ResolvedIdentity | None:
         return identity
 
 
+# Credential digest -> digest of the MCP session id minted on its handshake.
+# Separate map rather than a field on ResolvedIdentity: a session is a different
+# lifetime from an identity (a credential outlives any one session, and an
+# api-key caller has a session but no resolved identity), so merging them would
+# make one nullable for the other's sake.
+_SESSIONS: OrderedDict[str, str] = OrderedDict()
+
+
+def remember_session(credential: str, session_id: str) -> None:
+    """Pair a credential with the MCP session id minted on its handshake.
+
+    Exists because of an asymmetry in the streamable-HTTP lifecycle. The session
+    id is minted in the RESPONSE to ``initialize``, but every event is built
+    inside the MCP session task forked from that same request — and that task's
+    context is frozen before the id exists. So the task can never observe the
+    session id through a ContextVar, no matter which request carries the header:
+    the requests that carry it build no events, and the context that builds
+    events predates it. The credential is the only key present on both sides,
+    which is what makes it the join.
+
+    PRIVACY: the session id is stored HASHED. It is bearer-equivalent — holding
+    it plus a token addresses a live session — so it gets the same treatment as
+    a credential, and a long-lived process never holds one in plaintext.
+
+    KNOWN IMPRECISION: re-initializing on the SAME credential overwrites the
+    pairing, so if an older session is somehow still live it would report the
+    newer digest. Accepted rather than papered over: the alternative needs a
+    session-unique key, and no such key exists in the task that builds events.
+    In practice a re-handshake means the client dropped the old session, and
+    under OAuth the one-hour token TTL means a re-handshake usually arrives on a
+    new credential anyway.
+
+    No-ops on an empty credential or session id, so a caller never has to guard.
+    """
+    if not credential or not session_id:
+        return
+    key = credential_digest(credential)
+    digest = credential_digest(session_id)
+    with _LOCK:
+        _SESSIONS[key] = digest
+        _SESSIONS.move_to_end(key)
+        while len(_SESSIONS) > MAX_TRACKED_CREDENTIALS:
+            _SESSIONS.popitem(last=False)
+
+
+def lookup_session_digest(credential: str) -> str | None:
+    """Hashed MCP session id for this credential, or ``None`` if unknown.
+
+    Already a digest — the caller emits it as-is and never re-hashes.
+    """
+    if not credential:
+        return None
+    key = credential_digest(credential)
+    with _LOCK:
+        digest = _SESSIONS.get(key)
+        if digest is not None:
+            # Reading marks it live, so an in-use session is not evicted in
+            # favour of one that has gone quiet.
+            _SESSIONS.move_to_end(key)
+        return digest
+
+
 def reset_identities_for_tests() -> None:
-    """Drop every resolved identity. Test-only — never call from production."""
+    """Drop every resolved identity and session pairing. Test-only."""
     with _LOCK:
         _STORE.clear()
+        _SESSIONS.clear()
 
 
 __all__ = [
@@ -105,6 +168,8 @@ __all__ = [
     "ResolvedIdentity",
     "credential_digest",
     "lookup_identity",
+    "lookup_session_digest",
     "remember_identity",
+    "remember_session",
     "reset_identities_for_tests",
 ]

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -38,7 +38,7 @@ from opik_mcp.auth_context import (
     settings_auth_mode,
 )
 from opik_mcp.config import MissingConfigError, Settings, get_settings
-from opik_mcp.credential_identity import remember_identity
+from opik_mcp.credential_identity import remember_identity, remember_session
 from opik_mcp.instructions import render_instructions
 from opik_mcp.oauth_identity import resolve_oauth_identity
 from opik_mcp.opik_client import make_opik_client, resolve_opik_config
@@ -705,6 +705,14 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         # across OAuth token refreshes, so an 8-hour session counts once instead of
         # once per hourly token mint.
         session_id_token = inbound_mcp_session_id.set(mcp_session_id)
+        # The ContextVar above is NOT sufficient on its own, and the reason is
+        # subtle enough to be worth stating: events are built in the MCP session
+        # task, which is forked from the `initialize` request and whose context is
+        # therefore frozen BEFORE any session id exists. Requests that do carry
+        # `Mcp-Session-Id` build no events of their own, so the var is read as
+        # `None` for the life of the session. `remember_session` below closes
+        # that gap by keying the id to the credential instead; the ContextVar
+        # still serves events emitted inside a request, such as `auth_rejected`.
         if mcp_session_id is None and auth_mode == "oauth":
             identity = await resolve_oauth_identity(auth, get_settings())
             if identity is not None:
@@ -715,7 +723,15 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
                 if identity.workspace_name:
                     resolved_token = resolved_workspace_name.set(identity.workspace_name)
         try:
-            return await call_next(request)
+            response = await call_next(request)
+            if mcp_session_id is None:
+                # The session-minting request: the id exists only on the way
+                # out. Pair it with the credential now, because this is the one
+                # moment both are in scope together.
+                minted = response.headers.get("mcp-session-id")
+                if minted:
+                    remember_session(auth, minted)
+            return response
         finally:
             inbound_authorization.reset(auth_token)
             inbound_workspace.reset(workspace_token)

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -28,6 +28,7 @@ from opik_mcp.auth_context import (
     inbound_workspace,
 )
 from opik_mcp.config import Settings
+from opik_mcp.credential_identity import credential_digest, remember_session
 
 # Canaries: unique, greppable values that must never appear raw in an event.
 RAW_OAUTH_TOKEN = f"{OAUTH_ACCESS_TOKEN_PREFIX}BEARER-CANARY-TOKEN-UNIQUE-7a3b2c1d"
@@ -357,3 +358,76 @@ def test_env_id_is_stamped_and_hashed(make_client: Any) -> None:
         assert len(props["env_id_sha256"]) == 64
     else:
         assert "env_id_sha256" not in props
+
+
+# --- the session digest must survive the FROZEN session-task context ------- #
+#
+# Every test above sets `mcp_session_id` explicitly, which is why they all passed
+# while the field never once appeared in production. Tool events are not built in
+# a request context: they are built in the MCP session task, forked from
+# `initialize` before any session id exists. So the ContextVar reads None there
+# forever, and the requests that do carry `Mcp-Session-Id` build no events. The
+# tests below pin the path that actually runs in hosted mode.
+
+HANDSHAKE_AUTH = f"Bearer {RAW_OAUTH_TOKEN}"
+
+
+def test_mcp_session_digest_lands_when_the_context_var_is_empty(make_client: Any) -> None:
+    """THE REGRESSION TEST. This is the exact shape of the hosted bug.
+
+    No ContextVar — as in the session task — but the handshake paired the session
+    id to the credential, so the digest must still be stamped. Before the
+    credential-keyed pairing this asserted nothing and the field was inert.
+    """
+    client = make_client()
+    remember_session(HANDSHAKE_AUTH, RAW_MCP_SESSION_ID)
+
+    with _inbound(auth=HANDSHAKE_AUTH, mcp_session_id=None):
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+
+    props = event["event_properties"]
+    assert props["mcp_session_sha256"] == credential_digest(RAW_MCP_SESSION_ID)
+    # PRIVACY holds on this path too: the pairing stores a digest, not the id.
+    assert RAW_MCP_SESSION_ID not in json.dumps(event)
+
+
+def test_mcp_session_digest_is_keyed_to_the_handshake_credential(make_client: Any) -> None:
+    """The pairing is keyed to the credential the session task actually holds.
+
+    A session task's context is frozen at `initialize`, so it presents the
+    HANDSHAKE credential for the session's whole life even after the client
+    refreshes its token. Pairing on that credential is what makes the lookup hit.
+    """
+    client = make_client()
+    remember_session(HANDSHAKE_AUTH, RAW_MCP_SESSION_ID)
+
+    with _inbound(auth=HANDSHAKE_AUTH, mcp_session_id=None):
+        first = client._build_event("opik_mcp_tools_listed", {})
+    with _inbound(auth=HANDSHAKE_AUTH, mcp_session_id=None):
+        second = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+
+    digest = credential_digest(RAW_MCP_SESSION_ID)
+    assert first["event_properties"]["mcp_session_sha256"] == digest
+    assert second["event_properties"]["mcp_session_sha256"] == digest
+
+
+def test_no_session_digest_is_invented_for_stdio(make_client: Any) -> None:
+    """stdio has no session at all — the field must be ABSENT, not guessed.
+
+    Guards the fallback: a credential-keyed lookup that missed must leave the
+    field off rather than stamping something unrelated.
+    """
+    client = make_client()
+    with _inbound(auth=None, mcp_session_id=None):
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    assert "mcp_session_sha256" not in event["event_properties"]
+
+
+def test_an_unpaired_credential_gets_no_session_digest(make_client: Any) -> None:
+    """A credential we never saw handshake must not borrow another's session."""
+    client = make_client()
+    remember_session(HANDSHAKE_AUTH, RAW_MCP_SESSION_ID)
+
+    with _inbound(auth="Bearer opik_mcp_at_someone_else", mcp_session_id=None):
+        event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    assert "mcp_session_sha256" not in event["event_properties"]

--- a/tests/test_credential_identity.py
+++ b/tests/test_credential_identity.py
@@ -20,7 +20,9 @@ from opik_mcp.credential_identity import (
     ResolvedIdentity,
     credential_digest,
     lookup_identity,
+    lookup_session_digest,
     remember_identity,
+    remember_session,
     reset_identities_for_tests,
 )
 
@@ -96,3 +98,99 @@ def _keys() -> set[str]:
     from opik_mcp.credential_identity import _STORE
 
     return set(_STORE)
+
+
+# --- the credential -> session pairing ------------------------------------- #
+#
+# Needed because the MCP session id is minted in the RESPONSE to `initialize`,
+# while every event is built in the session task forked from that request —
+# whose context is frozen before the id exists. The credential is the only key
+# present on both sides.
+
+RAW_SESSION = "SESSION-CANARY-MUST-NOT-BE-STORED-RAW-7c3e11"
+
+
+def test_the_raw_session_id_is_never_stored() -> None:
+    """A session id is bearer-equivalent, so it gets credential treatment.
+
+    Checks the stored VALUE, not just the key: this map holds session ids, and
+    holding one in plaintext for the life of a pod is the thing to avoid.
+    """
+    reset_identities_for_tests()
+    remember_session(RAW_TOKEN, RAW_SESSION)
+
+    stored = lookup_session_digest(RAW_TOKEN)
+    assert stored == hashlib.sha256(RAW_SESSION.encode("utf-8")).hexdigest()
+    assert stored is not None and RAW_SESSION not in stored
+
+    from opik_mcp.credential_identity import _SESSIONS
+
+    blob = repr(list(_SESSIONS.items()))
+    assert RAW_SESSION not in blob
+    assert RAW_TOKEN not in blob
+
+
+def test_an_unknown_credential_has_no_session() -> None:
+    reset_identities_for_tests()
+    remember_session(RAW_TOKEN, RAW_SESSION)
+    assert lookup_session_digest("opik_mcp_at_never-seen") is None
+
+
+def test_empty_inputs_are_ignored_rather_than_stored() -> None:
+    """Callers must not have to guard — stdio passes no session at all."""
+    reset_identities_for_tests()
+    remember_session("", RAW_SESSION)
+    remember_session(RAW_TOKEN, "")
+    assert lookup_session_digest(RAW_TOKEN) is None
+    assert lookup_session_digest("") is None
+
+
+def test_the_session_map_cannot_grow_without_bound() -> None:
+    """A hosted pod sees a new credential per user; this map must not leak."""
+    reset_identities_for_tests()
+    for i in range(MAX_TRACKED_CREDENTIALS + 50):
+        remember_session(f"opik_mcp_at_token-{i}", f"session-{i}")
+
+    from opik_mcp.credential_identity import _SESSIONS
+
+    assert len(_SESSIONS) == MAX_TRACKED_CREDENTIALS
+    # Least-recently-used went first; the newest survived.
+    assert lookup_session_digest("opik_mcp_at_token-0") is None
+    last = MAX_TRACKED_CREDENTIALS + 49
+    assert lookup_session_digest(f"opik_mcp_at_token-{last}") is not None
+
+
+def test_reading_a_session_keeps_it_from_being_evicted() -> None:
+    """An in-use session must not lose its slot to one that has gone quiet."""
+    reset_identities_for_tests()
+    remember_session("opik_mcp_at_busy", "session-busy")
+    for i in range(MAX_TRACKED_CREDENTIALS - 1):
+        remember_session(f"opik_mcp_at_filler-{i}", f"session-{i}")
+
+    # Touch the first one, then push the map over its bound.
+    assert lookup_session_digest("opik_mcp_at_busy") is not None
+    remember_session("opik_mcp_at_newcomer", "session-new")
+
+    assert lookup_session_digest("opik_mcp_at_busy") is not None
+    assert lookup_session_digest("opik_mcp_at_filler-0") is None
+
+
+def test_a_re_handshake_on_the_same_credential_overwrites() -> None:
+    """Documents the known imprecision rather than pretending it away.
+
+    Re-initializing on the same credential repoints the pairing. Accepted: the
+    alternative needs a session-unique key, and the task that builds events has
+    none. A re-handshake means the client dropped the old session anyway.
+    """
+    reset_identities_for_tests()
+    remember_session(RAW_TOKEN, "session-first")
+    remember_session(RAW_TOKEN, "session-second")
+    assert lookup_session_digest(RAW_TOKEN) == credential_digest("session-second")
+
+
+def test_reset_clears_sessions_too() -> None:
+    """Or one test's session leaks into the next."""
+    reset_identities_for_tests()
+    remember_session(RAW_TOKEN, RAW_SESSION)
+    reset_identities_for_tests()
+    assert lookup_session_digest(RAW_TOKEN) is None

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -16,6 +16,11 @@ from opik_mcp.auth_context import (
     inbound_authorization,
     inbound_workspace,
 )
+from opik_mcp.credential_identity import (
+    credential_digest,
+    lookup_session_digest,
+    reset_identities_for_tests,
+)
 from opik_mcp.server import BearerAuthMiddleware
 
 
@@ -376,3 +381,69 @@ async def test_failed_introspection_leaves_the_handshake_working(
     resp = await mw.dispatch(request, call_next)
     assert resp.status_code == 200
     assert lookup_identity(token) is None
+
+
+# --- pairing the minted session id to the credential ----------------------- #
+#
+# The session id exists only on the RESPONSE to `initialize`, and the task that
+# builds events is forked from that request before the id exists. So the
+# middleware records the pairing on the way out; without it the session field is
+# inert no matter what the request headers say.
+
+MINTED_SESSION = "MINTED-SESSION-ID-9f14ab"
+
+
+@pytest.mark.anyio
+async def test_the_minted_session_id_is_paired_with_the_credential() -> None:
+    """The handshake response is the only place both values are in scope."""
+    reset_identities_for_tests()
+    mw = _build_middleware()
+    auth = f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}handshake"
+    request = _make_request({"authorization": auth})
+
+    async def call_next(_r: Request) -> Response:
+        # No Mcp-Session-Id inbound: this is the session-minting request. The
+        # transport puts the new id on the response.
+        return JSONResponse({"ok": True}, headers={"mcp-session-id": MINTED_SESSION})
+
+    await mw.dispatch(request, call_next)
+
+    # Stored hashed, and reachable by the credential the session task holds.
+    assert lookup_session_digest(auth) == credential_digest(MINTED_SESSION)
+
+
+@pytest.mark.anyio
+async def test_a_response_without_a_session_id_pairs_nothing() -> None:
+    """Not every request mints a session; absence must stay absence."""
+    reset_identities_for_tests()
+    mw = _build_middleware()
+    auth = f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}nosession"
+    request = _make_request({"authorization": auth})
+
+    async def call_next(_r: Request) -> Response:
+        return JSONResponse({"ok": True})
+
+    await mw.dispatch(request, call_next)
+    assert lookup_session_digest(auth) is None
+
+
+@pytest.mark.anyio
+async def test_a_request_already_carrying_a_session_does_not_repair_it() -> None:
+    """Only the minting request pairs.
+
+    A tool call carries the session id too, but re-pairing there would let a
+    rotated credential mint a second entry for the same session — and the entry
+    keyed to the HANDSHAKE credential is the only one the session task can read.
+    """
+    reset_identities_for_tests()
+    mw = _build_middleware()
+    rotated = f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}rotated"
+    request = _make_request(
+        {"authorization": rotated, "mcp-session-id": MINTED_SESSION},
+    )
+
+    async def call_next(_r: Request) -> Response:
+        return JSONResponse({"ok": True}, headers={"mcp-session-id": MINTED_SESSION})
+
+    await mw.dispatch(request, call_next)
+    assert lookup_session_digest(rotated) is None


### PR DESCRIPTION
## The problem

`mcp_session_sha256`, shipped in 0.2.19, is **inert** — it has never appeared on a single event and could not have. Found by driving a real server over streamable-http and inspecting the captured payloads. Every unit test passed because each one set the ContextVar directly, which is not what production does.

## Root cause

A lifecycle asymmetry, not a typo:

- The MCP session id is minted in the **response** to `initialize`.
- Every event is built inside the **MCP session task**, forked from that same request — so its context is frozen *before* the id exists.
- The later requests that *do* carry `Mcp-Session-Id` build no events of their own.

The two sides never share a context, so no ContextVar can bridge them. `server.py` already hinted at this: *"the analytics layer builds events in the MCP session task and never sees a request"*.

Proven by initializing with token A and calling with token B on the same session — the event reported **A**'s digest, confirming the context is frozen at handshake time.

## The fix

The credential is the only value in scope on both sides, so it becomes the join key:

- `BearerAuthMiddleware` pairs the minted session id with the credential on the way *out* of the handshake — the one moment both are in scope.
- `_build_event` falls back to that pairing when the ContextVar is empty.
- Keying on the **handshake** credential is what makes the lookup hit: a session task presents that same credential for its whole life, even after the client rotates its token.

Session ids are stored **hashed** (bearer-equivalent, so same treatment as a credential) in a separate LRU bounded by `MAX_TRACKED_CREDENTIALS`.

## Verified on a live server

Hardest case — OAuth session with the token rotated on the tool call:

```
initialize -> 200, Mcp-Session-Id='ac3dd31edaaa44b4a56cd51afd7e6edd'
opik_mcp_tools_listed        mcp_session_sha256=e57bd47b1e46...
opik_mcp_session_initialized mcp_session_sha256=e57bd47b1e46...
opik_mcp_tool_called         mcp_session_sha256=e57bd47b1e46...
raw session id leaked into any payload: False
```

`sha256("ac3dd31edaaa44b4a56cd51afd7e6edd")` matches byte-for-byte. stdio correctly reports nothing.

## Tests

+14. The important one reproduces the exact bug shape — no ContextVar, credential paired, digest must still land — so this cannot silently regress. Plus middleware tests that *only* the minting request pairs, LRU bounds, and that the raw session id is never stored.

Gate: 1,347 tests pass, ruff clean, mypy clean.

## Known imprecision, documented not hidden

Re-handshaking on the same credential repoints the pairing. Accepted: the alternative needs a session-unique key and the task that builds events has none. In practice a re-handshake means the client dropped the old session, and under OAuth the 1-hour TTL means it usually arrives on a new credential anyway.

Follow-up to #165 · relates to OPIK-8042