### PR TITLE
feat(analytics): make hosted identity failures visible (install_id_kind, identity_lookup)

### DIFF
--- a/src/opik_mcp/analytics/client.py
+++ b/src/opik_mcp/analytics/client.py
@@ -23,6 +23,7 @@ from opik_mcp.analytics.identity import (
     OPIK_MCP_VERSION,
     api_key_sha256,
     get_install_id,
+    install_id_kind,
 )
 from opik_mcp.auth_context import (
     classify_bearer,
@@ -31,7 +32,7 @@ from opik_mcp.auth_context import (
     inbound_workspace,
     settings_auth_mode,
 )
-from opik_mcp.caller_identity import caller_identity
+from opik_mcp.caller_identity import caller_identity_with_outcome
 from opik_mcp.config import (
     DEFAULT_WORKSPACE,
     Settings,
@@ -227,7 +228,7 @@ class AnalyticsClient:
             # actually maps to when the user took the action.
             "timestamp": datetime.now(UTC).isoformat(),
         }
-        identity = caller_identity(self._settings)
+        identity, lookup_outcome = caller_identity_with_outcome(self._settings)
         workspace = self._resolve_workspace(identity)
         # Where the name came from: resolved from the backend, chosen by the
         # operator, an unfilled config snippet, the self-hosted placeholder, or
@@ -297,6 +298,14 @@ class AnalyticsClient:
         # filter rather than a guess. Its ABSENCE is also how BI separates events
         # predating this change, which carried the old overloaded semantics.
         common["user_id_kind"] = user.kind
+        # Why it came out that way. Without this, a hosted server that resolves
+        # nobody is indistinguishable from a laptop running open-source Opik with
+        # auth disabled — both report install_id. See ``events.IdentityLookup``.
+        common["identity_lookup"] = lookup_outcome
+        # Whether ``install_id`` is a real id or the shared nil sentinel. The
+        # sentinel merges unrelated deployments into one row, so a tile that
+        # counts installs must be able to exclude it. See ``events.InstallIdKind``.
+        common["install_id_kind"] = install_id_kind()
 
         return {
             "user_id": user.value,

--- a/src/opik_mcp/analytics/events.py
+++ b/src/opik_mcp/analytics/events.py
@@ -293,6 +293,41 @@ LifecycleSource = Literal["main", "lifespan"]
 # falling back to an install id.
 UserIdKind = Literal["comet_user", "install_id"]
 
+# ``install_id_kind``: whether ``install_id`` is a real on-disk id ("file") or the
+# nil-UUID sentinel used when HOME is unwritable ("fallback"). The classifier is
+# ``identity.install_id_kind``.
+#
+# CRITICAL for BI, because the sentinel is a SHARED identity rather than a missing
+# one: every deployment with an unwritable HOME reports the SAME ``install_id``,
+# so unrelated installs merge into one counted row. On the hosted server that is
+# 100% of events — hundreds of people behind a single "install". Any tile that
+# counts installs, or attributes one host/workspace per install, must exclude
+# ``install_id_kind = 'fallback'`` or it is silently reporting an aggregate as an
+# individual. ``install_id`` itself is unchanged, so no existing tile moves until
+# it opts in.
+InstallIdKind = Literal["file", "fallback"]
+
+# ``identity_lookup``: why ``user_id_kind`` came out the way it did. Exists because
+# "anonymous" has two causes that must not be added together, and which were
+# previously indistinguishable:
+#
+# - "resolved"        — an identity was found; ``user_id`` is a Comet login.
+# - "none_expected"   — no inbound credential, so anonymity is CORRECT, not a
+#                       fault. Local and self-hosted Opik run with auth disabled
+#                       by design; ~60% of all tool calls are this.
+# - "miss"            — a credential WAS presented and we still could not resolve
+#                       it. This is a DEFECT, and it is the one number that says
+#                       whether hosted identity is actually working. Causes:
+#                       the handshake introspection failed, the pod restarted and
+#                       emptied the in-memory store, the credential was evicted,
+#                       or the credential is an API key forwarded to a hosted
+#                       server, which ``caller_identity`` cannot resolve at all.
+#
+# Without this split, a hosted server resolving nothing looks identical to a
+# laptop running open-source Opik: both report ``user_id_kind='install_id'``. That
+# is precisely why the hosted deploy could not be verified from the data.
+IdentityLookup = Literal["resolved", "none_expected", "miss"]
+
 # ``workspace_kind``: where the reported ``workspace`` name came from. The
 # classifier is ``client._resolve_workspace``. CRITICAL for BI: "placeholder" is
 # the literal "default" on an install that resolved nothing, and it collides with

--- a/src/opik_mcp/analytics/identity.py
+++ b/src/opik_mcp/analytics/identity.py
@@ -97,6 +97,24 @@ def get_install_id() -> str:
     return _get_install_id()[0]
 
 
+def install_id_kind() -> str:
+    """``"file"`` for a real on-disk id, ``"fallback"`` for the nil sentinel.
+
+    The sentinel is not merely uninformative — it is a SHARED identity. Any two
+    deployments with an unwritable HOME report the same ``install_id``, so
+    unrelated installs merge into one counted row. Measured on the hosted server:
+    100% of its events carry the nil id, collapsing hundreds of people into a
+    single "install" and silently mis-attributing every install-keyed tile.
+
+    ``install_id`` itself is unchanged, so no existing dashboard moves. This
+    field is what lets a query exclude the sentinel instead of counting it, and
+    what distinguishes "identity unavailable" from "one very busy machine".
+
+    Do not reintroduce the sentinel as a join key — see ``_FALLBACK_INSTALL_ID``.
+    """
+    return "fallback" if _get_install_id()[0] == _FALLBACK_INSTALL_ID else "file"
+
+
 def install_id_was_freshly_generated() -> bool:
     """True iff this process is the one that just wrote the install-id file."""
     return _get_install_id()[1]

--- a/src/opik_mcp/caller_identity.py
+++ b/src/opik_mcp/caller_identity.py
@@ -24,7 +24,7 @@ import logging
 
 from opik_mcp.account_identity import resolve_api_key_identity
 from opik_mcp.auth_context import classify_bearer, inbound_authorization
-from opik_mcp.config import Settings
+from opik_mcp.config import Settings, installation_type
 from opik_mcp.credential_identity import ResolvedIdentity, lookup_identity
 
 logger = logging.getLogger("opik_mcp.caller_identity")
@@ -36,17 +36,59 @@ def caller_identity(settings: Settings) -> ResolvedIdentity | None:
     Never raises and never blocks: identity is a telemetry nicety, and the call
     it describes must not be affected by it in any way.
     """
+    return caller_identity_with_outcome(settings)[0]
+
+
+def caller_identity_with_outcome(settings: Settings) -> tuple[ResolvedIdentity | None, str]:
+    """The caller's identity AND why it came out that way.
+
+    The second element feeds the ``identity_lookup`` BI field, and it exists
+    because ``None`` has two meanings that must never be summed:
+
+    - Nobody presented a credential, so anonymity is correct. Local and
+      self-hosted Opik run with auth disabled by design.
+    - A credential WAS presented and we still could not resolve it. That is a
+      defect, and it is the number that says whether hosted identity works.
+
+    Both previously emitted ``user_id_kind='install_id'`` and were therefore
+    indistinguishable in the warehouse — which is exactly why a hosted deploy
+    could not be verified from its own telemetry.
+
+    One honest imprecision on the settings-API-key path: resolution is
+    asynchronous, so the first events of a fresh cloud process can report "miss"
+    while the background refresh is still in flight. It self-corrects within the
+    session. Read "miss" per transport rather than fleet-wide.
+    """
     try:
         inbound_auth = inbound_authorization.get()
         if inbound_auth:
             _mode, token = classify_bearer(inbound_auth)
-            # Only an OAuth bearer has an identity we could have resolved; a
-            # forwarded API-key-shaped credential is opaque to us.
-            return lookup_identity(token) if token else None
-        return resolve_api_key_identity(settings)
+            if not token:
+                # An API-key-shaped credential forwarded to this server. A
+                # credential was presented and we cannot resolve it at all —
+                # there is no inbound-API-key resolution path today. A miss, not
+                # by-design anonymity, and on a hosted server it is the reason
+                # api-key callers can never be counted as people.
+                return (None, "miss")
+            identity = lookup_identity(token)
+            if identity is not None and identity.user_name:
+                return (identity, "resolved")
+            # The handshake should have stored this. It did not: introspection
+            # failed, the pod restarted and emptied the store, or the LRU evicted
+            # a live credential.
+            return (None, "miss")
+
+        identity = resolve_api_key_identity(settings)
+        if identity is not None and identity.user_name:
+            return (identity, "resolved")
+        if not settings.opik_api_key or installation_type(settings) != "cloud":
+            # No credential, or a deployment with no account-details endpoint to
+            # ask. Anonymous by construction, not by failure.
+            return (None, "none_expected")
+        return (None, "miss")
     except Exception:
         logger.debug("caller identity resolution failed", exc_info=True)
-        return None
+        return (None, "miss")
 
 
-__all__ = ["caller_identity"]
+__all__ = ["caller_identity", "caller_identity_with_outcome"]

--- a/tests/test_analytics_client_build_event.py
+++ b/tests/test_analytics_client_build_event.py
@@ -28,7 +28,12 @@ from opik_mcp.auth_context import (
     inbound_workspace,
 )
 from opik_mcp.config import Settings
-from opik_mcp.credential_identity import credential_digest, remember_session
+from opik_mcp.credential_identity import (
+    ResolvedIdentity,
+    credential_digest,
+    remember_identity,
+    remember_session,
+)
 
 # Canaries: unique, greppable values that must never appear raw in an event.
 RAW_OAUTH_TOKEN = f"{OAUTH_ACCESS_TOKEN_PREFIX}BEARER-CANARY-TOKEN-UNIQUE-7a3b2c1d"
@@ -431,3 +436,106 @@ def test_an_unpaired_credential_gets_no_session_digest(make_client: Any) -> None
     with _inbound(auth="Bearer opik_mcp_at_someone_else", mcp_session_id=None):
         event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
     assert "mcp_session_sha256" not in event["event_properties"]
+
+
+# --- install_id_kind + identity_lookup ------------------------------------- #
+#
+# Both exist because the hosted deploy could not be verified from its own
+# telemetry. Every hosted event reported `user_id_kind='install_id'` with the nil
+# sentinel as the value, which is indistinguishable from a laptop running
+# open-source Opik with auth disabled. These two fields separate those cases.
+
+
+def test_install_id_kind_reports_a_real_on_disk_id(make_client: Any) -> None:
+    client = make_client()
+    event = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})
+    assert event["event_properties"]["install_id_kind"] == "file"
+
+
+def test_install_id_kind_flags_the_shared_nil_sentinel(
+    make_client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sentinel is a SHARED id, not a missing one.
+
+    Two deployments with an unwritable HOME report the SAME install_id, so
+    unrelated installs merge into one counted row. A tile that counts installs
+    has to be able to exclude these.
+    """
+    from opik_mcp.analytics import identity as ident
+
+    monkeypatch.setattr(ident, "_get_install_id", lambda: (ident._FALLBACK_INSTALL_ID, False))
+    client = make_client()
+    props = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})["event_properties"]
+
+    assert props["install_id_kind"] == "fallback"
+    # install_id itself is UNCHANGED, so no existing dashboard moves.
+    assert props["install_id"] == ident._FALLBACK_INSTALL_ID
+
+
+def test_identity_lookup_says_resolved_when_a_user_is_known(make_client: Any) -> None:
+    token = f"{OAUTH_ACCESS_TOKEN_PREFIX}resolved-token"
+    remember_identity(
+        token,
+        ResolvedIdentity(user_name="awkoy", workspace_name="acme", workspace_id=None),
+    )
+    client = make_client()
+    with _inbound(auth=f"Bearer {token}"):
+        props = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})[
+            "event_properties"
+        ]
+    assert props["user_id_kind"] == "comet_user"
+    assert props["identity_lookup"] == "resolved"
+
+
+def test_an_unresolved_oauth_bearer_is_a_miss_not_by_design_anonymity(make_client: Any) -> None:
+    """THE HOSTED SIGNAL. A credential was presented and we resolved nothing.
+
+    This is the case that was invisible: it reported install_id, exactly like a
+    credential-less local install, so "hosted identity is broken" and "hosted is
+    working as designed" produced identical telemetry.
+    """
+    client = make_client()
+    with _inbound(auth=f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}never-stored"):
+        props = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})[
+            "event_properties"
+        ]
+    assert props["user_id_kind"] == "install_id"
+    assert props["identity_lookup"] == "miss"
+
+
+def test_a_forwarded_api_key_on_a_hosted_server_is_a_miss(make_client: Any) -> None:
+    """There is no inbound-API-key resolution path, so these can never be people.
+
+    Counted as a miss rather than expected-anonymous, because a credential WAS
+    presented — the gap is ours, not the caller's.
+    """
+    client = make_client()
+    with _inbound(auth="Bearer sk-some-forwarded-api-key"):
+        props = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})[
+            "event_properties"
+        ]
+    assert props["identity_lookup"] == "miss"
+
+
+def test_no_credential_at_all_is_expected_anonymity(make_client: Any) -> None:
+    """~60% of tool calls. Anonymous by design, and must not inflate the miss rate."""
+    client = make_client(opik_api_key="")
+    with _inbound(auth=None):
+        props = client._build_event("opik_mcp_tool_called", {"tool_name": "read"})[
+            "event_properties"
+        ]
+    assert props["identity_lookup"] == "none_expected"
+
+
+def test_new_kind_fields_are_stamped_on_every_event(make_client: Any) -> None:
+    """Both must be present wherever user_id_kind is, or a total silently misses rows."""
+    client = make_client()
+    for event_type in (
+        "opik_mcp_server_started",
+        "opik_mcp_tools_listed",
+        "opik_mcp_tool_called",
+        "opik_mcp_server_shutdown",
+    ):
+        props = client._build_event(event_type, {})["event_properties"]
+        assert "install_id_kind" in props, event_type
+        assert "identity_lookup" in props, event_type


### PR DESCRIPTION
## Why

The 0.2.20 hosted deploy **completed** (0.2.12 stopped serving at 11:00 UTC today), and **its telemetry cannot tell us whether it worked.**

Measured on prod, same version, both transports:

| transport | version | user_id_kind | events | distinct ids |
|---|---|---|---|---|
| stdio | 0.2.20 | **comet_user** | 4,779 | 43 |
| stdio | 0.2.20 | install_id | 7,074 | 106 |
| http | 0.2.20 | install_id | 179 | 1 |
| http | 0.2.20 | **comet_user** | **0** | — |

So identity resolution works — proven on stdio — and resolves nobody on hosted. But **nothing in the data distinguishes "hosted identity is broken" from "hosted is working as designed"**, because both cases emit `user_id_kind='install_id'`. That is why the deploy can't be verified from its own telemetry.

## What this adds

Two additive fields, stamped alongside `user_id_kind` on every event.

**`install_id_kind`** — `"file"` | `"fallback"` (OPIK-8044)

The nil-UUID fallback is a **shared** identity, not a missing one: every deployment with an unwritable HOME reports the *same* `install_id`, so unrelated installs merge into one row. Hosted is 100% this — hundreds of people behind a single "install", which also silently mis-attributes every tile that assigns one host or workspace per install. Now excludable. `install_id` itself is unchanged, so no existing tile moves until it opts in.

**`identity_lookup`** — `"resolved"` | `"none_expected"` | `"miss"` (OPIK-8042 AC3)

- `none_expected` — no credential at all. ~60% of tool calls, and **correct**: local and self-hosted Opik run with auth disabled by design.
- `miss` — a credential was presented and we resolved nothing. A **defect**: failed introspection, a pod restart emptying the in-memory store, LRU eviction, or an API key forwarded to a hosted server (which `caller_identity` cannot resolve at all today).

Summing those two as "anonymous" is exactly what hid the hosted problem.

## Verified on live servers

Both transports, real handshakes, payloads inspected:

```
stdio, no credential:
  opik_mcp_tools_listed      identity_lookup=none_expected  install_id_kind=file

hosted OAuth, unresolvable bearer:
  opik_mcp_tools_listed      identity_lookup=miss  install_id_kind=file
  opik_mcp_session_initialized identity_lookup=miss
  opik_mcp_tool_called       identity_lookup=miss
```

## Not in scope, deliberately

**Inbound API-key callers on hosted can never be identified.** `caller_identity` returns `None` for a non-OAuth credential — documented as intentional ("opaque to us"). Resolving it means calling the backend with someone else's forwarded key, which has security implications and needs its own review. This PR makes the gap **countable** (`identity_lookup='miss'`) rather than papering over it.

## Compatibility

No existing field changes semantics or value set. Both new fields are absent on pre-0.2.21 events, which is how BI separates the eras.

Gate: 1,358 tests pass, ruff clean, mypy clean. +11 tests.

Relates to OPIK-8042 · OPIK-8044