### PR TITLE
chore(mcp): stop advertising ask_ollie to the agent when it is disabled

### DIFF
--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -6,8 +6,8 @@ Cursor, VS Code, Goose). Hosts that ignore the field lose nothing — each
 tool's description is self-contained, so this is purely additive.
 
 The content sets cross-cutting context (workspace, Opik URL, today's date)
-and primes the LLM on when to prefer ``read``/``list``/direct writes vs.
-``ask_ollie``. Per GitHub MCP's published data, dynamic per-session
+and primes the LLM on when to prefer ``read``/``list`` vs. direct writes.
+Per GitHub MCP's published data, dynamic per-session
 instructions are worth +25pp workflow adherence on capable models and
 +60pp on smaller ones, so this is the highest-leverage single dial we
 have on tool selection quality.
@@ -29,6 +29,18 @@ from opik_mcp.config import DEFAULT_WORKSPACE, Settings, get_settings
 from opik_mcp.opik_client import opik_rest_base
 from opik_mcp.writes.registry import WRITE_OPERATIONS
 
+# Included only when ask_ollie is advertised (OPIK_MCP_ASK_OLLIE_ENABLED=true).
+# The tool is removed from the registry when disabled (see
+# server.apply_tool_visibility), so the instructions must not advertise it then.
+_ASK_OLLIE_CLAUSE = (
+    '\n- ask_ollie: use for investigative questions ("why is X failing?"), '
+    'cross-entity synthesis ("compare experiments A and B"), or when authoring '
+    "/ instrumentation requires Opik domain expertise. Returns a thread_id you "
+    "can pass back for follow-ups. Writes Ollie performs mid-stream (scores, "
+    "comments, test-suite items, prompts) execute without a per-action "
+    "confirmation step — be intentional about what you ask for."
+)
+
 _TEMPLATE = """\
 You're connected to Opik (Comet's LLM observability platform){user_clause} \
 in workspace "{workspace}". The Opik UI is at {opik_url}.
@@ -44,18 +56,12 @@ returns the messages list, and list('thread', project_id=…) enumerates a \
 project's threads.
 - Direct writes — use when the user's intent is concrete and well-defined \
 ("score this trace 0.8 on helpfulness", "comment 'retry with temperature=0' \
-on span X"). Skip ask_ollie for these — narrower tools are faster and more \
+on span X"). Prefer these narrower tools — they are faster and more \
 deterministic. The full write surface is two tools: write (takes \
 operation + data; pass a list for batch) and schema (returns an op's JSON \
 Schema + bundled example). Operations covered by Phase 1: \
 {write_operations}. run_experiment is a separate tool. Always consult \
-tools/list for what's actually advertised on this connection.
-- ask_ollie: use for investigative questions ("why is X failing?"), cross-entity \
-synthesis ("compare experiments A and B"), or when authoring / instrumentation \
-requires Opik domain expertise. Returns a thread_id you can pass back for \
-follow-ups. Writes Ollie performs mid-stream (scores, comments, test-suite \
-items, prompts) execute without a per-action confirmation step — be \
-intentional about what you ask for.
+tools/list for what's actually advertised on this connection.{ask_ollie_clause}
 
 Today's date is {date}.\
 """
@@ -84,8 +90,8 @@ def _render_default_project_clause(s: Settings) -> str:
         return ""
     return (
         f'\nThe user\'s default project is `project_name="{pname}"`. Pass it '
-        "as `project_name` to any tool/operation that accepts one (ask_ollie, "
-        "and write operations like score.create / trace.create) unless the "
+        "as `project_name` to any tool/operation that accepts one (write "
+        "operations like score.create / trace.create) unless the "
         "user explicitly names a different project.\n"
     )
 
@@ -119,6 +125,7 @@ def render_instructions(
     today = today if today is not None else datetime.now(UTC)
     date = today.strftime("%Y-%m-%d")
     default_project_clause = _render_default_project_clause(s)
+    ask_ollie_clause = _ASK_OLLIE_CLAUSE if s.opik_mcp_ask_ollie_enabled else ""
 
     return _TEMPLATE.format(
         user_clause=user_clause,
@@ -126,6 +133,7 @@ def render_instructions(
         opik_url=opik_url,
         date=date,
         default_project_clause=default_project_clause,
+        ask_ollie_clause=ask_ollie_clause,
         write_operations=", ".join(sorted(WRITE_OPERATIONS)),
     )
 

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -450,7 +450,7 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         search_by_name_fn=_search_experiment,
         list_fn=_list_experiments,
         list_extra_fields=("dataset_name", "created_at"),
-        description="Experiment status + summary scores. Pair with ask_ollie for analysis.",
+        description="Experiment status + summary scores.",
     ),
     "prompt": EntityHandler(
         entity_type="prompt",

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -112,6 +112,19 @@ def test_render_mentions_tool_selection_guidance() -> None:
     out = render_instructions(_settings())
     assert "read" in out
     assert "list" in out
+    assert "write" in out
+
+
+def test_render_omits_ask_ollie_when_disabled() -> None:
+    """ask_ollie is off in every shipped deployment, so the server removes the
+    tool from the registry; the instructions must not advertise it then."""
+    out = render_instructions(_settings())
+    assert "ask_ollie" not in out
+
+
+def test_render_includes_ask_ollie_when_enabled() -> None:
+    """When the tool is advertised, the routing guidance names it."""
+    out = render_instructions(_settings(opik_mcp_ask_ollie_enabled=True))
     assert "ask_ollie" in out
 
 


### PR DESCRIPTION
## Why

`ask_ollie` is off in every shipped deployment (`OPIK_MCP_ASK_OLLIE_ENABLED` defaults to `false`; #170 removes it from the tool registry via `apply_tool_visibility`). But two **agent-facing** strings still advertised it, so the model is told to use a tool that isn't there:

- **Session instructions** (`instructions.py`) — the `InitializeResult.instructions` blob (the highest-leverage tool-routing text) had an unconditional `ask_ollie` bullet, plus mentions in the write and default-project guidance.
- **Entity description** (`read_list/registry.py`) — the `experiment` read/list description said "Pair with `ask_ollie` for analysis."

## What changed

- The `ask_ollie` guidance in the instructions blob is now **gated on `opik_mcp_ask_ollie_enabled`** — it renders only when the tool is actually advertised, matching what the server does. Kept as a gate (not a deletion) so it stays correct if the kill switch is ever flipped back on.
- Dropped the `ask_ollie` mention from the `experiment` entity description and from the write/default-project lines.
- Tests: the blob **omits** `ask_ollie` when disabled and **includes** it when enabled.

Implementation code (`ask_ollie.py`, analytics, `ollie_client.py`, config) is untouched — this is only about what the agent is *told*.

`make check`: 1378 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)