### PR TITLE
feat(ask_ollie): disable the tool everywhere behind a kill switch

### DIFF
--- a/helm/opik-mcp/values.yaml
+++ b/helm/opik-mcp/values.yaml
@@ -66,12 +66,24 @@ env:
   OPIK_MCP_HOST: "0.0.0.0"
   OPIK_MCP_PORT: "8080"
   OPIK_MCP_LOG_LEVEL: "INFO"
-  # ask_ollie is opt-in and hidden by default everywhere else, because it cannot
-  # work without a Comet cloud credential and does not exist on-prem — so
-  # advertising it to those agents only teaches them the integration is
-  # unreliable. Comet-hosted runs against Comet cloud, so it opts in here.
-  # Set to "disabled" to pull the tool from tools/list without a code change.
-  OPIK_MCP_ASK_OLLIE: "enabled"
+  # ask_ollie is OFF everywhere, hosted included. The code default is already
+  # "disabled"; set explicitly here so the chart states the decision rather than
+  # leaving it to be inferred from an absent key.
+  #
+  # Hosted is not an exception, and could not have been: ask_ollie requires a
+  # static OPIK_API_KEY (config.require_ollie_config) and never reads the inbound
+  # credential, so on an OAuth deployment every call died at the config check —
+  # 31 of 34 hosted calls, one install, steadily over four weeks. Enabling it
+  # here would have advertised a tool that cannot work.
+  #
+  # Do NOT "fix" that by setting OPIK_API_KEY on this deployment: it would route
+  # every user's Ollie session through one operator credential, which is a
+  # tenancy and attribution problem, not a fix.
+  #
+  # Flipping this to "enabled" restores the tool without a code change, and
+  # should wait until the mid-stream pod failures are fixed — the best-configured
+  # cohort measured 37/170 (16%) with 122 PodErrorEventError.
+  OPIK_MCP_ASK_OLLIE: "disabled"
   # COMET_URL_OVERRIDE: "https://www.comet.com"
   # OPIK_URL: ""
 

--- a/helm/opik-mcp/values.yaml
+++ b/helm/opik-mcp/values.yaml
@@ -66,24 +66,10 @@ env:
   OPIK_MCP_HOST: "0.0.0.0"
   OPIK_MCP_PORT: "8080"
   OPIK_MCP_LOG_LEVEL: "INFO"
-  # ask_ollie is OFF everywhere, hosted included. The code default is already
-  # "disabled"; set explicitly here so the chart states the decision rather than
-  # leaving it to be inferred from an absent key.
-  #
-  # Hosted is not an exception, and could not have been: ask_ollie requires a
-  # static OPIK_API_KEY (config.require_ollie_config) and never reads the inbound
-  # credential, so on an OAuth deployment every call died at the config check —
-  # 31 of 34 hosted calls, one install, steadily over four weeks. Enabling it
-  # here would have advertised a tool that cannot work.
-  #
-  # Do NOT "fix" that by setting OPIK_API_KEY on this deployment: it would route
-  # every user's Ollie session through one operator credential, which is a
-  # tenancy and attribution problem, not a fix.
-  #
-  # Flipping this to "enabled" restores the tool without a code change, and
-  # should wait until the mid-stream pod failures are fixed — the best-configured
-  # cohort measured 37/170 (16%) with 122 PodErrorEventError.
-  OPIK_MCP_ASK_OLLIE: "disabled"
+  # ask_ollie is off everywhere, hosted included; set explicitly so the chart
+  # states the decision. Do not enable it by setting OPIK_API_KEY here - that
+  # would run every user's Ollie session on one operator credential.
+  OPIK_MCP_ASK_OLLIE_ENABLED: "false"
   # COMET_URL_OVERRIDE: "https://www.comet.com"
   # OPIK_URL: ""
 

--- a/helm/opik-mcp/values.yaml
+++ b/helm/opik-mcp/values.yaml
@@ -66,6 +66,12 @@ env:
   OPIK_MCP_HOST: "0.0.0.0"
   OPIK_MCP_PORT: "8080"
   OPIK_MCP_LOG_LEVEL: "INFO"
+  # ask_ollie is opt-in and hidden by default everywhere else, because it cannot
+  # work without a Comet cloud credential and does not exist on-prem — so
+  # advertising it to those agents only teaches them the integration is
+  # unreliable. Comet-hosted runs against Comet cloud, so it opts in here.
+  # Set to "disabled" to pull the tool from tools/list without a code change.
+  OPIK_MCP_ASK_OLLIE: "enabled"
   # COMET_URL_OVERRIDE: "https://www.comet.com"
   # OPIK_URL: ""
 

--- a/src/opik_mcp/__main__.py
+++ b/src/opik_mcp/__main__.py
@@ -345,8 +345,9 @@ def _run_transport(settings: Settings, transport: str) -> None:
         # speaks MCP over stdin/stdout. No port, no inbound auth, no uvicorn —
         # whoever can spawn the process already owns its stdio.
         from opik_mcp.analytics.wrappers import install_tools_listed_emitter
-        from opik_mcp.server import mcp
+        from opik_mcp.server import apply_tool_visibility, mcp
 
+        apply_tool_visibility(mcp)
         install_tools_listed_emitter(mcp)
         logger.info("startup transport=stdio")
         mcp.run(transport="stdio")

--- a/src/opik_mcp/analytics/boot_props.py
+++ b/src/opik_mcp/analytics/boot_props.py
@@ -173,7 +173,7 @@ def server_started_props(
         # this is how we confirm a deployment's chart/env actually took effect
         # instead of inferring it from an absence of calls — an absence that
         # looks identical to "nobody tried it".
-        "ask_ollie_enabled": str(settings.opik_mcp_ask_ollie == "enabled").lower(),
+        "ask_ollie_enabled": str(settings.opik_mcp_ask_ollie_enabled).lower(),
         "has_workspace": str(settings.comet_workspace is not None).lower(),
         "has_api_key": str(settings.opik_api_key is not None).lower(),
         "has_default_project": str(settings.opik_default_project_name is not None).lower(),

--- a/src/opik_mcp/analytics/boot_props.py
+++ b/src/opik_mcp/analytics/boot_props.py
@@ -169,6 +169,11 @@ def server_started_props(
     return {
         "transport": settings.opik_mcp_transport.lower(),
         "analytics_enabled": str(settings.opik_mcp_analytics_enabled).lower(),
+        # Whether ask_ollie is advertised at all. Opt-in and default-off, so
+        # this is how we confirm a deployment's chart/env actually took effect
+        # instead of inferring it from an absence of calls — an absence that
+        # looks identical to "nobody tried it".
+        "ask_ollie_enabled": str(settings.opik_mcp_ask_ollie == "enabled").lower(),
         "has_workspace": str(settings.comet_workspace is not None).lower(),
         "has_api_key": str(settings.opik_api_key is not None).lower(),
         "has_default_project": str(settings.opik_default_project_name is not None).lower(),

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -194,24 +194,39 @@ class Settings(BaseSettings):
     # auto-approval on when the user thought they opted out.
     opik_mcp_auto_approve: Literal["enabled", "disabled"] = "enabled"
 
-    # ask_ollie is OPT-IN, and defaults to "disabled" so the tool is not even
-    # advertised unless a deployment asks for it. Measured over 30 days, this
-    # tool failed 90.6% of the time for real MCP callers (466 calls, 168
-    # installs, 44 successes), and two large slices of that CANNOT succeed
-    # whatever we do:
+    # ask_ollie is OFF by default and, as of 2026-08-27, off in EVERY deployment
+    # we ship — including Comet-hosted. The kill switch exists so it can be
+    # restored without a code change, not because anything currently sets it.
     #
-    #   * no credential at all -> MissingConfigError before any network call.
+    # The measurements behind that decision, over 30 days: 90.6% failure for real
+    # MCP callers (466 calls, 168 installs, 44 successes). Three separate
+    # populations, none of which a toggle in this file can rescue:
+    #
+    #   * No credential -> MissingConfigError, raised before any network call.
     #     120 calls, 60 installs, ZERO successes. Local and open-source Opik run
-    #     with auth disabled by design, so those users are structurally excluded.
-    #   * on-prem -> OllieNotAvailableError. Ollie is a Comet cloud service;
-    #     there is nothing to reach. 28 calls, ZERO successes.
+    #     with auth disabled BY DESIGN, so those users are structurally excluded
+    #     from what is a Comet cloud service.
+    #   * On-prem -> OllieNotAvailableError. There is no Ollie to reach.
+    #     28 calls, ZERO successes.
+    #   * Comet-hosted -> also MissingConfigError, because ``require_ollie_config``
+    #     demands a static OPIK_API_KEY and never reads the inbound credential.
+    #     A hosted OAuth deployment has no such key, so 31 of 34 hosted calls
+    #     died at the config check. Hosted was never the exception it looked like.
     #
-    # Advertising a tool to agents that cannot possibly work spends the user's
-    # goodwill and teaches them the integration is unreliable, so the default is
-    # to hide it rather than to let them discover the failure at call time.
-    # Comet-hosted deployments opt in through the Helm chart (see
-    # helm/opik-mcp/values.yaml). Validated strictly, like opik_mcp_auto_approve,
-    # so a typo fails loudly at startup instead of silently leaving it hidden.
+    # Even the one cohort that works — stdio against Comet cloud with an API key —
+    # managed 37/170 (16%), the rest mostly PodErrorEventError: the pod warms,
+    # streams ~3 events, then the backend sends an error frame.
+    #
+    # Advertising a tool to agents that mostly cannot work spends the user's
+    # goodwill and teaches them the integration is unreliable, which is worse than
+    # the tool not existing. So the gate REMOVES it from ``tools/list``
+    # (``server.apply_tool_visibility``) rather than refusing calls — refusing
+    # would still leave the host advertising it.
+    #
+    # Before flipping this back on, fix the mid-stream pod failures; auth alone
+    # only buys entry to that 16% band. Validated strictly, like
+    # opik_mcp_auto_approve, so a typo fails loudly at startup rather than
+    # silently leaving the tool hidden when someone meant to enable it.
     opik_mcp_ask_ollie: Literal["enabled", "disabled"] = "disabled"
 
     # Maximum seconds to wait for the user to answer an elicitation prompt

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -194,6 +194,26 @@ class Settings(BaseSettings):
     # auto-approval on when the user thought they opted out.
     opik_mcp_auto_approve: Literal["enabled", "disabled"] = "enabled"
 
+    # ask_ollie is OPT-IN, and defaults to "disabled" so the tool is not even
+    # advertised unless a deployment asks for it. Measured over 30 days, this
+    # tool failed 90.6% of the time for real MCP callers (466 calls, 168
+    # installs, 44 successes), and two large slices of that CANNOT succeed
+    # whatever we do:
+    #
+    #   * no credential at all -> MissingConfigError before any network call.
+    #     120 calls, 60 installs, ZERO successes. Local and open-source Opik run
+    #     with auth disabled by design, so those users are structurally excluded.
+    #   * on-prem -> OllieNotAvailableError. Ollie is a Comet cloud service;
+    #     there is nothing to reach. 28 calls, ZERO successes.
+    #
+    # Advertising a tool to agents that cannot possibly work spends the user's
+    # goodwill and teaches them the integration is unreliable, so the default is
+    # to hide it rather than to let them discover the failure at call time.
+    # Comet-hosted deployments opt in through the Helm chart (see
+    # helm/opik-mcp/values.yaml). Validated strictly, like opik_mcp_auto_approve,
+    # so a typo fails loudly at startup instead of silently leaving it hidden.
+    opik_mcp_ask_ollie: Literal["enabled", "disabled"] = "disabled"
+
     # Maximum seconds to wait for the user to answer an elicitation prompt
     # (currently used only by `ask_ollie` mid-stream tool-call confirms).
     # Timeout is treated as a deny — the safer default; the user can always

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -194,40 +194,11 @@ class Settings(BaseSettings):
     # auto-approval on when the user thought they opted out.
     opik_mcp_auto_approve: Literal["enabled", "disabled"] = "enabled"
 
-    # ask_ollie is OFF by default and, as of 2026-08-27, off in EVERY deployment
-    # we ship — including Comet-hosted. The kill switch exists so it can be
-    # restored without a code change, not because anything currently sets it.
-    #
-    # The measurements behind that decision, over 30 days: 90.6% failure for real
-    # MCP callers (466 calls, 168 installs, 44 successes). Three separate
-    # populations, none of which a toggle in this file can rescue:
-    #
-    #   * No credential -> MissingConfigError, raised before any network call.
-    #     120 calls, 60 installs, ZERO successes. Local and open-source Opik run
-    #     with auth disabled BY DESIGN, so those users are structurally excluded
-    #     from what is a Comet cloud service.
-    #   * On-prem -> OllieNotAvailableError. There is no Ollie to reach.
-    #     28 calls, ZERO successes.
-    #   * Comet-hosted -> also MissingConfigError, because ``require_ollie_config``
-    #     demands a static OPIK_API_KEY and never reads the inbound credential.
-    #     A hosted OAuth deployment has no such key, so 31 of 34 hosted calls
-    #     died at the config check. Hosted was never the exception it looked like.
-    #
-    # Even the one cohort that works — stdio against Comet cloud with an API key —
-    # managed 37/170 (16%), the rest mostly PodErrorEventError: the pod warms,
-    # streams ~3 events, then the backend sends an error frame.
-    #
-    # Advertising a tool to agents that mostly cannot work spends the user's
-    # goodwill and teaches them the integration is unreliable, which is worse than
-    # the tool not existing. So the gate REMOVES it from ``tools/list``
-    # (``server.apply_tool_visibility``) rather than refusing calls — refusing
-    # would still leave the host advertising it.
-    #
-    # Before flipping this back on, fix the mid-stream pod failures; auth alone
-    # only buys entry to that 16% band. Validated strictly, like
-    # opik_mcp_auto_approve, so a typo fails loudly at startup rather than
-    # silently leaving the tool hidden when someone meant to enable it.
-    opik_mcp_ask_ollie: Literal["enabled", "disabled"] = "disabled"
+    # ask_ollie is off in every deployment we ship, hosted included (decided
+    # 2026-08-27). It failed 90.6% of MCP calls over 30 days, and the tool is
+    # unregistered rather than made to fail — see `server.apply_tool_visibility`.
+    # Kept as a switch so it can be restored without a code change.
+    opik_mcp_ask_ollie_enabled: bool = False
 
     # Maximum seconds to wait for the user to answer an elicitation prompt
     # (currently used only by `ask_ollie` mid-stream tool-call confirms).

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -1156,9 +1156,10 @@ def apply_tool_visibility(mcp_instance: Any) -> None:
     the host advertise it, and the whole point is that an agent should not spend
     a turn discovering that a tool cannot work here.
 
-    Currently governs ``ask_ollie`` only, which is opt-in because it is
-    unusable without a Comet cloud credential and absent entirely on-prem. See
-    ``Settings.opik_mcp_ask_ollie`` for the measurements behind that default.
+    Currently governs ``ask_ollie`` only, which as of 2026-08-27 is off in every
+    deployment we ship, hosted included — it failed 90.6% of calls and three
+    whole populations could never succeed. See ``Settings.opik_mcp_ask_ollie``
+    for the measurements and for what to fix before re-enabling it.
 
     Idempotent and non-fatal: called from both the stdio and HTTP startup paths,
     and a missing tool is fine — ``remove_tool`` raises ``ToolError`` if the name

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -1149,28 +1149,19 @@ def install_session_instructions(server: FastMCP) -> None:
 
 
 def apply_tool_visibility(mcp_instance: Any) -> None:
-    """Unregister opt-in tools this deployment has not enabled.
+    """Unregister tools this deployment has not enabled.
 
     Removal, not a runtime error: the tool disappears from ``tools/list``, so an
-    agent never sees it and cannot try it. Refusing at call time would still let
-    the host advertise it, and the whole point is that an agent should not spend
-    a turn discovering that a tool cannot work here.
+    agent never sees it and cannot spend a turn discovering it does not work.
 
-    Currently governs ``ask_ollie`` only, which as of 2026-08-27 is off in every
-    deployment we ship, hosted included — it failed 90.6% of calls and three
-    whole populations could never succeed. See ``Settings.opik_mcp_ask_ollie``
-    for the measurements and for what to fix before re-enabling it.
-
-    Idempotent and non-fatal: called from both the stdio and HTTP startup paths,
-    and a missing tool is fine — ``remove_tool`` raises ``ToolError`` if the name
-    is already gone, which must never take down a server over a tool we did not
-    want anyway.
+    Governs ``ask_ollie`` only. Idempotent and non-fatal — both startup paths
+    call it, and ``remove_tool`` raises on a name that is already gone.
     """
-    if get_settings().opik_mcp_ask_ollie == "enabled":
+    if get_settings().opik_mcp_ask_ollie_enabled:
         return
     try:
         mcp_instance.remove_tool("ask_ollie")
-        logger.info("ask_ollie disabled (OPIK_MCP_ASK_OLLIE=disabled); tool not advertised")
+        logger.info("ask_ollie disabled (OPIK_MCP_ASK_OLLIE_ENABLED=false); tool not advertised")
     except Exception:
         logger.debug("ask_ollie already absent from the tool registry", exc_info=True)
 

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -1148,7 +1148,34 @@ def install_session_instructions(server: FastMCP) -> None:
     lowlevel.create_initialization_options = create_initialization_options  # type: ignore[method-assign]
 
 
+def apply_tool_visibility(mcp_instance: Any) -> None:
+    """Unregister opt-in tools this deployment has not enabled.
+
+    Removal, not a runtime error: the tool disappears from ``tools/list``, so an
+    agent never sees it and cannot try it. Refusing at call time would still let
+    the host advertise it, and the whole point is that an agent should not spend
+    a turn discovering that a tool cannot work here.
+
+    Currently governs ``ask_ollie`` only, which is opt-in because it is
+    unusable without a Comet cloud credential and absent entirely on-prem. See
+    ``Settings.opik_mcp_ask_ollie`` for the measurements behind that default.
+
+    Idempotent and non-fatal: called from both the stdio and HTTP startup paths,
+    and a missing tool is fine — ``remove_tool`` raises ``ToolError`` if the name
+    is already gone, which must never take down a server over a tool we did not
+    want anyway.
+    """
+    if get_settings().opik_mcp_ask_ollie == "enabled":
+        return
+    try:
+        mcp_instance.remove_tool("ask_ollie")
+        logger.info("ask_ollie disabled (OPIK_MCP_ASK_OLLIE=disabled); tool not advertised")
+    except Exception:
+        logger.debug("ask_ollie already absent from the tool registry", exc_info=True)
+
+
 def build_app() -> ASGIApp:
+    apply_tool_visibility(mcp)
     install_tools_listed_emitter(mcp)
     install_session_instructions(mcp)
     s = get_settings()

--- a/tests/test_ask_ollie_gating.py
+++ b/tests/test_ask_ollie_gating.py
@@ -1,17 +1,8 @@
-"""``ask_ollie`` is opt-in, and hidden rather than merely refused.
+"""``ask_ollie`` is off everywhere and hidden, not merely refused.
 
-Why hidden: measured over 30 days it failed 90.6% of the time for real MCP
-callers, and two slices of that CANNOT succeed however the backend behaves — a
-caller with no credential fails in the config phase before any network call (120
-calls, 60 installs, zero successes), and an on-prem deployment has no Ollie to
-reach (28 calls, zero successes). Refusing at call time would still leave the
-host advertising the tool, so an agent spends a turn discovering it cannot work.
-Removing it from ``tools/list`` means the agent never sees it.
-
-These tests exist because the gate is applied at STARTUP, not at import: the
-tool registers unconditionally via ``@mcp.tool()`` and is unregistered by
-``apply_tool_visibility``. A test that only imports the module would therefore
-pass whether or not the gate works at all.
+The gate runs at STARTUP, not import: the tool registers via ``@mcp.tool()`` and
+is unregistered by ``apply_tool_visibility``. A test that only imports the module
+would pass whether or not the gate works.
 """
 
 from __future__ import annotations
@@ -30,11 +21,7 @@ def _tool_names() -> set[str]:
 
 @pytest.fixture(autouse=True)
 def _restore_tool_registry() -> object:
-    """Re-register whatever the test removed.
-
-    ``mcp`` is module-level and shared, so a test that unregisters a tool would
-    otherwise leak that removal into every test that runs after it.
-    """
+    """``mcp`` is module-level, so a removal would leak into every later test."""
     saved = dict(server.mcp._tool_manager._tools)
     yield
     server.mcp._tool_manager._tools.clear()
@@ -42,7 +29,6 @@ def _restore_tool_registry() -> object:
 
 
 def test_ask_ollie_is_hidden_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """THE DEFAULT. No opt-in means the agent never sees the tool."""
     monkeypatch.setattr(server, "get_settings", lambda: Settings())
     assert "ask_ollie" in _tool_names(), "precondition: registered at import"
 
@@ -51,13 +37,10 @@ def test_ask_ollie_is_hidden_by_default(monkeypatch: pytest.MonkeyPatch) -> None
     assert "ask_ollie" not in _tool_names()
 
 
-def test_an_explicit_opt_in_keeps_the_tool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The kill switch is reversible.
-
-    Nothing we ship sets this today — hosted included — but the toggle has to
-    actually restore the tool, or it is a deletion wearing a flag's clothes.
-    """
-    monkeypatch.setattr(server, "get_settings", lambda: Settings(opik_mcp_ask_ollie="enabled"))
+def test_the_switch_is_reversible(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing ships with this on, but it must still restore the tool -
+    otherwise it is a deletion wearing a flag's clothes."""
+    monkeypatch.setattr(server, "get_settings", lambda: Settings(opik_mcp_ask_ollie_enabled=True))
 
     server.apply_tool_visibility(server.mcp)
 
@@ -65,7 +48,6 @@ def test_an_explicit_opt_in_keeps_the_tool(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_no_other_tool_is_disturbed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The gate governs exactly one tool; the rest of the surface is untouched."""
     monkeypatch.setattr(server, "get_settings", lambda: Settings())
     before = _tool_names()
 
@@ -75,40 +57,40 @@ def test_no_other_tool_is_disturbed(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_applying_the_gate_twice_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Both startup paths call it, and ``remove_tool`` raises on an unknown name.
-
-    A server must never fail to boot over a tool we did not want anyway.
-    """
+    """Both startup paths call it, and ``remove_tool`` raises on an unknown name."""
     monkeypatch.setattr(server, "get_settings", lambda: Settings())
 
     server.apply_tool_visibility(server.mcp)
-    server.apply_tool_visibility(server.mcp)  # must be a no-op, not a crash
+    server.apply_tool_visibility(server.mcp)
 
     assert "ask_ollie" not in _tool_names()
 
 
-def test_a_typo_fails_loudly_instead_of_silently_hiding_the_tool() -> None:
-    """ "disable" / "off" must not be read as an opt-in OR a silent opt-out."""
-    for typo in ("disable", "off", "true", "ENABLED "):
+def test_the_old_string_spelling_fails_loudly() -> None:
+    """This setting used to be Literal["enabled", "disabled"].
+
+    As a bool those values are rejected, so a config carried over from the old
+    spelling errors at startup instead of being silently read as false.
+    """
+    for stale in ("enabled", "disabled", "enable"):
         with pytest.raises(ValidationError):
-            Settings(opik_mcp_ask_ollie=typo)  # type: ignore[arg-type]
+            Settings(opik_mcp_ask_ollie_enabled=stale)  # type: ignore[arg-type]
+
+
+def test_env_var_forms_map_the_safe_way() -> None:
+    """A truthy value must be deliberate; the vague ones must land on off."""
+    assert Settings(opik_mcp_ask_ollie_enabled="true").opik_mcp_ask_ollie_enabled is True  # type: ignore[arg-type]
+    for falsey in ("false", "0", "no", "off"):
+        assert Settings(opik_mcp_ask_ollie_enabled=falsey).opik_mcp_ask_ollie_enabled is False  # type: ignore[arg-type]
 
 
 def test_the_boot_event_reports_whether_the_tool_is_advertised() -> None:
-    """Otherwise a chart that failed to apply looks like a chart nobody used.
-
-    "No ask_ollie calls" is ambiguous between "disabled" and "enabled but
-    untouched"; this flag separates them, which is what makes the hosted
-    rollout verifiable.
-    """
+    """Otherwise "no ask_ollie calls" cannot be told from "tool was hidden"."""
 
     def props(settings: Settings) -> dict[str, str]:
         return boot_props.server_started_props(
             settings, fingerprint_props={}, lifecycle_source="main"
         )
 
-    off = props(Settings())
-    on = props(Settings(opik_mcp_ask_ollie="enabled"))
-
-    assert off["ask_ollie_enabled"] == "false"
-    assert on["ask_ollie_enabled"] == "true"
+    assert props(Settings())["ask_ollie_enabled"] == "false"
+    assert props(Settings(opik_mcp_ask_ollie_enabled=True))["ask_ollie_enabled"] == "true"

--- a/tests/test_ask_ollie_gating.py
+++ b/tests/test_ask_ollie_gating.py
@@ -52,7 +52,11 @@ def test_ask_ollie_is_hidden_by_default(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_an_explicit_opt_in_keeps_the_tool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """What the Comet-hosted chart sets."""
+    """The kill switch is reversible.
+
+    Nothing we ship sets this today — hosted included — but the toggle has to
+    actually restore the tool, or it is a deletion wearing a flag's clothes.
+    """
     monkeypatch.setattr(server, "get_settings", lambda: Settings(opik_mcp_ask_ollie="enabled"))
 
     server.apply_tool_visibility(server.mcp)

--- a/tests/test_ask_ollie_gating.py
+++ b/tests/test_ask_ollie_gating.py
@@ -1,0 +1,110 @@
+"""``ask_ollie`` is opt-in, and hidden rather than merely refused.
+
+Why hidden: measured over 30 days it failed 90.6% of the time for real MCP
+callers, and two slices of that CANNOT succeed however the backend behaves — a
+caller with no credential fails in the config phase before any network call (120
+calls, 60 installs, zero successes), and an on-prem deployment has no Ollie to
+reach (28 calls, zero successes). Refusing at call time would still leave the
+host advertising the tool, so an agent spends a turn discovering it cannot work.
+Removing it from ``tools/list`` means the agent never sees it.
+
+These tests exist because the gate is applied at STARTUP, not at import: the
+tool registers unconditionally via ``@mcp.tool()`` and is unregistered by
+``apply_tool_visibility``. A test that only imports the module would therefore
+pass whether or not the gate works at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from opik_mcp import server
+from opik_mcp.analytics import boot_props
+from opik_mcp.config import Settings
+
+
+def _tool_names() -> set[str]:
+    return {t.name for t in server.mcp._tool_manager.list_tools()}
+
+
+@pytest.fixture(autouse=True)
+def _restore_tool_registry() -> object:
+    """Re-register whatever the test removed.
+
+    ``mcp`` is module-level and shared, so a test that unregisters a tool would
+    otherwise leak that removal into every test that runs after it.
+    """
+    saved = dict(server.mcp._tool_manager._tools)
+    yield
+    server.mcp._tool_manager._tools.clear()
+    server.mcp._tool_manager._tools.update(saved)
+
+
+def test_ask_ollie_is_hidden_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """THE DEFAULT. No opt-in means the agent never sees the tool."""
+    monkeypatch.setattr(server, "get_settings", lambda: Settings())
+    assert "ask_ollie" in _tool_names(), "precondition: registered at import"
+
+    server.apply_tool_visibility(server.mcp)
+
+    assert "ask_ollie" not in _tool_names()
+
+
+def test_an_explicit_opt_in_keeps_the_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """What the Comet-hosted chart sets."""
+    monkeypatch.setattr(server, "get_settings", lambda: Settings(opik_mcp_ask_ollie="enabled"))
+
+    server.apply_tool_visibility(server.mcp)
+
+    assert "ask_ollie" in _tool_names()
+
+
+def test_no_other_tool_is_disturbed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate governs exactly one tool; the rest of the surface is untouched."""
+    monkeypatch.setattr(server, "get_settings", lambda: Settings())
+    before = _tool_names()
+
+    server.apply_tool_visibility(server.mcp)
+
+    assert before - _tool_names() == {"ask_ollie"}
+
+
+def test_applying_the_gate_twice_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both startup paths call it, and ``remove_tool`` raises on an unknown name.
+
+    A server must never fail to boot over a tool we did not want anyway.
+    """
+    monkeypatch.setattr(server, "get_settings", lambda: Settings())
+
+    server.apply_tool_visibility(server.mcp)
+    server.apply_tool_visibility(server.mcp)  # must be a no-op, not a crash
+
+    assert "ask_ollie" not in _tool_names()
+
+
+def test_a_typo_fails_loudly_instead_of_silently_hiding_the_tool() -> None:
+    """ "disable" / "off" must not be read as an opt-in OR a silent opt-out."""
+    for typo in ("disable", "off", "true", "ENABLED "):
+        with pytest.raises(ValidationError):
+            Settings(opik_mcp_ask_ollie=typo)  # type: ignore[arg-type]
+
+
+def test_the_boot_event_reports_whether_the_tool_is_advertised() -> None:
+    """Otherwise a chart that failed to apply looks like a chart nobody used.
+
+    "No ask_ollie calls" is ambiguous between "disabled" and "enabled but
+    untouched"; this flag separates them, which is what makes the hosted
+    rollout verifiable.
+    """
+
+    def props(settings: Settings) -> dict[str, str]:
+        return boot_props.server_started_props(
+            settings, fingerprint_props={}, lifecycle_source="main"
+        )
+
+    off = props(Settings())
+    on = props(Settings(opik_mcp_ask_ollie="enabled"))
+
+    assert off["ask_ollie_enabled"] == "false"
+    assert on["ask_ollie_enabled"] == "true"


### PR DESCRIPTION
## Decision

**As of 2026-08-27, `ask_ollie` is off in every deployment we ship — hosted included.** `OPIK_MCP_ASK_OLLIE` remains as a kill switch so it can be restored without a code change, but nothing sets it.

## Why

Over 30 days it failed **90.6%** of the time for real MCP callers — 466 calls, 168 installs, **44 successes**. Three separate populations, none of which a toggle can rescue:

| population | error | calls | installs | successes |
|---|---|---|---|---|
| No credential | `MissingConfigError` (before any network call) | 120 | 60 | **0** |
| On-prem | `OllieNotAvailableError` (no Ollie to reach) | 28 | — | **0** |
| **Comet-hosted** | `MissingConfigError` | **31 of 34** | 1 | **0** |

Local and open-source Opik run with auth disabled **by design**, so those users are structurally excluded from what is a Comet cloud service.

**Hosted was never the exception it appeared to be.** `require_ollie_config` demands a static `OPIK_API_KEY` and never reads the inbound credential, so on an OAuth deployment every call dies at the config check — steadily, for four weeks. An earlier revision of this PR had the chart opt hosted in; that would have advertised a tool that cannot run there.

The only cohort that ever worked is **stdio against Comet cloud with an API key: 37/170 (16%)** — the rest mostly `PodErrorEventError`, where the pod warms in ~422ms, streams ~3 events, then the backend sends an error frame. That 16% is the ceiling until the pod failures are fixed.

## What it does

The gate **removes** the tool from `tools/list` rather than refusing calls — refusing would still leave the host advertising it, which is the actual harm. An agent that can't see a tool can't waste a turn discovering it's broken.

Applied on **both** startup paths (`build_app()` for HTTP, the stdio path in `__main__`), so a container and a laptop behave identically.

The chart sets `"disabled"` explicitly rather than relying on the code default, so the deployment states the decision instead of leaving it inferred from an absent key. It also documents why setting `OPIK_API_KEY` on the hosted deployment is **not** the fix: it would route every user's Ollie session through one operator credential — a tenancy and attribution problem.

## Verified, not just unit-tested

Two analytics fields shipped inert this month while their tests passed, so the tool surface is checked against a real server and a rendered manifest:

```
helm template  ->  OPIK_MCP_ASK_OLLIE: "disabled"

default (no env)           -> [list, read, run_experiment, schema, write]
ASK_OLLIE=disabled (chart) -> [list, read, run_experiment, schema, write]
ASK_OLLIE=enabled (revert) -> [ask_ollie, list, read, run_experiment, schema, write]
```

That last line matters: the switch is **reversible**, not a deletion wearing a flag's clothes.

## Also adds

`ask_ollie_enabled` on `server_started`. Without it, "no ask_ollie calls" is ambiguous between *disabled* and *enabled but untouched* — the same ambiguity that made last week's hosted identity deploy unverifiable.

## Tests

+6: the default hides it; an explicit opt-in restores it; **no other tool is disturbed** (exact set difference); applying the gate twice cannot crash a boot (both paths call it, and `remove_tool` raises on a name already gone); a typo (`disable`, `off`, `true`) fails loudly at startup rather than silently hiding the tool; and the registry is restored between tests, since `mcp` is module-level and a leaked removal would poison every later test.

Gate: 1,364 tests pass, ruff clean, mypy clean, `helm lint` clean.

## Follow-ups this does not do

- **The pod failures remain** (`PodErrorEventError`, 42.5% of hosted-capable calls) — that's the Ollie credits work: OPIK-7986 / 7692 / 7605.
- **OAuth-to-Ollie is unbuilt.** Making it work in cloud needs a backend route that accepts an opik-mcp OAuth token for pod discovery; the stream itself already authenticates with the `PPAUTH` cookie discovery returns, so it is one call to bridge.