### PR TITLE
Stamp the release version on main builds, not .dev0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,10 +90,22 @@ jobs:
           # exact tag to :x.y.z + :latest.
           SHA_TAG="sha-$(git rev-parse --short=12 HEAD)"
 
+          # On main, the image built here is the RELEASE CANDIDATE for $VERSION:
+          # `release.yaml` promotes this exact digest to :x.y.z rather than
+          # rebuilding, so whatever is stamped now is what production reports
+          # forever. Stamping `.dev0` there put `0.2.29.dev0` into prod and out
+          # of every BI cohort that filters dev builds. Off main nothing is
+          # promoted, so `.dev0` is correct and keeps branch wheels from
+          # claiming to be the release.
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_name }}" = "main" ]; then
+            PYVER="$VERSION"
+          else
+            PYVER="$VERSION.dev0"
+          fi
           echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
-          echo "pyver=$VERSION.dev0" | tee -a "$GITHUB_OUTPUT"
+          echo "pyver=$PYVER" | tee -a "$GITHUB_OUTPUT"
           echo "sha_tag=$SHA_TAG" | tee -a "$GITHUB_OUTPUT"
-          echo "### Pending version: $VERSION (image $SHA_TAG)" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Pending version: $VERSION (stamped $PYVER, image $SHA_TAG)" >> "$GITHUB_STEP_SUMMARY"
 
   python-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Production booted 0.2.29 reporting itself as **`0.2.29.dev0`**:

```
version        transport  last_boot
0.2.29.dev0    http       17:19:41
0.2.24         http       16:37:55
```

## Cause — mine, from #177

The release **promotes** the image CI built rather than rebuilding it, so whatever version CI stamps into `_version.py` is what production reports forever. #177 changed `pyver` to `$VERSION.dev0` unconditionally. That's correct reasoning for a build of a not-yet-released version — and wrong for the one build that *becomes* the release.

Before #177, main builds stamped the plain version and only PR/branch builds got `.dev0`. This restores that, with the reason written down.

## Why it isn't cosmetic

Several BI cohorts filter `opik_mcp_version NOT LIKE '%dev%'` to keep dev builds out of adoption metrics — including the **per-tool usage tile added for `read_skill`**. With production stamped `.dev0`, hosted traffic was being excluded from the dashboards meant to measure it. `read_skill` usage from prod would have read as zero.

## Effect on 0.2.29

The running code is correct — `0.2.29.dev0` is built from the `0.2.29` commit, so `read_skill` is live. Only the version string is wrong. It self-corrects on the next release; no need to re-cut 0.2.29 unless you want the string fixed sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)