### PR TITLE
[OPIK-8185] opik-instrument: verify span coverage + guard common ingestion traps

### DIFF
--- a/src/opik_mcp/skills/opik-instrument/SKILL.md
+++ b/src/opik_mcp/skills/opik-instrument/SKILL.md
@@ -85,6 +85,15 @@ To find the newest trace instead of using a known id, use the client's trace sea
 
 Traces are asynchronous — allow a few seconds after the run and make sure the flush ran.
 
+**Verify coverage, not just arrival.** A trace arriving is necessary but not sufficient — batching can silently drop or truncate spans, so a trace can land *incomplete* and still look fine. Before reporting `verified`:
+- **Count vs. expected.** Compare `len(client.search_spans(trace_id=tid))` against the call sites you instrumented on the path you ran (entrypoint + each traced tool/LLM). Fewer spans than expected means spans were dropped — do not report `verified`.
+- **Every span is well-formed.** Each span has a non-empty `name` and `type`; LLM spans carry input/output (and usage where the integration provides it). A span returned with an empty `name`/`type` is the batching-race symptom below, not a real span.
+
+**Common ingestion traps.** If the trace is empty, partial, or has unnamed spans, it is almost always one of these — not a bug in the instrumentation you added:
+- **Batching race on fast spans.** With batching on, a span created and ended within one flush window can be reordered by the backend and dropped (or stripped of its name). Ensure a single `flush()` at the very end and allow a few seconds before verifying.
+- **Post-hoc scores dropped.** A feedback score attached *after* a span closes (`log_traces_feedback_scores` / `log_spans_feedback_scores` by id) is lost if the span's create hasn't reached the backend yet — flush before posting the score, and reference the span by id.
+- **Missing flush.** The most common empty-trace cause: a script that exits without `opik.flush_tracker()` / `await client.flush()`.
+
 ### 7. Report
 Return a short human result + the trace link (see **Output**), then make the single expansion offer.
 

--- a/src/opik_mcp/skills/opik-instrument/SKILL.md
+++ b/src/opik_mcp/skills/opik-instrument/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools:
   - Glob
   - Bash
 metadata:
-  last_updated: "2026-08-05"
+  last_updated: "2026-09-10"
   source_commit: "2.0.0"
   argument-hint: "[optional: file or directory path]"
 ---
@@ -88,6 +88,8 @@ Traces are asynchronous — allow a few seconds after the run and make sure the 
 **Verify coverage, not just arrival.** A trace arriving is necessary but not sufficient — batching can silently drop or truncate spans, so a trace can land *incomplete* and still look fine. Before reporting `verified`:
 - **Count vs. expected.** Compare `len(client.search_spans(trace_id=tid))` against the call sites you instrumented on the path you ran (entrypoint + each traced tool/LLM). Fewer spans than expected means spans were dropped — do not report `verified`.
 - **Every span is well-formed.** Each span has a non-empty `name` and `type`; LLM spans carry input/output (and usage where the integration provides it). A span returned with an empty `name`/`type` is the batching-race symptom below, not a real span.
+
+**With the Opik MCP connected, verify there instead.** `read(entity_type="trace", id=tid)` returns `{trace, spans, spansTruncated}` with the span tree inlined (up to 200 spans), so both checks above run over that one call, no script needed: count the spans against the instrumented call sites, and confirm each has a `name`/`type` and the LLM spans carry input/output. If `spansTruncated` is true, count with the SDK instead. The SDK stays the default because it is already installed; the MCP is the shortcut when it is there.
 
 **Common ingestion traps.** If the trace is empty, partial, or has unnamed spans, it is almost always one of these — not a bug in the instrumentation you added:
 - **Batching race on fast spans.** With batching on, a span created and ended within one flush window can be reordered by the backend and dropped (or stripped of its name). Ensure a single `flush()` at the very end and allow a few seconds before verifying.


### PR DESCRIPTION
## What
Enhances the `opik-instrument` skill's **Step 6 — Verify ingestion** so that "verified" means a *complete* trace, not just that *a* trace arrived.

- **Coverage check** — compare the number of spans from `search_spans` against the call sites instrumented on the exercised path; every span must have a non-empty `name`/`type`, and LLM spans must carry input/output. Fewer or empty spans ⇒ not `verified`.
- **Common ingestion traps guard** — a short checklist for the failure modes that make a trace land empty / partial / unnamed: the batching race on fast spans, post-hoc feedback/score binding, and missing flush.

## Why
The skill already runs a safe path and checks that a trace arrives. But a trace can arrive *silently incomplete* — batching can drop or unname fast spans, and post-hoc scores can be lost if posted before the span's create reaches the backend. These were hit first-hand while instrumenting a multi-agent app from scratch: a tracer adapter that passed all unit tests and a static audit still lost trace data across three runs; only running the app and inspecting the platform caught it. A "code edits alone are not success" skill should catch that class of failure.

Docs-only change to the authored skill (`src/opik_mcp/skills/opik-instrument/SKILL.md`); the public `opik-skills` pack is built verbatim from it.

Closes OPIK-8185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
