### PR TITLE
[Experimental] Dashboards + chart_data tool surface

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.comet-ml/opik-mcp",
+  "title": "Opik",
+  "description": "Read Opik traces and spans, log feedback scores, manage prompts, and run evaluations.",
+  "version": "0.2.23",
+  "repository": {
+    "url": "https://github.com/comet-ml/opik-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "opik-mcp",
+      "version": "0.2.23",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "OPIK_API_KEY",
+          "description": "Opik API key, from https://www.comet.com/api/my/settings/. Not needed for a local open-source Opik, or when connecting over OAuth.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "OPIK_WORKSPACE",
+          "description": "Workspace name as it appears in the Comet URL. Leave unset for OAuth or a local open-source Opik; set it for a named cloud workspace or self-hosted Comet, otherwise reads silently come back from the account default.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "COMET_URL_OVERRIDE",
+          "description": "Base URL of a self-hosted Comet deployment. Defaults to https://www.comet.com.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "OPIK_URL",
+          "description": "Full Opik REST base URL. Only needed when Opik is served from a different host or path than the Comet UI; otherwise derived from COMET_URL_OVERRIDE.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.comet.com/_mcp/server"
+    }
+  ]
+}

--- a/src/opik_mcp/charts/__init__.py
+++ b/src/opik_mcp/charts/__init__.py
@@ -1,0 +1,42 @@
+"""Dashboards and charts (OPIK-8210).
+
+Three pieces, one vocabulary:
+
+- :mod:`~opik_mcp.charts.vocabulary` — what a chart can be about (metrics,
+  breakdowns, intervals, stat names), transcribed from opik-backend's own
+  validation rules so a bad combination fails locally with a usable sentence.
+- :mod:`~opik_mcp.charts.spec` — ``ChartSpec``, the agent-facing description
+  of one chart, compiled either into the widget JSON Opik stores or into the
+  metric query that returns its data.
+- :mod:`~opik_mcp.charts.config` / :mod:`~opik_mcp.charts.query` — the two
+  compilations: a dashboard's stored ``config`` blob, and the ``chart_data``
+  tool that runs a chart and summarises the result.
+
+The MCP surface on top is the ``dashboard.*`` operations on the ``write``
+tool, the ``dashboard`` entity on ``read``/``list``, and the ``chart_data``
+tool.
+"""
+
+from opik_mcp.charts.config import (
+    DASHBOARD_VERSION,
+    DashboardConfigError,
+    add_chart,
+    build_config,
+    flatten_charts,
+    remove_widget,
+)
+from opik_mcp.charts.query import run_chart_data
+from opik_mcp.charts.spec import ChartSpec
+from opik_mcp.charts.vocabulary import ChartVocabularyError
+
+__all__ = [
+    "DASHBOARD_VERSION",
+    "ChartSpec",
+    "ChartVocabularyError",
+    "DashboardConfigError",
+    "add_chart",
+    "build_config",
+    "flatten_charts",
+    "remove_widget",
+    "run_chart_data",
+]

--- a/src/opik_mcp/charts/config.py
+++ b/src/opik_mcp/charts/config.py
@@ -1,0 +1,311 @@
+"""Assembly of a dashboard's stored ``config`` blob.
+
+opik-backend treats ``dashboard.config`` as an opaque ``JsonNode``: it stores
+and returns whatever it is handed, and every rule about the shape lives in the
+Opik frontend. That makes this module the risky part of the write path — a
+config that round-trips through the API happily can still render as an empty
+dashboard — so the shapes here are transcribed from the frontend's own
+``lib/dashboard`` sources rather than inferred:
+
+- ``version`` is ``DASHBOARD_VERSION`` (4). The UI runs migrations for
+  anything lower; emitting the current version means it renders untouched.
+- Sections own their widgets AND their layout; the layout is a separate array
+  keyed by widget id (``i``), because the grid component takes them apart.
+- Placement mirrors ``calculateLayoutForAddingWidget``: first position that
+  minimises column height in a 6-column grid, with per-type default sizes.
+
+Everything here is pure — no client, no I/O — so the write tool's ``dry_run``
+can show the exact config it would send.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Final
+
+from opik_mcp.charts.spec import ChartSpec
+
+#: Frontend's ``DASHBOARD_VERSION``. Bump only alongside a frontend migration.
+DASHBOARD_VERSION: Final = 4
+
+#: Frontend's ``GRID_COLUMNS`` / ``MAX_WIDGET_HEIGHT``.
+GRID_COLUMNS: Final = 6
+MAX_WIDGET_HEIGHT: Final = 12
+
+DEFAULT_SECTION_TITLE: Final = "Overview"
+
+#: Per-widget-type default box, from ``getWidgetSizeConfig``. Sizes an agent
+#: never has to think about: a chart is half a row, a stat card a sixth.
+_WIDGET_SIZES: Final[dict[str, dict[str, int]]] = {
+    "project_metrics": {"w": 2, "h": 4, "minW": 2, "minH": 4},
+    "project_stats_card": {"w": 1, "h": 2, "minW": 1, "minH": 2},
+    "text_markdown": {"w": 2, "h": 4, "minW": 1, "minH": 4},
+}
+_FALLBACK_SIZE: Final[dict[str, int]] = {"w": 2, "h": 2, "minW": 1, "minH": 1}
+
+
+class DashboardConfigError(ValueError):
+    """The stored config is not a shape we can safely edit."""
+
+
+def new_id() -> str:
+    """Short, collision-free id for a section or widget.
+
+    The frontend uses ``uniqid()``; the only contract is uniqueness within the
+    dashboard and stability across saves, so a truncated uuid4 does the job
+    while staying visibly ours in a config an operator may read.
+    """
+    return f"mcp{uuid.uuid4().hex[:10]}"
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+# --- layout --------------------------------------------------------------- #
+
+
+def _size_for(widget_type: str) -> dict[str, int]:
+    return _WIDGET_SIZES.get(widget_type, _FALLBACK_SIZE)
+
+
+def _column_heights(layout: list[dict[str, Any]]) -> list[int]:
+    """Bottom edge of each grid column — ``getColumnHeights``."""
+    heights = [0] * GRID_COLUMNS
+    for item in layout:
+        x = int(item.get("x", 0))
+        w = int(item.get("w", 1))
+        bottom = int(item.get("y", 0)) + int(item.get("h", 1))
+        for col in range(max(0, x), min(x + w, GRID_COLUMNS)):
+            heights[col] = max(heights[col], bottom)
+    return heights
+
+
+def _first_available_position(w: int, heights: list[int]) -> tuple[int, int]:
+    """``findFirstAvailablePosition`` — leftmost x whose span is shallowest."""
+    best_x = 0
+    best_y: int | None = None
+    for x in range(0, GRID_COLUMNS - w + 1):
+        top = max(heights[x : x + w])
+        if best_y is None or top < best_y:
+            best_x, best_y = x, top
+    return best_x, 0 if best_y is None else best_y
+
+
+def layout_item(widget_id: str, widget_type: str, layout: list[dict[str, Any]]) -> dict[str, Any]:
+    """Layout entry placing a new widget below/beside what is already there."""
+    size = _size_for(widget_type)
+    w = min(size["w"], GRID_COLUMNS)
+    x, y = (0, 0) if not layout else _first_available_position(w, _column_heights(layout))
+    return {
+        "i": widget_id,
+        "x": x,
+        "y": y,
+        "w": w,
+        "h": size["h"],
+        "minW": size["minW"],
+        "minH": size["minH"],
+        "maxW": GRID_COLUMNS,
+        "maxH": MAX_WIDGET_HEIGHT,
+    }
+
+
+# --- building ------------------------------------------------------------- #
+
+
+def build_section(title: str, charts: list[ChartSpec]) -> dict[str, Any]:
+    """One section holding ``charts``, laid out in order."""
+    widgets: list[dict[str, Any]] = []
+    layout: list[dict[str, Any]] = []
+    for chart in charts:
+        widget = chart.to_widget(new_id())
+        widgets.append(widget)
+        layout.append(layout_item(widget["id"], widget["type"], layout))
+    return {"id": new_id(), "title": title, "widgets": widgets, "layout": layout}
+
+
+def build_config(
+    charts: list[ChartSpec] | None = None,
+    *,
+    section_title: str = DEFAULT_SECTION_TITLE,
+) -> dict[str, Any]:
+    """A complete ``dashboard.config`` holding ``charts`` in one section.
+
+    An empty dashboard still gets its section: that is what the UI's "create
+    dashboard" does, and a dashboard with zero sections offers no target to
+    drop a widget onto.
+    """
+    return {
+        "version": DASHBOARD_VERSION,
+        "sections": [build_section(section_title, list(charts or []))],
+        "lastModified": _now_ms(),
+    }
+
+
+# --- editing an existing config ------------------------------------------- #
+
+
+def _sections_of(config: Any) -> list[dict[str, Any]]:
+    if not isinstance(config, dict):
+        raise DashboardConfigError(
+            "dashboard config is not an object — refusing to edit it. Read the "
+            "dashboard and rewrite it with dashboard.create instead."
+        )
+    sections = config.get("sections")
+    if sections is None:
+        return []
+    if not isinstance(sections, list):
+        raise DashboardConfigError("dashboard config.sections is not a list — refusing to edit it.")
+    return [s for s in sections if isinstance(s, dict)]
+
+
+def add_chart(
+    config: Any,
+    chart: ChartSpec,
+    *,
+    section: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return ``(new_config, added_widget)`` with ``chart`` appended.
+
+    ``section`` names the target section by title or id; when it is omitted the
+    chart lands in the last section, which is where the UI appends too. A named
+    section that does not exist is created rather than refused — "put this on a
+    new 'Cost' row" is a normal request, and failing it would cost a turn to
+    learn a section id nobody has yet.
+
+    Read-modify-write: the backend PATCH replaces ``config`` wholesale, so the
+    caller must have just fetched the live config. Every other section, widget
+    and layout entry is preserved byte-for-byte.
+    """
+    # Copy up front so the caller's fetched config is never mutated in place —
+    # a failed PATCH must leave the in-memory dashboard as it was read.
+    sections = [dict(s) for s in _sections_of(config)]
+    widget = chart.to_widget(new_id())
+
+    index: int | None = None
+    if section is not None:
+        index = next(
+            (
+                i
+                for i, cand in enumerate(sections)
+                if cand.get("title") == section or cand.get("id") == section
+            ),
+            None,
+        )
+    elif sections:
+        index = len(sections) - 1
+
+    if index is None:
+        target: dict[str, Any] = {
+            "id": new_id(),
+            "title": section or DEFAULT_SECTION_TITLE,
+            "widgets": [],
+            "layout": [],
+        }
+        sections.append(target)
+    else:
+        target = sections[index]
+
+    widgets = [w for w in (target.get("widgets") or []) if isinstance(w, dict)]
+    layout = [entry for entry in (target.get("layout") or []) if isinstance(entry, dict)]
+    target["widgets"] = [*widgets, widget]
+    target["layout"] = [*layout, layout_item(widget["id"], widget["type"], layout)]
+
+    new_config = dict(config) if isinstance(config, dict) else {}
+    new_config["version"] = DASHBOARD_VERSION
+    new_config["sections"] = sections
+    new_config["lastModified"] = _now_ms()
+    return new_config, widget
+
+
+def remove_widget(config: Any, widget_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return ``(new_config, removed_widget)`` without ``widget_id``.
+
+    Drops the layout entry alongside the widget — an orphaned layout entry
+    leaves a hole in the grid that nothing can fill or remove from the UI.
+    """
+    sections = [dict(s) for s in _sections_of(config)]
+    removed: dict[str, Any] | None = None
+    for section in sections:
+        widgets = [w for w in (section.get("widgets") or []) if isinstance(w, dict)]
+        match = next((w for w in widgets if w.get("id") == widget_id), None)
+        if match is None:
+            continue
+        removed = match
+        section["widgets"] = [w for w in widgets if w.get("id") != widget_id]
+        section["layout"] = [
+            entry
+            for entry in (section.get("layout") or [])
+            if isinstance(entry, dict) and entry.get("i") != widget_id
+        ]
+        break
+
+    if removed is None:
+        known = ", ".join(w["id"] for _s, w in iter_widgets(config)) or "none"
+        raise DashboardConfigError(
+            f"no widget {widget_id!r} on this dashboard. Widget ids: {known}"
+        )
+
+    new_config = dict(config) if isinstance(config, dict) else {}
+    new_config["version"] = DASHBOARD_VERSION
+    new_config["sections"] = sections
+    new_config["lastModified"] = _now_ms()
+    return new_config, removed
+
+
+# --- reading -------------------------------------------------------------- #
+
+
+def iter_widgets(config: Any) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    """``(section, widget)`` pairs, in dashboard order. Never raises."""
+    out: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    if not isinstance(config, dict):
+        return out
+    for section in config.get("sections") or []:
+        if not isinstance(section, dict):
+            continue
+        for widget in section.get("widgets") or []:
+            if isinstance(widget, dict) and isinstance(widget.get("id"), str):
+                out.append((section, widget))
+    return out
+
+
+def flatten_charts(config: Any) -> list[dict[str, Any]]:
+    """The dashboard's charts as a flat, readable list.
+
+    What a reader actually needs is every chart with its section, id, type and
+    query — the nesting and the layout geometry are storage detail. Flattening
+    on read means an agent can answer "what is on this dashboard" and pass a
+    widget id straight to ``chart_data`` or ``dashboard.remove_chart`` without
+    walking the config itself.
+    """
+    charts: list[dict[str, Any]] = []
+    for section, widget in iter_widgets(config):
+        charts.append(
+            {
+                "widget_id": widget["id"],
+                "section": section.get("title"),
+                "section_id": section.get("id"),
+                "title": widget.get("title") or widget.get("generatedTitle"),
+                "type": widget.get("type"),
+                "config": widget.get("config") or {},
+            }
+        )
+    return charts
+
+
+__all__ = [
+    "DASHBOARD_VERSION",
+    "DEFAULT_SECTION_TITLE",
+    "GRID_COLUMNS",
+    "DashboardConfigError",
+    "add_chart",
+    "build_config",
+    "build_section",
+    "flatten_charts",
+    "iter_widgets",
+    "layout_item",
+    "new_id",
+    "remove_widget",
+]

--- a/src/opik_mcp/charts/dashboard_ops.py
+++ b/src/opik_mcp/charts/dashboard_ops.py
@@ -1,0 +1,444 @@
+"""The ``dashboard.*`` write operations — resolution and compilation.
+
+The other write operations translate one validated model into one request
+body. Dashboards need two things those do not, and both live here rather
+than in ``writes/dispatch.py``:
+
+*Resolution.* A chart is described in the words a user says — a project
+NAME, a dashboard by its title — while the stored config holds UUIDs. So
+the live path resolves names to ids first (:func:`resolve_context`), which
+needs a client and therefore cannot happen during validation.
+
+*Read-modify-write.* opik-backend stores ``config`` as one opaque
+document and ``PATCH`` replaces it wholesale, so adding a chart means
+fetching the current config, editing it, and sending the whole thing back.
+Nothing here mutates what it fetched: a failed request leaves the live
+dashboard exactly as it was.
+
+``dry_run`` runs without a client, so it previews with an empty context and
+:func:`preview_note` says which parts get resolved at execution — a preview
+that quietly showed unresolved names as "no project" would be a preview of
+a dashboard nobody asked for.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from opik_mcp.charts.config import add_chart, build_config, iter_widgets, remove_widget
+from opik_mcp.charts.spec import ChartSpec
+from opik_mcp.config import Settings, get_settings
+from opik_mcp.opik_client import (
+    OpikAuthError,
+    OpikNotFoundError,
+    OpikServerError,
+    OpikValidationError,
+    opik_rest_base,
+)
+from opik_mcp.writes.errors import BackendError, ValidationFailedError, ValidationIssue
+
+if TYPE_CHECKING:  # pragma: no cover — import cycle at runtime, types only
+    from opik_mcp.opik_client import OpikClient
+    from opik_mcp.writes.registry import WriteOperation
+
+DASHBOARDS_ENDPOINT = "/v1/private/dashboards"
+
+#: Operations handled here. ``dispatch`` routes on this rather than on a
+#: name prefix so a future ``dashboard.*`` operation cannot silently fall
+#: into the generic builder and emit a body nobody wrote.
+DASHBOARD_OPERATIONS: frozenset[str] = frozenset(
+    {
+        "dashboard.create",
+        "dashboard.update",
+        "dashboard.add_charts",
+        "dashboard.remove_charts",
+    }
+)
+
+
+def _fail(
+    op: WriteOperation,
+    field: str,
+    message: str,
+    code: str,
+) -> ValidationFailedError:
+    """A ``validation_failed`` envelope carrying this operation's schema.
+
+    Resolution failures ARE validation failures from the caller's side —
+    "no project called that" is a payload problem — so they arrive in the
+    same envelope, with the same schema and example, as a missing field.
+    """
+    return ValidationFailedError.build(
+        op.name,
+        [ValidationIssue(field, message, code)],
+        expected_schema=op.pydantic_model.model_json_schema(),
+        example=op.example,
+    )
+
+
+def _wrap_backend(op: WriteOperation, exc: Exception, *, path: str) -> BackendError:
+    status = getattr(exc, "http_status", None)
+    return BackendError.build(op.name, status or 502, str(exc), method="GET", path=path)
+
+
+# --- resolution (live path only) ------------------------------------------ #
+
+
+async def _resolve_project_id(op: WriteOperation, client: OpikClient, name: str) -> str:
+    """Project name → id, or a validation failure naming what to do instead.
+
+    Deliberately does NOT create the project. opik-backend's dashboard
+    endpoint would create one for an unknown ``project_name``, which turns a
+    typo into a permanent empty project charting nothing.
+    """
+    try:
+        page = await client.list_projects(name=name, size=10)
+    except (OpikAuthError, OpikValidationError, OpikServerError) as exc:
+        raise _wrap_backend(op, exc, path="/v1/private/projects") from exc
+    candidates = [
+        item
+        for item in (page.get("content") or [])
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    ]
+    exact = [c for c in candidates if c.get("name") == name]
+    if len(exact) == 1:
+        return str(exact[0]["id"])
+    if len(candidates) == 1:
+        return str(candidates[0]["id"])
+    if not candidates:
+        raise _fail(
+            op,
+            "project_name",
+            f"no project named {name!r} in this workspace. list('project') shows "
+            "what is there; pass project_id to be explicit.",
+            "project_not_found",
+        )
+    listed = ", ".join(f"{c.get('name')!r} ({c['id']})" for c in candidates[:10])
+    raise _fail(
+        op,
+        "project_name",
+        f"{len(candidates)} projects match {name!r} — pass project_id for the one "
+        f"you mean: {listed}",
+        "project_ambiguous",
+    )
+
+
+async def _resolve_dashboard(op: WriteOperation, client: OpikClient, ref: str) -> dict[str, Any]:
+    """Dashboard id or name → the stored record (including its ``config``).
+
+    Tries the id route first because that is the cheap, unambiguous case,
+    then falls back to a name search. A name matching several dashboards is
+    refused with the ids listed: editing the wrong dashboard is silent
+    damage the caller would not notice.
+    """
+    try:
+        return await client.get_dashboard(ref)
+    except (OpikNotFoundError, OpikValidationError):
+        pass
+    except (OpikAuthError, OpikServerError) as exc:
+        raise _wrap_backend(op, exc, path=f"{DASHBOARDS_ENDPOINT}/{ref}") from exc
+
+    try:
+        page = await client.list_dashboards(name=ref, size=10)
+    except (OpikAuthError, OpikValidationError, OpikServerError) as exc:
+        raise _wrap_backend(op, exc, path=DASHBOARDS_ENDPOINT) from exc
+    matches = [
+        item
+        for item in (page.get("content") or [])
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    ]
+    exact = [m for m in matches if m.get("name") == ref]
+    pick = exact[0] if len(exact) == 1 else (matches[0] if len(matches) == 1 else None)
+    if pick is None:
+        if not matches:
+            raise _fail(
+                op,
+                "dashboard",
+                f"no dashboard {ref!r} in this workspace. list('dashboard') shows "
+                "the dashboards you can edit.",
+                "dashboard_not_found",
+            )
+        listed = ", ".join(f"{m.get('name')!r} ({m['id']})" for m in matches[:10])
+        raise _fail(
+            op,
+            "dashboard",
+            f"{len(matches)} dashboards match {ref!r} — pass the id: {listed}",
+            "dashboard_ambiguous",
+        )
+    try:
+        return await client.get_dashboard(str(pick["id"]))
+    except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as exc:
+        raise _wrap_backend(op, exc, path=f"{DASHBOARDS_ENDPOINT}/{pick['id']}") from exc
+
+
+async def _resolve_chart_projects(
+    op: WriteOperation,
+    client: OpikClient,
+    charts: list[ChartSpec],
+    *,
+    default_project_id: str | None,
+) -> list[ChartSpec]:
+    """Resolve every chart's ``project_name``, and inherit the dashboard's project.
+
+    Inheritance matters more than it looks: a widget with no project scope
+    renders as "not configured" in the UI, so a chart added to a
+    project-scoped dashboard without one would save fine and display
+    nothing. A chart that names its own project keeps it.
+
+    Names are resolved once per distinct name — a dashboard is routinely
+    six charts over the same project.
+    """
+    if not charts:
+        return []
+    cache: dict[str, str] = {}
+    resolved: list[ChartSpec] = []
+    for chart in charts:
+        if chart.project_name is not None:
+            name = chart.project_name
+            if name not in cache:
+                cache[name] = await _resolve_project_id(op, client, name)
+            resolved.append(chart.with_project_id(cache[name]))
+        elif (
+            default_project_id
+            and chart.project_id is None
+            and not chart.project_ids
+            and not chart.all_projects
+        ):
+            resolved.append(chart.with_project_id(default_project_id))
+        else:
+            resolved.append(chart)
+    return resolved
+
+
+def dashboard_url(dashboard_id: str, settings: Settings) -> str | None:
+    """Deep link to the dashboard in the Opik UI, when the config allows one.
+
+    Same derivation as the instructions blob: the REST base minus its
+    ``/api`` suffix is the UI origin. Without a workspace name there is no
+    route to build, so we return ``None`` rather than a link that 404s.
+    """
+    base = opik_rest_base(settings)
+    workspace = settings.comet_workspace
+    if base is None or not workspace:
+        return None
+    if base.endswith("/api"):
+        base = base[: -len("/api")]
+    return f"{base}/{workspace}/dashboards/{dashboard_id}"
+
+
+async def resolve_context(
+    op: WriteOperation,
+    model: Any,
+    client: OpikClient,
+    *,
+    settings: Settings | None = None,
+) -> dict[str, Any]:
+    """Everything :func:`build_request` needs that only the backend knows.
+
+    Returns ``{}`` for operations this module does not handle, so the
+    dispatcher can call it unconditionally.
+    """
+    if op.name not in DASHBOARD_OPERATIONS:
+        return {}
+    s = settings if settings is not None else get_settings()
+
+    if op.name == "dashboard.create":
+        project_id: str | None = None
+        if model.project_name is not None:
+            project_id = await _resolve_project_id(op, client, model.project_name)
+        elif model.project_id is not None:
+            project_id = str(model.project_id)
+        charts = await _resolve_chart_projects(
+            op, client, list(model.charts), default_project_id=project_id
+        )
+        return {"project_id": project_id, "charts": charts, "settings": s}
+
+    record = await _resolve_dashboard(op, client, model.dashboard)
+    dashboard_id = str(record.get("id") or model.dashboard)
+    context: dict[str, Any] = {
+        "dashboard": record,
+        "dashboard_id": dashboard_id,
+        "dashboard_url": dashboard_url(dashboard_id, s),
+        "settings": s,
+    }
+    # ``update`` and ``add_charts`` carry charts; ``remove_charts`` does not.
+    model_charts = getattr(model, "charts", None)
+    if model_charts:
+        record_project = record.get("project_id")
+        context["charts"] = await _resolve_chart_projects(
+            op,
+            client,
+            list(model_charts),
+            default_project_id=record_project if isinstance(record_project, str) else None,
+        )
+    return context
+
+
+# --- compilation ---------------------------------------------------------- #
+
+
+def _widget_summary(widget: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "widget_id": widget.get("id"),
+        "title": widget.get("title"),
+        "type": widget.get("type"),
+    }
+
+
+def build_request(
+    op: WriteOperation,
+    model: Any,
+    context: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """``(path, body)`` for a dashboard operation.
+
+    With an empty ``context`` this is the ``dry_run`` preview: the path
+    carries whatever the caller passed for ``dashboard`` (a name is resolved
+    at execution) and the config edits show the widgets that WOULD be added
+    rather than a merged config this code has not fetched.
+
+    ``context["result"]`` is filled in as a side effect — the ids and the
+    deep link the caller needs next, which are only knowable here.
+    """
+    if op.name == "dashboard.create":
+        return _build_create(model, context)
+    if op.name == "dashboard.update":
+        return _build_update(model, context)
+    if op.name == "dashboard.add_charts":
+        return _build_add_charts(op, model, context)
+    if op.name == "dashboard.remove_charts":
+        return _build_remove_charts(op, model, context)
+    raise RuntimeError(f"dashboard_ops: unhandled operation {op.name!r}")  # pragma: no cover
+
+
+def _build_create(model: Any, context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    charts: list[ChartSpec] = context.get("charts") or list(model.charts)
+    config = build_config(charts, section_title=model.section_title)
+    body: dict[str, Any] = {"name": model.name, "type": model.type, "config": config}
+    if model.description is not None:
+        body["description"] = model.description
+    project_id = context.get("project_id") or (
+        str(model.project_id) if model.project_id is not None else None
+    )
+    if project_id is not None:
+        body["project_id"] = project_id
+    context["result"] = {
+        "charts_added": [_widget_summary(w) for w in _config_widgets(config)],
+        # The dashboard id is minted by the backend, so the link is built by
+        # the dispatcher from the response body rather than here.
+    }
+    return DASHBOARDS_ENDPOINT, body
+
+
+def _config_widgets(config: dict[str, Any]) -> list[dict[str, Any]]:
+    return [widget for _section, widget in iter_widgets(config)]
+
+
+def _patch_path(model: Any, context: dict[str, Any]) -> str:
+    return f"{DASHBOARDS_ENDPOINT}/{context.get('dashboard_id') or model.dashboard}"
+
+
+def _result(context: dict[str, Any], **fields: Any) -> None:
+    context["result"] = {
+        k: v
+        for k, v in {
+            "dashboard_id": context.get("dashboard_id"),
+            "dashboard_url": context.get("dashboard_url"),
+            **fields,
+        }.items()
+        if v is not None
+    }
+
+
+def _build_update(model: Any, context: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    body: dict[str, Any] = {}
+    if model.name is not None:
+        body["name"] = model.name
+    if model.description is not None:
+        body["description"] = model.description
+    if model.type is not None:
+        body["type"] = model.type
+    if model.charts is not None:
+        charts: list[ChartSpec] = context.get("charts") or list(model.charts)
+        # A wholesale config replacement, and the operation says so: every
+        # existing widget, section and layout is dropped for these charts.
+        config = build_config(charts, section_title=model.section_title)
+        body["config"] = config
+        _result(context, charts_replaced=[_widget_summary(w) for w in _config_widgets(config)])
+    else:
+        _result(context)
+    return _patch_path(model, context), body
+
+
+def _build_add_charts(
+    op: WriteOperation, model: Any, context: dict[str, Any]
+) -> tuple[str, dict[str, Any]]:
+    charts: list[ChartSpec] = context.get("charts") or list(model.charts)
+    record = context.get("dashboard")
+    if record is None:
+        # dry_run: no fetch happened. Show the widgets that would be appended;
+        # the real body is the whole merged config (see ``preview_note``).
+        preview = [chart.to_widget(f"<generated#{i + 1}>") for i, chart in enumerate(charts)]
+        return _patch_path(model, context), {"charts_to_add": preview}
+
+    config = record.get("config")
+    added: list[dict[str, Any]] = []
+    try:
+        for chart in charts:
+            config, widget = add_chart(config, chart, section=model.section)
+            added.append(widget)
+    except ValueError as exc:  # DashboardConfigError
+        raise _fail(op, "dashboard", str(exc), "dashboard_config_unreadable") from exc
+    _result(context, charts_added=[_widget_summary(w) for w in added])
+    return _patch_path(model, context), {"config": config}
+
+
+def _build_remove_charts(
+    op: WriteOperation, model: Any, context: dict[str, Any]
+) -> tuple[str, dict[str, Any]]:
+    record = context.get("dashboard")
+    if record is None:
+        return _patch_path(model, context), {"widget_ids_to_remove": list(model.widget_ids)}
+
+    config = record.get("config")
+    removed: list[dict[str, Any]] = []
+    try:
+        for widget_id in model.widget_ids:
+            config, widget = remove_widget(config, widget_id)
+            removed.append(widget)
+    except ValueError as exc:  # DashboardConfigError — unknown id, or a bad config
+        raise _fail(op, "widget_ids", str(exc), "widget_not_found") from exc
+    _result(context, charts_removed=[_widget_summary(w) for w in removed])
+    return _patch_path(model, context), {"config": config}
+
+
+def preview_note(op: WriteOperation) -> str | None:
+    """What a ``dry_run`` of this operation is NOT showing, or ``None``.
+
+    Only the parts that need the backend: a preview that looks exact when it
+    is not is worse than no preview, because the caller stops checking.
+    """
+    if op.name == "dashboard.create":
+        return (
+            "project_name values (on the dashboard and on each chart) are resolved "
+            "to project ids at execution; widget ids are generated then too."
+        )
+    if op.name in ("dashboard.add_charts", "dashboard.remove_charts"):
+        return (
+            "the live call fetches the dashboard's current config and sends the whole "
+            "merged config; this preview shows only the change, and `dashboard` is "
+            "resolved from a name to an id at execution."
+        )
+    if op.name == "dashboard.update":
+        return "`dashboard` is resolved from a name to an id at execution."
+    return None
+
+
+__all__ = [
+    "DASHBOARDS_ENDPOINT",
+    "DASHBOARD_OPERATIONS",
+    "build_request",
+    "dashboard_url",
+    "preview_note",
+    "resolve_context",
+]

--- a/src/opik_mcp/charts/query.py
+++ b/src/opik_mcp/charts/query.py
@@ -1,0 +1,615 @@
+"""``chart_data`` tool — run a chart's query and get its numbers back.
+
+The read half of the dashboards surface. It answers the question a chart
+answers ("what has trace volume done this week, split by trace name?")
+without a dashboard having to exist, and it replays a chart that DOES exist
+(``dashboard=…, widget=…``) so an agent can analyse what a user is looking at
+in the UI.
+
+Two design choices worth stating:
+
+*Series come back summarised.* A raw ``/metrics`` response is a wall of
+timestamped points, and the questions asked of a chart are almost always
+"what is it now, where was it, and which bucket is worst" — so each series
+carries ``first/last/min/max/avg/total/change_pct`` alongside its points.
+The summary is computed over the FULL series even when points are trimmed to
+fit the budget, so trimming can never change the answer to those questions.
+
+*The window is a phrase, not a pair of timestamps.* ``window="7d"`` with an
+auto-chosen bucket size is what a caller means nine times in ten, and an
+LLM computing two ISO timestamps by hand gets timezones wrong. Explicit
+``start``/``end`` remain available for a fixed window.
+
+Only project-scoped time-series metrics are queryable here — that is the one
+family opik-backend exposes as a single addressable query. Replaying a stat
+card or an experiment widget returns a message naming what to use instead,
+rather than a half-answer.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from opik_mcp.charts.config import flatten_charts
+from opik_mcp.charts.vocabulary import (
+    METRICS,
+    ChartVocabularyError,
+    MetricDef,
+    check_breakdown,
+    check_sub_metric,
+    request_filter_key,
+    resolve_interval,
+    resolve_metric,
+)
+from opik_mcp.config import Settings, get_settings
+from opik_mcp.opik_client import (
+    OpikAuthError,
+    OpikNotFoundError,
+    OpikServerError,
+    OpikValidationError,
+    make_opik_client,
+)
+from opik_mcp.read_list.compression import compact_json, estimate_tokens
+
+logger = logging.getLogger("opik_mcp.charts.query")
+
+#: Ceiling on the fan-out. Each project is one backend query, and a chart over
+#: more than a handful of projects is a workspace question, not a chart.
+MAX_PROJECTS = 10
+
+#: Defaults for the response budget. A daily series over a quarter is ~90
+#: points; 20 series x 90 points is already a large tool result, so both are
+#: capped and the caller is told when a cap bit.
+DEFAULT_MAX_SERIES = 20
+DEFAULT_MAX_POINTS = 90
+
+_WINDOW_RE = re.compile(r"^(\d+)\s*([hdwm])$", re.IGNORECASE)
+_WINDOW_UNITS = {"h": "hours", "d": "days", "w": "weeks"}
+
+
+class OpikChartClient(Protocol):
+    """The client surface ``chart_data`` needs.
+
+    A Protocol rather than the concrete client so the tests exercise the real
+    query/summary logic against a fake that returns canned metric responses.
+    """
+
+    async def list_projects(
+        self, *, name: str | None = None, page: int = 1, size: int = 10
+    ) -> dict[str, Any]: ...
+
+    async def get_project(self, project_id: str, /) -> dict[str, Any]: ...
+
+    async def get_dashboard(self, dashboard_id: str, /) -> dict[str, Any]: ...
+
+    async def list_dashboards(
+        self,
+        *,
+        name: str | None = None,
+        project_id: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]: ...
+
+    async def get_project_metrics(
+        self, project_id: str, body: dict[str, Any], /
+    ) -> dict[str, Any]: ...
+
+
+# --- window / interval ---------------------------------------------------- #
+
+
+def parse_window(window: str, *, now: datetime | None = None) -> tuple[datetime, datetime]:
+    """``"7d"`` → (now - 7 days, now). Accepts h/d/w/m (m = 30 days)."""
+    end = now or datetime.now(UTC)
+    match = _WINDOW_RE.match(window.strip())
+    if match is None:
+        raise ChartVocabularyError(
+            f"window {window!r} is not a duration. Use e.g. '24h', '7d', '4w', "
+            "'3m' — or pass explicit start/end timestamps."
+        )
+    amount, unit = int(match.group(1)), match.group(2).lower()
+    if amount <= 0:
+        raise ChartVocabularyError("window must be a positive duration, e.g. '7d'.")
+    delta = (
+        timedelta(days=30 * amount) if unit == "m" else timedelta(**{_WINDOW_UNITS[unit]: amount})
+    )
+    return end - delta, end
+
+
+def _parse_timestamp(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ChartVocabularyError(
+            f"{field}={value!r} is not an ISO-8601 timestamp, e.g. '2026-09-01T00:00:00Z'."
+        ) from exc
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def auto_interval(start: datetime, end: datetime) -> str:
+    """Bucket size that keeps a window readable: ~24-120 points.
+
+    Hourly past two days is hundreds of points for no extra insight; weekly
+    inside a fortnight is two bars. The thresholds mirror the ranges the Opik
+    UI's own date presets use.
+    """
+    span = end - start
+    if span <= timedelta(days=2):
+        return "HOURLY"
+    if span <= timedelta(days=60):
+        return "DAILY"
+    return "WEEKLY"
+
+
+def resolve_window(
+    *,
+    window: str | None,
+    start: str | None,
+    end: str | None,
+    interval: str | None,
+) -> tuple[datetime, datetime, str]:
+    """Resolve (start, end, wire interval) from the caller's time arguments."""
+    if start is not None or end is not None:
+        started = _parse_timestamp(start, "start") if start else None
+        ended = _parse_timestamp(end, "end") if end else datetime.now(UTC)
+        if started is None:
+            raise ChartVocabularyError("pass `start` when passing `end`, or use `window`.")
+        if started >= ended:
+            raise ChartVocabularyError("start must be before end.")
+    else:
+        started, ended = parse_window(window or "7d")
+    wire_interval = (
+        auto_interval(started, ended)
+        if interval is None or interval.strip().lower() in ("", "auto")
+        else resolve_interval(interval)
+    )
+    return started, ended, wire_interval
+
+
+def _iso(moment: datetime) -> str:
+    """UTC ISO-8601 with a ``Z`` suffix — the form opik-backend parses."""
+    return moment.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+# --- request building ----------------------------------------------------- #
+
+
+def build_metric_request(
+    *,
+    metric: MetricDef,
+    start: datetime,
+    end: datetime,
+    interval: str,
+    breakdown: str | None = None,
+    breakdown_key: str | None = None,
+    sub_metric: str | None = None,
+    filters: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """The ``POST /v1/private/projects/{id}/metrics`` body for one chart."""
+    body: dict[str, Any] = {
+        "metric_type": metric.wire,
+        "interval": interval,
+        "interval_start": _iso(start),
+        "interval_end": _iso(end),
+    }
+    if filters:
+        body[request_filter_key(metric.family)] = filters
+    if breakdown is not None:
+        check_breakdown(metric, breakdown, metadata_key=breakdown_key)
+        check_sub_metric(metric, breakdown, sub_metric)
+        config: dict[str, Any] = {"field": breakdown}
+        if breakdown_key is not None:
+            config["metadata_key"] = breakdown_key
+        if sub_metric is not None:
+            config["sub_metric"] = sub_metric
+        body["breakdown"] = config
+    return body
+
+
+def query_from_widget(widget: dict[str, Any]) -> dict[str, Any]:
+    """Translate a stored widget's config into ``chart_data`` arguments.
+
+    The inverse of ``ChartSpec.to_widget`` for the one widget type that maps
+    to a metric query. Returns the kwargs (``metric``, ``breakdown``,
+    ``filters``, ``project_ids``, …); raises ``ChartVocabularyError`` for a
+    widget type whose data does not come from this endpoint, because a plotted
+    number from the wrong source is worse than a refusal.
+    """
+    widget_type = widget.get("type")
+    if widget_type != "project_metrics":
+        raise ChartVocabularyError(
+            f"widget {widget.get('id')!r} is a {widget_type!r} widget — chart_data "
+            "runs project_metrics (time-series) widgets. Read the dashboard to see "
+            "a stat card's or experiment widget's configuration."
+        )
+    config = widget.get("config")
+    if not isinstance(config, dict):
+        raise ChartVocabularyError(f"widget {widget.get('id')!r} has no config to run.")
+    wire = str(config.get("metricType") or "")
+    metric = next((m for m in METRICS.values() if m.wire == wire), None)
+    if metric is None:
+        raise ChartVocabularyError(
+            f"widget {widget.get('id')!r} charts metric type {wire!r}, which this "
+            "server does not know how to query."
+        )
+    raw_breakdown = config.get("breakdown")
+    breakdown_config: dict[str, Any] = raw_breakdown if isinstance(raw_breakdown, dict) else {}
+    field = breakdown_config.get("field")
+    project_ids = config.get("projectIds")
+    if not isinstance(project_ids, list):
+        single = config.get("projectId")
+        project_ids = [single] if isinstance(single, str) and single else []
+    filters = config.get(
+        {"trace": "traceFilters", "span": "spanFilters", "thread": "threadFilters"}[metric.family]
+    )
+    return {
+        "metric": metric.name,
+        "breakdown": field if isinstance(field, str) and field != "none" else None,
+        "breakdown_key": breakdown_config.get("metadataKey"),
+        "sub_metric": breakdown_config.get("subMetric"),
+        "filters": [f for f in filters if isinstance(f, dict)]
+        if isinstance(filters, list)
+        else None,
+        "project_ids": [p for p in project_ids if isinstance(p, str)],
+        "all_projects": bool(config.get("allProjects")),
+        "title": widget.get("title"),
+    }
+
+
+# --- summarising ---------------------------------------------------------- #
+
+
+def summarize(points: list[tuple[str, float | None]]) -> dict[str, Any]:
+    """Per-series stats over the full point list.
+
+    ``None`` points are real signal — "no data in this bucket" is different
+    from zero for an average — so they are counted, excluded from the maths,
+    and never coerced.
+    """
+    values = [v for _t, v in points if isinstance(v, int | float)]
+    summary: dict[str, Any] = {"points": len(points), "with_data": len(values)}
+    if not values:
+        return summary
+    first, last = values[0], values[-1]
+    summary |= {
+        "first": first,
+        "last": last,
+        "min": min(values),
+        "max": max(values),
+        "avg": round(sum(values) / len(values), 6),
+        "total": round(sum(values), 6),
+    }
+    summary["change"] = round(last - first, 6)
+    if first:
+        summary["change_pct"] = round((last - first) / abs(first) * 100, 2)
+    return summary
+
+
+def _points_of(series: dict[str, Any]) -> list[tuple[str, float | None]]:
+    out: list[tuple[str, float | None]] = []
+    for point in series.get("data") or []:
+        if not isinstance(point, dict):
+            continue
+        value = point.get("value")
+        out.append((str(point.get("time")), value if isinstance(value, int | float) else None))
+    return out
+
+
+def _series_rank(summary: dict[str, Any]) -> float:
+    """Ordering key — biggest series first, so a capped breakdown keeps the
+    buckets that matter. ``total`` is the right magnitude for counts and cost;
+    for rates and percentiles it still orders by "most present"."""
+    total = summary.get("total")
+    return abs(float(total)) if isinstance(total, int | float) else 0.0
+
+
+# --- the tool ------------------------------------------------------------- #
+
+
+async def _resolve_projects(
+    client: OpikChartClient,
+    *,
+    project_id: str | None,
+    project_name: str | None,
+    project_ids: list[str] | None,
+) -> list[dict[str, str]]:
+    """Resolve the caller's project arguments to ``[{id, name}]``.
+
+    A name is resolved with the same rules as ``read``: exactly one match
+    resolves, several ask which, none is an error naming the filter used —
+    charts are worth failing loudly for, because a silently-wrong project
+    produces a plausible chart of the wrong thing.
+    """
+    if project_ids:
+        if len(project_ids) > MAX_PROJECTS:
+            raise ToolError(
+                f"chart_data takes at most {MAX_PROJECTS} projects; got {len(project_ids)}. "
+                "Chart the top projects individually, or use all-projects widgets in the UI."
+            )
+        resolved: list[dict[str, str]] = []
+        for pid in project_ids:
+            try:
+                project = await client.get_project(pid)
+            except OpikNotFoundError:
+                raise ToolError(f"project {pid!r} not found in this workspace.") from None
+            resolved.append({"id": pid, "name": str(project.get("name") or pid)})
+        return resolved
+
+    if project_id is not None:
+        try:
+            project = await client.get_project(project_id)
+        except OpikNotFoundError:
+            raise ToolError(
+                f"project {project_id!r} not found in this workspace. "
+                "list('project') shows the projects you can chart."
+            ) from None
+        return [{"id": project_id, "name": str(project.get("name") or project_id)}]
+
+    if project_name is None:
+        raise ToolError(
+            "chart_data needs a project: pass project_name, project_id, or "
+            "project_ids (or dashboard+widget to replay a saved chart)."
+        )
+
+    page = await client.list_projects(name=project_name, size=10)
+    candidates = [
+        item
+        for item in (page.get("content") or [])
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    ]
+    exact = [c for c in candidates if c.get("name") == project_name]
+    if len(exact) == 1:
+        return [{"id": str(exact[0]["id"]), "name": project_name}]
+    if len(candidates) == 1:
+        return [{"id": str(candidates[0]["id"]), "name": str(candidates[0].get("name") or "")}]
+    if not candidates:
+        raise ToolError(
+            f"no project matching {project_name!r} in this workspace. "
+            "list('project') shows what is there."
+        )
+    listed = ", ".join(f"{c.get('name')!r} ({c['id']})" for c in candidates[:10])
+    raise ToolError(
+        f"{len(candidates)} projects match {project_name!r} — pass project_id for the "
+        f"one you mean: {listed}"
+    )
+
+
+async def _resolve_widget(
+    client: OpikChartClient, dashboard: str, widget: str | None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """``(dashboard_record, widget)`` for a saved chart named by id or title."""
+    record: dict[str, Any] | None = None
+    try:
+        record = await client.get_dashboard(dashboard)
+    except (OpikNotFoundError, OpikValidationError):
+        record = None
+    if record is None:
+        page = await client.list_dashboards(name=dashboard, size=10)
+        matches = [
+            item
+            for item in (page.get("content") or [])
+            if isinstance(item, dict) and isinstance(item.get("id"), str)
+        ]
+        exact = [m for m in matches if m.get("name") == dashboard]
+        pick = exact[0] if len(exact) == 1 else (matches[0] if len(matches) == 1 else None)
+        if pick is None:
+            if not matches:
+                raise ToolError(
+                    f"no dashboard matching {dashboard!r}. list('dashboard') shows "
+                    "the dashboards in this workspace."
+                )
+            listed = ", ".join(f"{m.get('name')!r} ({m['id']})" for m in matches[:10])
+            raise ToolError(
+                f"{len(matches)} dashboards match {dashboard!r} — pass the id: {listed}"
+            )
+        record = await client.get_dashboard(str(pick["id"]))
+
+    charts = flatten_charts(record.get("config"))
+    if not charts:
+        raise ToolError(
+            f"dashboard {record.get('name')!r} has no widgets yet — add one with "
+            "write('dashboard.add_chart', …)."
+        )
+    if widget is None:
+        if len(charts) > 1:
+            listed = ", ".join(f"{c['title']!r} ({c['widget_id']})" for c in charts[:20])
+            raise ToolError(
+                f"dashboard {record.get('name')!r} has {len(charts)} widgets — name one "
+                f"via `widget`: {listed}"
+            )
+        chosen = charts[0]
+    else:
+        pool = [c for c in charts if c["widget_id"] == widget or c["title"] == widget]
+        if not pool:
+            listed = ", ".join(f"{c['title']!r} ({c['widget_id']})" for c in charts[:20])
+            raise ToolError(f"no widget {widget!r} on that dashboard. Widgets: {listed}")
+        chosen = pool[0]
+    return record, {
+        "id": chosen["widget_id"],
+        "title": chosen["title"],
+        "type": chosen["type"],
+        "config": chosen["config"],
+    }
+
+
+async def run_chart_data(
+    *,
+    metric: str | None = None,
+    project_name: str | None = None,
+    project_id: str | None = None,
+    project_ids: list[str] | None = None,
+    window: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    interval: str | None = None,
+    breakdown: str | None = None,
+    breakdown_key: str | None = None,
+    sub_metric: str | None = None,
+    filters: list[dict[str, Any]] | None = None,
+    dashboard: str | None = None,
+    widget: str | None = None,
+    max_series: int = DEFAULT_MAX_SERIES,
+    max_points: int = DEFAULT_MAX_POINTS,
+    settings: Settings | None = None,
+    client: OpikChartClient | None = None,
+) -> str:
+    """``chart_data`` entrypoint. See ``server.py`` for the registered tool."""
+    opik = client if client is not None else make_opik_client(settings or get_settings())
+
+    source = "spec"
+    widget_record: dict[str, Any] | None = None
+    dashboard_record: dict[str, Any] | None = None
+    if dashboard is not None:
+        source = "widget"
+        try:
+            dashboard_record, widget_record = await _resolve_widget(opik, dashboard, widget)
+            replay = query_from_widget(widget_record)
+        except ChartVocabularyError as exc:
+            raise ToolError(str(exc)) from exc
+        # Explicit arguments win over the saved config: replaying a chart over a
+        # different window ("what did this chart look like last month?") is the
+        # main reason to replay one at all.
+        metric = metric or replay["metric"]
+        breakdown = breakdown or replay["breakdown"]
+        breakdown_key = breakdown_key or replay["breakdown_key"]
+        sub_metric = sub_metric or replay["sub_metric"]
+        filters = filters if filters is not None else replay["filters"]
+        if project_id is None and project_name is None and not project_ids:
+            project_ids = replay["project_ids"] or None
+            if not project_ids and replay["all_projects"]:
+                raise ToolError(
+                    f"widget {widget_record['id']!r} charts ALL projects in the "
+                    "workspace, which this tool cannot aggregate. Pass project_ids "
+                    f"(up to {MAX_PROJECTS}) to chart specific projects instead."
+                )
+    elif widget is not None:
+        raise ToolError("`widget` needs `dashboard` — pass the dashboard holding it.")
+
+    if metric is None:
+        raise ToolError(
+            "chart_data needs `metric` (e.g. 'trace_count'), or dashboard+widget "
+            "to replay a saved chart."
+        )
+
+    try:
+        metric_def = resolve_metric(metric)
+        window_start, window_end, wire_interval = resolve_window(
+            window=window, start=start, end=end, interval=interval
+        )
+        body = build_metric_request(
+            metric=metric_def,
+            start=window_start,
+            end=window_end,
+            interval=wire_interval,
+            breakdown=breakdown,
+            breakdown_key=breakdown_key,
+            sub_metric=sub_metric,
+            filters=filters,
+        )
+    except ChartVocabularyError as exc:
+        raise ToolError(str(exc)) from exc
+
+    projects = await _resolve_projects(
+        opik, project_id=project_id, project_name=project_name, project_ids=project_ids
+    )
+
+    series: list[dict[str, Any]] = []
+    for project in projects:
+        try:
+            response = await opik.get_project_metrics(project["id"], body)
+        except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as exc:
+            raise ToolError(
+                f"failed to read metric {metric_def.name!r} for project {project['name']!r}: {exc}"
+            ) from exc
+        for raw in response.get("results") or []:
+            if not isinstance(raw, dict):
+                continue
+            points = _points_of(raw)
+            entry: dict[str, Any] = {
+                "name": str(raw.get("name") or metric_def.name),
+                "summary": summarize(points),
+                "points": points,
+            }
+            if len(projects) > 1:
+                entry["project"] = project["name"]
+            series.append(entry)
+
+    series.sort(key=lambda s: _series_rank(s["summary"]), reverse=True)
+    notes: list[str] = []
+    if len(series) > max_series:
+        notes.append(
+            f"{len(series) - max_series} of {len(series)} series omitted (largest "
+            f"{max_series} kept, ranked by total)."
+        )
+        series = series[:max_series]
+    for entry in series:
+        points = entry["points"]
+        if len(points) > max_points:
+            entry["points_omitted"] = len(points) - max_points
+            entry["points"] = points[-max_points:]
+        entry["points"] = [[t, v] for t, v in entry["points"]]
+    if any("points_omitted" in s for s in series):
+        notes.append(
+            "Some series show only their most recent points; each `summary` still "
+            "covers the whole window."
+        )
+    if metric_def.multi_series and breakdown is None:
+        notes.append(f"metric {metric_def.name}: {metric_def.multi_series}.")
+
+    payload: dict[str, Any] = {
+        "metric": metric_def.name,
+        "metric_type": metric_def.wire,
+        "interval": wire_interval,
+        "interval_start": _iso(window_start),
+        "interval_end": _iso(window_end),
+        "projects": projects,
+        "series": series,
+    }
+    if breakdown is not None:
+        payload["breakdown"] = {"field": breakdown, "key": breakdown_key, "sub_metric": sub_metric}
+    if filters:
+        payload["filters"] = filters
+    if widget_record is not None and dashboard_record is not None:
+        payload["replayed"] = {
+            "dashboard": dashboard_record.get("name"),
+            "dashboard_id": dashboard_record.get("id"),
+            "widget_id": widget_record["id"],
+            "widget_title": widget_record.get("title"),
+        }
+    if not series:
+        notes.append(
+            "No series returned — the projects have no matching data in this window "
+            "(a breakdown only returns buckets that have data)."
+        )
+    if notes:
+        payload["notes"] = notes
+
+    text = compact_json(payload)
+    header = (
+        f"[chart_data: metric={metric_def.name} source={source} "
+        f"projects={len(projects)} interval={wire_interval} "
+        f"window={_iso(window_start)}/{_iso(window_end)} series={len(series)} "
+        f"tokens~{estimate_tokens(text)}]"
+    )
+    return f"{header}\n{text}"
+
+
+__all__ = [
+    "DEFAULT_MAX_POINTS",
+    "DEFAULT_MAX_SERIES",
+    "MAX_PROJECTS",
+    "OpikChartClient",
+    "auto_interval",
+    "build_metric_request",
+    "parse_window",
+    "query_from_widget",
+    "resolve_window",
+    "run_chart_data",
+    "summarize",
+]

--- a/src/opik_mcp/charts/spec.py
+++ b/src/opik_mcp/charts/spec.py
@@ -1,0 +1,325 @@
+"""``ChartSpec`` — the agent-facing description of one chart.
+
+This is the model the ``write`` tool's dashboard operations and the
+``chart_data`` tool both take, and it is deliberately NOT the shape Opik
+stores. The stored shape is a UI widget object (camelCase keys, a layout
+entry, a grid position, a ``version`` the frontend migrates); asking an LLM
+to author that is asking it to guess at private frontend contracts. Instead
+it describes the chart in Opik's own domain terms —
+
+    {"metric": "trace_count", "project_name": "demo", "breakdown": "name"}
+
+— and :meth:`ChartSpec.to_widget` compiles that into the exact widget JSON
+the Opik UI renders, while :mod:`charts.query` compiles the same spec into
+the ``/metrics`` request that returns its data. One description, two
+executions, so a chart an agent can plot is a chart it can also save.
+
+Three widget kinds are supported, matching the dashboard widgets that read
+project data: ``metric`` (a time series), ``stat`` (a single-number card) and
+``text`` (a markdown note). The experiment widgets are deliberately absent —
+they are driven by experiment selection rather than a metric query, so
+nothing here could validate or replay them.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from opik_mcp.charts.vocabulary import (
+    ChartVocabularyError,
+    MetricDef,
+    check_breakdown,
+    check_stat_metric,
+    check_sub_metric,
+    resolve_metric,
+    widget_filter_key,
+)
+
+ChartKind = Literal["metric", "stat", "text"]
+
+#: Widget ``type`` values in the stored config, keyed by our ``kind``.
+WIDGET_TYPES: dict[ChartKind, str] = {
+    "metric": "project_metrics",
+    "stat": "project_stats_card",
+    "text": "text_markdown",
+}
+
+
+class ChartSpec(BaseModel):
+    """One chart, as an agent describes it.
+
+    ``extra='forbid'`` so a plausible-but-wrong key (``metric_type``,
+    ``chartType``) fails here with the field list rather than being dropped
+    on the floor and rendering an empty widget in the UI.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ChartKind = Field(
+        default="metric",
+        description=(
+            "'metric' = time-series chart, 'stat' = single-number card, 'text' = markdown note."
+        ),
+    )
+    title: str | None = Field(
+        default=None,
+        max_length=200,
+        description="Widget title. Defaults to a title derived from the metric.",
+    )
+    metric: str | None = Field(
+        default=None,
+        max_length=200,
+        description=(
+            "For kind='metric': a metric name (trace_count, duration, cost, "
+            "feedback_scores, span_token_usage, thread_count, …). For "
+            "kind='stat': a stat name (trace_count, error_count, duration.p50, "
+            "total_estimated_cost_sum, feedback_scores.<name>, …)."
+        ),
+    )
+    chart_type: Literal["line", "bar"] = Field(
+        default="line", description="Rendering for kind='metric'."
+    )
+    source: Literal["traces", "spans"] = Field(
+        default="traces", description="Which stats table a kind='stat' card reads."
+    )
+    project_name: str | None = Field(
+        default=None,
+        max_length=200,
+        description="Project to chart, by name. Resolved to an id when the chart is saved.",
+    )
+    project_id: UUID | None = Field(
+        default=None, description="Project to chart, by UUID. Mutually exclusive with project_name."
+    )
+    project_ids: list[UUID] | None = Field(
+        default=None,
+        max_length=50,
+        description="Chart several projects at once (workspace aggregation).",
+    )
+    all_projects: bool = Field(
+        default=False,
+        description=(
+            "Aggregate across every project in the workspace, resolved at render "
+            "time — so the chart follows projects added later."
+        ),
+    )
+    breakdown: str | None = Field(
+        default=None,
+        description=(
+            "Split the series by a dimension: name, model, provider, tags, "
+            "metadata, type, error_info, error_type, guardrail_name."
+        ),
+    )
+    breakdown_key: str | None = Field(
+        default=None,
+        max_length=200,
+        description="Metadata field to group by when breakdown='metadata'.",
+    )
+    sub_metric: str | None = Field(
+        default=None,
+        max_length=200,
+        description=(
+            "Required with a breakdown on multi-series metrics: a percentile "
+            "(p50/p90/p99) for duration, the score name for feedback scores, "
+            "the usage key for token usage."
+        ),
+    )
+    feedback_scores: list[str] | None = Field(
+        default=None,
+        max_length=50,
+        description="Restrict a feedback-score chart to these score names.",
+    )
+    filters: list[dict[str, Any]] | None = Field(
+        default=None,
+        max_length=50,
+        description=(
+            "Opik filter objects — {field, operator, value, key?} — applied to "
+            "the metric's own entity (traces, spans or threads, per the metric)."
+        ),
+    )
+    text: str | None = Field(
+        default=None, max_length=10_000, description="Markdown body for kind='text'."
+    )
+
+    # --- validation ------------------------------------------------------- #
+
+    @model_validator(mode="after")
+    def _validate(self) -> ChartSpec:
+        # Vocabulary errors are raised as ValueError so Pydantic folds them
+        # into the same ``validation_failed`` envelope as every other field
+        # rule — the model never sees two different error shapes for "this
+        # chart cannot exist".
+        try:
+            self._validate_projects()
+            if self.kind == "text":
+                self._validate_text()
+            elif self.kind == "stat":
+                self._validate_stat()
+            else:
+                self._validate_metric()
+        except ChartVocabularyError as exc:
+            raise ValueError(f"chart_spec_invalid: {exc}") from exc
+        return self
+
+    def _validate_projects(self) -> None:
+        if self.project_name is not None and self.project_id is not None:
+            raise ChartVocabularyError("pass either project_name or project_id, not both.")
+        picks = [
+            self.project_name is not None or self.project_id is not None,
+            self.project_ids is not None,
+            self.all_projects,
+        ]
+        if sum(picks) > 1:
+            raise ChartVocabularyError(
+                "pick ONE project scope: project_name/project_id, project_ids, or all_projects."
+            )
+        if self.project_ids is not None and not self.project_ids:
+            raise ChartVocabularyError(
+                "project_ids is empty — pass at least one id, or all_projects=true "
+                "to aggregate over the whole workspace."
+            )
+
+    def _validate_text(self) -> None:
+        if not self.text:
+            raise ChartVocabularyError("kind='text' needs `text` (the markdown body).")
+        if self.metric is not None:
+            raise ChartVocabularyError("kind='text' takes no metric.")
+
+    def _validate_stat(self) -> None:
+        if not self.metric:
+            raise ChartVocabularyError(
+                "kind='stat' needs `metric` — the stat to display, e.g. 'trace_count'."
+            )
+        check_stat_metric(self.metric, self.source)
+        if self.breakdown is not None:
+            raise ChartVocabularyError(
+                "a stat card shows one number and cannot be broken down — use "
+                "kind='metric' for a split series."
+            )
+
+    def _validate_metric(self) -> None:
+        if not self.metric:
+            raise ChartVocabularyError(
+                "kind='metric' needs `metric`, e.g. 'trace_count' or 'duration'."
+            )
+        metric = resolve_metric(self.metric)
+        if self.breakdown is not None:
+            check_breakdown(metric, self.breakdown, metadata_key=self.breakdown_key)
+            check_sub_metric(metric, self.breakdown, self.sub_metric)
+        elif self.breakdown_key is not None:
+            raise ChartVocabularyError(
+                "breakdown_key is only meaningful with breakdown='metadata'."
+            )
+
+    # --- derived ---------------------------------------------------------- #
+
+    @property
+    def metric_def(self) -> MetricDef:
+        """The resolved metric. Only valid for ``kind='metric'``."""
+        assert self.metric is not None  # guaranteed by _validate_metric
+        return resolve_metric(self.metric)
+
+    def resolved_title(self) -> str:
+        """Title to store — the caller's, or one derived from the chart itself."""
+        if self.title:
+            return self.title
+        if self.kind == "text":
+            return "Note"
+        assert self.metric is not None
+        base = self.metric.replace("_", " ").replace(".", " ").strip().capitalize()
+        if self.kind == "metric" and self.breakdown:
+            return f"{base} by {self.breakdown.replace('_', ' ')}"
+        return base
+
+    def project_scope(self) -> dict[str, Any]:
+        """The stored widget's project fields.
+
+        ``projectIds`` is the canonical field in the current dashboard config
+        (a one-element list IS a single-project widget); ``allProjects`` is the
+        dynamic "every project" signal, which resolves at render time rather
+        than freezing today's project list into the config.
+        """
+        if self.all_projects:
+            return {"allProjects": True}
+        if self.project_ids:
+            return {"projectIds": [str(p) for p in self.project_ids]}
+        if self.project_id is not None:
+            return {"projectIds": [str(self.project_id)]}
+        # Unscoped: legal, and the widget then follows the dashboard's own
+        # project selection at view time (project-scoped dashboards, or the
+        # runtime picker on a workspace dashboard).
+        return {}
+
+    def breakdown_config(self) -> dict[str, Any] | None:
+        """Widget-config form of the breakdown (camelCase, as the UI stores it)."""
+        if self.breakdown is None:
+            return None
+        config: dict[str, Any] = {"field": self.breakdown}
+        if self.breakdown_key is not None:
+            config["metadataKey"] = self.breakdown_key
+        if self.sub_metric is not None:
+            config["subMetric"] = self.sub_metric
+        return config
+
+    # --- compilation ------------------------------------------------------ #
+
+    def to_widget(self, widget_id: str) -> dict[str, Any]:
+        """Compile to the widget object stored inside ``dashboard.config``.
+
+        Key casing is the frontend's, not ours: these objects are read by the
+        Opik UI, so ``metricType`` / ``chartType`` / ``traceFilters`` are load
+        bearing. Empty filter lists are written explicitly because that is what
+        the UI's own editor writes, and a missing key reads as "not configured"
+        in some widget editors.
+        """
+        widget: dict[str, Any] = {
+            "id": widget_id,
+            "title": self.resolved_title(),
+            "type": WIDGET_TYPES[self.kind],
+        }
+        if self.kind == "text":
+            widget["config"] = {"content": self.text or ""}
+            return widget
+
+        if self.kind == "stat":
+            stat_filter_key = "traceFilters" if self.source == "traces" else "spanFilters"
+            config: dict[str, Any] = {
+                "source": self.source,
+                "metric": self.metric,
+                **self.project_scope(),
+                stat_filter_key: self.filters or [],
+            }
+            widget["config"] = config
+            return widget
+
+        metric = self.metric_def
+        config = {
+            "metricType": metric.wire,
+            "chartType": self.chart_type,
+            **self.project_scope(),
+            widget_filter_key(metric.family): self.filters or [],
+        }
+        breakdown = self.breakdown_config()
+        if breakdown is not None:
+            config["breakdown"] = breakdown
+        if self.feedback_scores is not None:
+            config["feedbackScores"] = self.feedback_scores
+        widget["config"] = config
+        return widget
+
+    def with_project_id(self, project_id: str) -> ChartSpec:
+        """Copy with ``project_name`` resolved to ``project_id``.
+
+        Name→id resolution needs a backend call, so it happens in the write
+        dispatcher (which has a client) rather than in validation (which must
+        stay pure and offline for ``dry_run``).
+        """
+        return self.model_copy(update={"project_id": UUID(project_id), "project_name": None})
+
+
+ChartSpecList = Annotated[list[ChartSpec], Field(max_length=50)]
+
+
+__all__ = ["WIDGET_TYPES", "ChartKind", "ChartSpec", "ChartSpecList"]

--- a/src/opik_mcp/charts/vocabulary.py
+++ b/src/opik_mcp/charts/vocabulary.py
@@ -1,0 +1,433 @@
+"""The chart vocabulary — metrics, breakdowns, intervals, stat metrics.
+
+Single source of truth for "what can a chart be about", shared by the three
+surfaces that must agree on it:
+
+- ``charts.spec`` validates an agent's ``ChartSpec`` against it,
+- ``charts.query`` builds the ``/metrics`` request body from it,
+- ``charts.config`` emits the widget JSON the Opik UI renders from it.
+
+Every table here mirrors a concrete opik-backend rule, cited per entry:
+``MetricType``, ``BreakdownField.isCompatibleWith`` and
+``BreakdownConfigValidator``. The point of duplicating them is that a bad
+combination fails locally with a sentence the model can act on, instead of
+round-tripping to a 422 whose message names Java field paths
+(``breakdown.subMetric``) the agent has never seen.
+
+The MCP-facing names are the backend enum values lowercased (``trace_count``,
+``feedback_scores``), plus a small alias table for the words people actually
+use (``latency`` → ``DURATION``). Lowercase because every other identifier on
+this tool surface is lowercase; the wire form is upper-cased on the way out.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+MetricFamily = Literal["trace", "span", "thread"]
+"""Which entity a metric aggregates over. Decides three things: the filter
+key on the request (``trace_filters`` / ``span_filters`` / ``thread_filters``),
+the filter key in the stored widget config (``traceFilters`` / …), and which
+breakdown fields the backend will accept."""
+
+SubMetricKind = Literal["percentile", "feedback_score", "usage_key"]
+"""What ``sub_metric`` means for a metric that requires one under a breakdown
+(``BreakdownConfigValidator``). ``None`` on a metric means it takes none."""
+
+
+@dataclass(frozen=True)
+class MetricDef:
+    """One entry of the metric vocabulary."""
+
+    name: str
+    """MCP-facing name (lowercase)."""
+
+    wire: str
+    """opik-backend ``MetricType`` enum value."""
+
+    family: MetricFamily
+
+    summary: str
+    """One line for the tool description / error messages."""
+
+    breakdownable: bool
+    """Whether opik-backend accepts ANY breakdown for this metric.
+
+    Mirrors membership of ``BreakdownField``'s ``TRACE_METRICS`` /
+    ``SPAN_METRICS`` / ``THREAD_METRICS`` sets — which are narrower than the
+    metric families: ``trace_error_rate`` is a trace metric but is in none of
+    those sets, so every breakdown but ``none`` is rejected for it.
+    """
+
+    sub_metric: SubMetricKind | None = None
+    """Set when a breakdown on this metric requires ``sub_metric``."""
+
+    multi_series: str = ""
+    """Noted when the backend returns more than one series for the metric
+    (e.g. duration returns p50/p90/p99), so a caller reading the result knows
+    the series split is the backend's, not a breakdown."""
+
+
+_METRIC_LIST: Final[tuple[MetricDef, ...]] = (
+    # --- trace metrics --- #
+    MetricDef("trace_count", "TRACE_COUNT", "trace", "Number of traces per bucket.", True),
+    MetricDef(
+        "duration",
+        "DURATION",
+        "trace",
+        "Trace latency percentiles (ms).",
+        True,
+        sub_metric="percentile",
+        multi_series="returns three series: duration.p50, duration.p90, duration.p99",
+    ),
+    MetricDef(
+        "trace_average_duration",
+        "TRACE_AVERAGE_DURATION",
+        "trace",
+        "Mean trace latency (ms).",
+        False,
+    ),
+    MetricDef(
+        "trace_error_rate", "TRACE_ERROR_RATE", "trace", "Share of traces that errored.", False
+    ),
+    MetricDef("cost", "COST", "trace", "Estimated LLM spend (USD) attributed to traces.", True),
+    MetricDef(
+        "token_usage",
+        "TOKEN_USAGE",
+        "trace",
+        "Token counts on traces.",
+        True,
+        sub_metric="usage_key",
+        multi_series="one series per usage key (prompt_tokens, completion_tokens, …)",
+    ),
+    MetricDef(
+        "feedback_scores",
+        "FEEDBACK_SCORES",
+        "trace",
+        "Average trace feedback score.",
+        True,
+        sub_metric="feedback_score",
+        multi_series="one series per feedback-score name",
+    ),
+    MetricDef(
+        "guardrails_failed_count",
+        "GUARDRAILS_FAILED_COUNT",
+        "trace",
+        "Guardrail failures on traces.",
+        True,
+    ),
+    # --- span metrics --- #
+    MetricDef("span_count", "SPAN_COUNT", "span", "Number of spans per bucket.", True),
+    MetricDef(
+        "span_duration",
+        "SPAN_DURATION",
+        "span",
+        "Span latency percentiles (ms).",
+        True,
+        sub_metric="percentile",
+        multi_series="returns three series: duration.p50, duration.p90, duration.p99",
+    ),
+    MetricDef(
+        "span_average_duration",
+        "SPAN_AVERAGE_DURATION",
+        "span",
+        "Mean span latency (ms).",
+        False,
+    ),
+    MetricDef("span_error_rate", "SPAN_ERROR_RATE", "span", "Share of spans that errored.", False),
+    MetricDef("span_cost", "SPAN_COST", "span", "Estimated spend (USD) per span.", False),
+    MetricDef(
+        "span_token_usage",
+        "SPAN_TOKEN_USAGE",
+        "span",
+        "Token counts on spans — the one to break down by model or provider.",
+        True,
+        sub_metric="usage_key",
+        multi_series="one series per usage key (prompt_tokens, completion_tokens, …)",
+    ),
+    MetricDef(
+        "span_feedback_scores",
+        "SPAN_FEEDBACK_SCORES",
+        "span",
+        "Average span feedback score.",
+        True,
+        sub_metric="feedback_score",
+        multi_series="one series per feedback-score name",
+    ),
+    # --- thread metrics --- #
+    MetricDef("thread_count", "THREAD_COUNT", "thread", "Number of conversation threads.", True),
+    MetricDef(
+        "thread_duration",
+        "THREAD_DURATION",
+        "thread",
+        "Thread duration percentiles (ms).",
+        True,
+        sub_metric="percentile",
+        multi_series="returns three series: duration.p50, duration.p90, duration.p99",
+    ),
+    MetricDef(
+        "thread_average_duration",
+        "THREAD_AVERAGE_DURATION",
+        "thread",
+        "Mean thread duration (ms).",
+        False,
+    ),
+    MetricDef("thread_cost", "THREAD_COST", "thread", "Estimated spend (USD) per thread.", False),
+    MetricDef(
+        "thread_feedback_scores",
+        "THREAD_FEEDBACK_SCORES",
+        "thread",
+        "Average thread feedback score.",
+        True,
+        sub_metric="feedback_score",
+        multi_series="one series per feedback-score name",
+    ),
+)
+
+METRICS: Final[dict[str, MetricDef]] = {m.name: m for m in _METRIC_LIST}
+METRIC_NAMES: Final[tuple[str, ...]] = tuple(METRICS)
+
+#: Words people use for a metric that is not what the backend calls it. Kept
+#: deliberately small — an alias table is a second vocabulary to maintain, so
+#: it earns its place only for the handful of terms an LLM reaches for first.
+METRIC_ALIASES: Final[dict[str, str]] = {
+    "latency": "duration",
+    "trace_duration": "duration",
+    "traces": "trace_count",
+    "spans": "span_count",
+    "threads": "thread_count",
+    "error_rate": "trace_error_rate",
+    "errors": "trace_error_rate",
+    "tokens": "token_usage",
+    "spend": "cost",
+    "quality": "feedback_scores",
+    "scores": "feedback_scores",
+}
+
+
+class ChartVocabularyError(ValueError):
+    """A metric / breakdown / interval the vocabulary doesn't have.
+
+    Carries the valid alternatives in the message: a wrong guess should cost
+    one turn, not a fishing expedition (same contract as ``UnknownSkillError``).
+    """
+
+
+def resolve_metric(name: str) -> MetricDef:
+    """MCP-facing metric name (or alias, any case) → its definition."""
+    key = name.strip().lower()
+    key = METRIC_ALIASES.get(key, key)
+    metric = METRICS.get(key)
+    if metric is None:
+        raise ChartVocabularyError(
+            f"unknown metric {name!r}. Valid metrics: {', '.join(METRIC_NAMES)}"
+        )
+    return metric
+
+
+# --- breakdowns ----------------------------------------------------------- #
+
+#: ``BreakdownField`` values, minus ``none`` which is spelled by omitting the
+#: breakdown entirely on this surface.
+BREAKDOWN_FIELDS: Final[tuple[str, ...]] = (
+    "tags",
+    "metadata",
+    "name",
+    "error_info",
+    "error_type",
+    "model",
+    "provider",
+    "type",
+    "guardrail_name",
+)
+
+#: Which families each breakdown field applies to — a direct transcription of
+#: ``BreakdownField.isCompatibleWith``. ``guardrail_name`` is the one field
+#: pinned to a single metric rather than a family, handled below.
+_BREAKDOWN_FAMILIES: Final[dict[str, frozenset[str]]] = {
+    "tags": frozenset({"trace", "span", "thread"}),
+    "metadata": frozenset({"trace", "span"}),
+    "name": frozenset({"trace", "span"}),
+    "error_info": frozenset({"trace", "span"}),
+    "error_type": frozenset({"trace", "span"}),
+    "model": frozenset({"span"}),
+    "provider": frozenset({"span"}),
+    "type": frozenset({"span"}),
+    "guardrail_name": frozenset(),  # metric-pinned, see check_breakdown
+}
+
+
+def check_breakdown(metric: MetricDef, field: str, *, metadata_key: str | None) -> None:
+    """Raise ``ChartVocabularyError`` unless the backend would accept the pair.
+
+    Reproduces ``BreakdownField.isCompatibleWith`` plus the ``METADATA``
+    requires-a-key rule, so an incompatible combination is refused here with a
+    message naming what WOULD work, rather than as a backend 422.
+    """
+    if field not in _BREAKDOWN_FAMILIES:
+        raise ChartVocabularyError(
+            f"unknown breakdown {field!r}. Valid breakdowns: {', '.join(BREAKDOWN_FIELDS)}"
+        )
+    if not metric.breakdownable:
+        allowed = ", ".join(m.name for m in _METRIC_LIST if m.breakdownable)
+        raise ChartVocabularyError(
+            f"metric {metric.name!r} does not support a breakdown. Metrics that do: {allowed}"
+        )
+    if field == "guardrail_name":
+        if metric.name != "guardrails_failed_count":
+            raise ChartVocabularyError(
+                "breakdown 'guardrail_name' only applies to metric 'guardrails_failed_count'."
+            )
+    elif metric.family not in _BREAKDOWN_FAMILIES[field]:
+        usable = ", ".join(f for f in BREAKDOWN_FIELDS if metric.family in _BREAKDOWN_FAMILIES[f])
+        raise ChartVocabularyError(
+            f"breakdown {field!r} does not apply to {metric.family} metrics "
+            f"like {metric.name!r}. Usable breakdowns here: {usable or 'none'}"
+        )
+    if field == "metadata" and not metadata_key:
+        raise ChartVocabularyError(
+            "breakdown 'metadata' needs breakdown_key — the metadata field to "
+            "group by, e.g. breakdown_key='environment'."
+        )
+
+
+VALID_PERCENTILES: Final[tuple[str, ...]] = ("p50", "p90", "p99")
+
+
+def check_sub_metric(metric: MetricDef, field: str, sub_metric: str | None) -> None:
+    """Enforce ``BreakdownConfigValidator``'s ``sub_metric`` rules locally.
+
+    Under a breakdown, duration metrics need a percentile, feedback-score
+    metrics need the score name, and token-usage metrics need the usage key —
+    because a breakdown collapses the multi-series response to one series and
+    the backend has no default for which one that is.
+    """
+    if metric.sub_metric is None:
+        return
+    if not sub_metric:
+        hint = {
+            "percentile": "a percentile — one of p50, p90, p99",
+            "feedback_score": "the feedback-score name to plot, e.g. 'hallucination'",
+            "usage_key": "the usage key, e.g. 'completion_tokens'",
+        }[metric.sub_metric]
+        raise ChartVocabularyError(
+            f"breakdown {field!r} on metric {metric.name!r} needs sub_metric: {hint}."
+        )
+    if metric.sub_metric == "percentile" and sub_metric.lower() not in VALID_PERCENTILES:
+        raise ChartVocabularyError(
+            f"sub_metric {sub_metric!r} is not a percentile. Valid values: "
+            f"{', '.join(VALID_PERCENTILES)}"
+        )
+
+
+# --- intervals ------------------------------------------------------------ #
+
+INTERVALS: Final[tuple[str, ...]] = ("hourly", "daily", "weekly", "total")
+
+
+def resolve_interval(interval: str) -> str:
+    """MCP-facing interval → opik-backend ``TimeInterval`` enum value."""
+    key = interval.strip().lower()
+    if key not in INTERVALS:
+        raise ChartVocabularyError(
+            f"unknown interval {interval!r}. Valid intervals: {', '.join(INTERVALS)}"
+        )
+    return key.upper()
+
+
+# --- stat-card metrics ---------------------------------------------------- #
+#
+# Stat cards read the trace/span STATS aggregates, a different vocabulary from
+# the time-series metrics above (they are stat names, not MetricType values).
+# Transcribed from the frontend's ProjectStatsCardWidget metric table, which is
+# what the widget's `metric` field is validated against when the UI renders it.
+
+_SHARED_STAT_METRICS: Final[tuple[str, ...]] = (
+    "duration.p50",
+    "duration.p90",
+    "duration.p99",
+    "input",
+    "output",
+    "metadata",
+    "tags",
+    "total_estimated_cost_sum",
+    "usage.completion_tokens",
+    "usage.prompt_tokens",
+    "usage.total_tokens",
+    "error_count",
+)
+
+STAT_METRICS: Final[dict[str, tuple[str, ...]]] = {
+    "traces": (
+        "trace_count",
+        "thread_count",
+        "llm_span_count",
+        "span_count",
+        "total_estimated_cost",
+        "guardrails_failed_count",
+        *_SHARED_STAT_METRICS,
+    ),
+    "spans": (
+        "span_count",
+        "total_estimated_cost",
+        *_SHARED_STAT_METRICS,
+    ),
+}
+
+#: Prefix that turns a stat metric into "average of this feedback score", the
+#: one open-ended member of the stat vocabulary (the score name is workspace
+#: data, so it cannot be enumerated here).
+FEEDBACK_SCORE_STAT_PREFIX: Final = "feedback_scores."
+
+
+def check_stat_metric(metric: str, source: str) -> None:
+    valid = STAT_METRICS.get(source)
+    if valid is None:
+        raise ChartVocabularyError(
+            f"unknown stat source {source!r}. Valid sources: {', '.join(STAT_METRICS)}"
+        )
+    if metric.startswith(FEEDBACK_SCORE_STAT_PREFIX) and len(metric) > len(
+        FEEDBACK_SCORE_STAT_PREFIX
+    ):
+        return
+    if metric not in valid:
+        raise ChartVocabularyError(
+            f"unknown stat metric {metric!r} for source {source!r}. Valid: "
+            f"{', '.join(valid)}, or '{FEEDBACK_SCORE_STAT_PREFIX}<score name>'"
+        )
+
+
+# --- filters -------------------------------------------------------------- #
+
+
+def request_filter_key(family: MetricFamily) -> str:
+    """Filter field on the ``/metrics`` request body for this metric family."""
+    return {"trace": "trace_filters", "span": "span_filters", "thread": "thread_filters"}[family]
+
+
+def widget_filter_key(family: MetricFamily) -> str:
+    """Filter field inside the stored widget config (the UI reads camelCase)."""
+    return {"trace": "traceFilters", "span": "spanFilters", "thread": "threadFilters"}[family]
+
+
+__all__ = [
+    "BREAKDOWN_FIELDS",
+    "FEEDBACK_SCORE_STAT_PREFIX",
+    "INTERVALS",
+    "METRICS",
+    "METRIC_ALIASES",
+    "METRIC_NAMES",
+    "STAT_METRICS",
+    "VALID_PERCENTILES",
+    "ChartVocabularyError",
+    "MetricDef",
+    "MetricFamily",
+    "check_breakdown",
+    "check_stat_metric",
+    "check_sub_metric",
+    "request_filter_key",
+    "resolve_interval",
+    "resolve_metric",
+    "widget_filter_key",
+]

--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -43,16 +43,22 @@ Tool selection:
 - read / list: use for any "show me X" or "what is Y" — these are the cheapest \
 reads. read takes (entity_type, id_or_name_or_uri); list takes (entity_type, \
 optional name filter, page, size). Readable entity types include trace, span, \
-project, experiment, prompt, test_suite, thread. Composite reads (trace, prompt, \
-thread) inline their child collections so one call usually gets the full picture. \
-For a thread, pass the thread link/URI or a project_id — read('thread', …) \
-returns the messages list, and list('thread', project_id=…) enumerates a \
-project's threads.
+project, experiment, prompt, test_suite, thread, dashboard. Composite reads \
+(trace, prompt, thread, dashboard) inline their child collections so one call \
+usually gets the full picture. For a thread, pass the thread link/URI or a \
+project_id — read('thread', …) returns the messages list, and \
+list('thread', project_id=…) enumerates a project's threads.
+- chart_data: the numbers behind any Opik metric — volume, latency, cost, \
+tokens, errors, feedback scores — over a project and a window, optionally \
+broken down by name/model/provider/tags/metadata. Use it to ANSWER a \
+quantitative question, and to check a chart before saving it with the \
+dashboard.* write operations. Pass dashboard+widget to re-run a chart the user \
+already has.
 - Direct writes — use when the user's intent is concrete and well-defined \
 ("score this trace 0.8 on helpfulness", "comment 'retry with temperature=0' \
 on span X").{prefer_narrow_clause} The full write surface is two tools: write (takes \
 operation + data; pass a list for batch) and schema (returns an op's JSON \
-Schema + bundled example). Operations covered by Phase 1: \
+Schema + bundled example). Operations: \
 {write_operations}. run_experiment is a separate tool. Always consult \
 tools/list for what's actually advertised on this connection.{ask_ollie_clause}
 - read_skill: Opik's own agent skills ({skill_names}) ship with this server. \

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -166,6 +166,15 @@ class OpikListClient(Protocol):
         self, prompt_id: str, /, *, page: int = 1, size: int = 10
     ) -> dict[str, Any]: ...
 
+    async def list_dashboards(
+        self,
+        *,
+        name: str | None = None,
+        project_id: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]: ...
+
 
 class OpikReadClient(OpikListClient, Protocol):
     """Adds singleton ``get_*`` endpoints to ``OpikListClient`` for the read tool.
@@ -196,6 +205,8 @@ class OpikReadClient(OpikListClient, Protocol):
         project_name: str | None = None,
         truncate: bool = False,
     ) -> dict[str, Any]: ...
+
+    async def get_dashboard(self, dashboard_id: str, /) -> dict[str, Any]: ...
 
 
 # --- client --------------------------------------------------------------- #
@@ -598,6 +609,63 @@ class OpikClient:
             f"/v1/private/prompts/{prompt_id}/versions",
             params={"page": page, "size": size},
             entity_hint=f"prompt {prompt_id!r} versions",
+        )
+
+    # -- reads: dashboards / charts --
+
+    async def list_dashboards(
+        self,
+        *,
+        name: str | None = None,
+        project_id: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]:
+        """``GET /v1/private/dashboards`` — Spring Page envelope.
+
+        ``name`` is a case-insensitive substring filter (used for the read
+        tool's name lookup). ``project_id`` narrows to the dashboards scoped to
+        one project; without it the page covers the workspace's dashboards.
+        """
+        params: dict[str, Any] = {"page": page, "size": size}
+        if name is not None:
+            params["name"] = name
+        if project_id is not None:
+            params["project_id"] = project_id
+        return await self._get_json(
+            "/v1/private/dashboards",
+            params=params,
+            entity_hint="dashboards",
+        )
+
+    async def get_dashboard(self, dashboard_id: str) -> dict[str, Any]:
+        """``GET /v1/private/dashboards/{id}`` — dashboard + its ``config`` blob.
+
+        ``config`` is an opaque JSON document owned by the Opik frontend (see
+        ``charts.config``); the read tool flattens it into a chart list rather
+        than handing the nesting to the model.
+        """
+        return await self._get_json(
+            f"/v1/private/dashboards/{dashboard_id}",
+            params=None,
+            entity_hint=f"dashboard {dashboard_id!r}",
+        )
+
+    async def get_project_metrics(
+        self,
+        project_id: str,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``POST /v1/private/projects/{id}/metrics`` — one chart's time series.
+
+        POST-with-body because the request carries filters and a breakdown, not
+        because it writes: this is the read behind every ``project_metrics``
+        dashboard widget, and behind the ``chart_data`` tool.
+        """
+        return await self._post_json(
+            f"/v1/private/projects/{project_id}/metrics",
+            json=body,
+            entity_hint=f"metrics for project {project_id!r}",
         )
 
     # -- internals --

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -27,6 +27,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+from opik_mcp.charts.config import flatten_charts
 from opik_mcp.opik_client import OpikListClient, OpikReadClient
 from opik_mcp.read_list.compression import (
     TOKEN_FULL_THRESHOLD,
@@ -246,6 +247,23 @@ async def _fetch_thread(
     }
 
 
+async def _fetch_dashboard(client: OpikReadClient, entity_id: str) -> dict[str, Any]:
+    """Dashboard metadata + its charts, flattened.
+
+    The stored ``config`` is a nested frontend document — sections holding
+    widgets, plus a parallel layout array of grid geometry. None of that
+    nesting answers a question anyone asks of a dashboard, and the layout
+    answers none at all, so the read returns the metadata with a flat
+    ``charts`` list: one entry per widget carrying its section, id, title,
+    type and query config. That is the shape ``chart_data`` and
+    ``dashboard.remove_chart`` take ids from.
+    """
+    dashboard = await client.get_dashboard(entity_id)
+    charts = flatten_charts(dashboard.get("config"))
+    meta = {k: v for k, v in dashboard.items() if k != "config"}
+    return {"dashboard": meta, "charts": charts, "chart_count": len(charts)}
+
+
 async def _unsupported_fetch(_client: OpikReadClient, _entity_id: str) -> dict[str, Any]:
     """Sentinel for list-only entities. The read tool raises before calling this."""
     raise NotImplementedError(
@@ -270,6 +288,10 @@ async def _search_prompt(client: OpikReadClient, name: str) -> list[dict[str, An
 
 async def _search_test_suite(client: OpikReadClient, name: str) -> list[dict[str, Any]]:
     return _candidates(await client.list_test_suites(name=name, size=5))
+
+
+async def _search_dashboard(client: OpikReadClient, name: str) -> list[dict[str, Any]]:
+    return _candidates(await client.list_dashboards(name=name, size=5))
 
 
 # --- list fns ------------------------------------------------------------- #
@@ -315,6 +337,12 @@ async def _list_prompt_versions(client: OpikListClient, **kw: Any) -> dict[str, 
         raise ValueError("list prompt_version requires prompt_id")
     kw.pop("name", None)
     return await client.list_prompt_versions(prompt_id, **kw)
+
+
+async def _list_dashboards(client: OpikListClient, **kw: Any) -> dict[str, Any]:
+    # ``project_id`` is optional here (unlike traces/threads): passing it lists
+    # the dashboards scoped to that project, omitting it lists the workspace's.
+    return await client.list_dashboards(**kw)
 
 
 async def _list_threads(client: OpikListClient, **kw: Any) -> dict[str, Any]:
@@ -484,6 +512,20 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         description=(
             "Prompt version. Currently list-only — pass prompt_id to enumerate. "
             "Use read('prompt', id) to get the prompt + all versions in one call."
+        ),
+    ),
+    "dashboard": EntityHandler(
+        entity_type="dashboard",
+        fetch_fn=_fetch_dashboard,
+        search_by_name_fn=_search_dashboard,
+        list_fn=_list_dashboards,
+        list_extra_fields=("type", "created_at"),
+        description=(
+            "Dashboard + its charts, flattened: {dashboard, charts, chart_count}. "
+            "Each chart carries its widget_id, section, title, type and query "
+            "config — pass a widget_id to chart_data to run it. list('dashboard') "
+            "enumerates the workspace's dashboards; add project_id for a "
+            "project's own."
         ),
     ),
     "thread": EntityHandler(

--- a/src/opik_mcp/read_list/uri.py
+++ b/src/opik_mcp/read_list/uri.py
@@ -12,6 +12,7 @@ Recognized shapes (matching the deleted ``resources.py`` URI templates):
 - ``opik://test-suites/{id}``               → ("test_suite", id)
 - ``opik://experiments/{id}``               → ("experiment", id)
 - ``opik://prompts/{id}``                   → ("prompt", id)
+- ``opik://dashboards/{id}``                → ("dashboard", id)
 - ``opik://projects/{pid}/threads/{tid}``   → ("thread", tid, project_id=pid)
 
 A pasted Opik web thread link (``https://…/projects/{pid}/…?thread={tid}``) is
@@ -61,6 +62,7 @@ _PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^opik://test-suites/([^/?#]+)$"), "test_suite"),
     (re.compile(r"^opik://experiments/([^/?#]+)$"), "experiment"),
     (re.compile(r"^opik://prompts/([^/?#]+)$"), "prompt"),
+    (re.compile(r"^opik://dashboards/([^/?#]+)$"), "dashboard"),
 ]
 
 # Threads carry a project id AND a thread id, so they need two capture groups —

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -37,6 +37,18 @@ from opik_mcp.auth_context import (
     resolved_workspace_name,
     settings_auth_mode,
 )
+from opik_mcp.charts.query import (
+    DEFAULT_MAX_POINTS,
+    DEFAULT_MAX_SERIES,
+    MAX_PROJECTS,
+    run_chart_data,
+)
+from opik_mcp.charts.vocabulary import (
+    BREAKDOWN_FIELDS,
+    INTERVALS,
+    METRIC_NAMES,
+    METRICS,
+)
 from opik_mcp.config import MissingConfigError, Settings, get_settings
 from opik_mcp.credential_identity import remember_identity, remember_session
 from opik_mcp.instructions import render_instructions
@@ -101,6 +113,31 @@ def _list_props(_result: Any, kwargs: dict[str, Any]) -> dict[str, str]:
         "had_name_filter": str(kwargs.get("name") is not None).lower(),
         "page": str(kwargs.get("page", 1)),
         "size": str(kwargs.get("size", 25)),
+    }
+
+
+def _chart_data_props(_result: Any, kwargs: dict[str, Any]) -> dict[str, str]:
+    """Analytics labels for ``chart_data``.
+
+    ``metric`` and ``breakdown`` are closed vocabularies (see
+    ``charts.vocabulary``), so they are safe as raw labels and they are the
+    two dimensions that say what people actually chart. ``source`` separates
+    an ad-hoc question from replaying a saved widget — the difference between
+    "an agent computed a chart" and "an agent read the user's dashboard".
+    """
+    metric = str(kwargs.get("metric") or "")
+    breakdown = str(kwargs.get("breakdown") or "")
+    return {
+        "source": "widget" if kwargs.get("dashboard") is not None else "spec",
+        "metric": metric if metric in METRIC_NAMES else ("alias_or_unknown" if metric else "none"),
+        "breakdown": breakdown
+        if breakdown in BREAKDOWN_FIELDS
+        else ("other" if breakdown else "none"),
+        "had_filters": str(bool(kwargs.get("filters"))).lower(),
+        "project_count_bucket": bucket_count(
+            len(kwargs.get("project_ids") or [])
+            or (1 if kwargs.get("project_id") or kwargs.get("project_name") else 0)
+        ),
     }
 
 
@@ -356,6 +393,186 @@ async def list_entities(
         project_name=project_name,
         test_suite_id=test_suite_id,
         prompt_id=prompt_id,
+    )
+
+
+# --- chart_data (OPIK-8210) ---------------------------------------------- #
+#
+# The description is rendered from ``charts.vocabulary`` rather than written
+# out, for the same reason the write tool's is rendered from its registry: the
+# metric list IS the tool's contract, and a hand-maintained copy of it would
+# drift the first time opik-backend gains a metric type.
+
+
+def _chart_metric_catalog() -> str:
+    families = {"trace": "Traces", "span": "Spans", "thread": "Threads"}
+    lines: list[str] = []
+    for family, label in families.items():
+        names = [m.name for m in METRICS.values() if m.family == family]
+        lines.append(f"- {label}: {', '.join(names)}")
+    return "\n".join(lines)
+
+
+_CHART_DATA_DESCRIPTION = (
+    "Run an Opik metric query and get the numbers back — the data behind a "
+    "dashboard chart, with or without the dashboard.\n\n"
+    "Use it to ANSWER a question with data ('has p99 latency moved this "
+    "week?', 'which model is burning the most tokens?'), to CHECK a chart "
+    "before saving it with write('dashboard.create', …), and to READ a chart "
+    "a user is looking at (pass `dashboard` + `widget`).\n\n"
+    f"Metrics:\n{_chart_metric_catalog()}\n\n"
+    "Notes:\n"
+    "- Scope: project_name, project_id, or project_ids "
+    f"(max {MAX_PROJECTS}) — or dashboard+widget, which brings its own.\n"
+    "- Window: `window='7d'` (h/d/w/m) or explicit start/end. The bucket size "
+    f"is chosen from the window unless you pass interval ({', '.join(INTERVALS)}).\n"
+    "- `breakdown` splits the series (name, model, provider, tags, metadata, "
+    "type, error_info, error_type, guardrail_name). Multi-series metrics "
+    "(duration, token_usage, feedback_scores) need `sub_metric` under a "
+    "breakdown — a percentile, a usage key, or a score name.\n"
+    "- Each series comes back with its points AND a summary "
+    "(first/last/min/max/avg/total/change_pct) computed over the whole window, "
+    "so the summary is still exact when points are trimmed."
+)
+
+
+@mcp.tool(description=_CHART_DATA_DESCRIPTION)
+@instrument_tool("chart_data", props_fn=_chart_data_props)
+async def chart_data(
+    metric: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Metric to chart, e.g. 'trace_count', 'duration', 'cost', "
+                "'feedback_scores', 'span_token_usage'. Optional only when "
+                "replaying a saved widget via dashboard+widget."
+            ),
+            max_length=200,
+        ),
+    ] = None,
+    project_name: Annotated[
+        str | None,
+        Field(description="Project to chart, by name.", max_length=200),
+    ] = None,
+    project_id: Annotated[
+        str | None,
+        Field(description="Project to chart, by UUID."),
+    ] = None,
+    project_ids: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                f"Chart several projects at once (max {MAX_PROJECTS}); each is "
+                "returned as its own series."
+            ),
+        ),
+    ] = None,
+    window: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Relative window ending now: '24h', '7d', '4w', '3m'. "
+                "Defaults to '7d'. Ignored when start/end are given."
+            ),
+            max_length=16,
+        ),
+    ] = None,
+    start: Annotated[
+        str | None,
+        Field(description="ISO-8601 window start, e.g. '2026-08-01T00:00:00Z'.", max_length=64),
+    ] = None,
+    end: Annotated[
+        str | None,
+        Field(description="ISO-8601 window end. Defaults to now.", max_length=64),
+    ] = None,
+    interval: Annotated[
+        str | None,
+        Field(
+            description=(
+                f"Bucket size: {', '.join(INTERVALS)}, or 'auto' (default) to pick "
+                "one from the window."
+            ),
+            max_length=16,
+        ),
+    ] = None,
+    breakdown: Annotated[
+        str | None,
+        Field(
+            description="Split the series by a dimension.",
+            json_schema_extra={"enum": list(BREAKDOWN_FIELDS)},
+        ),
+    ] = None,
+    breakdown_key: Annotated[
+        str | None,
+        Field(description="Metadata field to group by when breakdown='metadata'.", max_length=200),
+    ] = None,
+    sub_metric: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Which series to keep under a breakdown: a percentile (p50/p90/p99) "
+                "for duration metrics, the score name for feedback scores, the usage "
+                "key for token usage."
+            ),
+            max_length=200,
+        ),
+    ] = None,
+    filters: Annotated[
+        list[dict[str, Any]] | None,
+        Field(
+            description=(
+                "Opik filter objects — {field, operator, value, key?} — applied to "
+                "the metric's own entity (traces, spans or threads)."
+            ),
+        ),
+    ] = None,
+    dashboard: Annotated[
+        str | None,
+        Field(
+            description="Replay a saved chart: the dashboard's id or name.",
+            max_length=200,
+        ),
+    ] = None,
+    widget: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Which chart on that dashboard, by widget_id or title — from "
+                "read('dashboard', …).charts[]. Optional when it holds one chart."
+            ),
+            max_length=200,
+        ),
+    ] = None,
+    max_series: Annotated[
+        int,
+        Field(description="Cap on returned series (largest kept).", ge=1, le=100),
+    ] = DEFAULT_MAX_SERIES,
+    max_points: Annotated[
+        int,
+        Field(description="Cap on points per series (most recent kept).", ge=2, le=1000),
+    ] = DEFAULT_MAX_POINTS,
+    ctx: Context[ServerSession, None] | None = None,
+) -> str:
+    """Run a chart's query and return its series, summarised."""
+    if ctx is not None:
+        await ctx.info(f"chart_data.called metric={metric} dashboard={dashboard}")
+    return await run_chart_data(
+        metric=metric,
+        project_name=project_name,
+        project_id=project_id,
+        project_ids=project_ids,
+        window=window,
+        start=start,
+        end=end,
+        interval=interval,
+        breakdown=breakdown,
+        breakdown_key=breakdown_key,
+        sub_metric=sub_metric,
+        filters=filters,
+        dashboard=dashboard,
+        widget=widget,
+        max_series=max_series,
+        max_points=max_points,
     )
 
 

--- a/src/opik_mcp/skills/opik-dashboards/SKILL.md
+++ b/src/opik_mcp/skills/opik-dashboards/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: opik-dashboards
+description: Answer a question about an LLM app with Opik's own metrics, and save the answer as a chart or a dashboard. Runs metric queries over traces, spans and threads (volume, latency, cost, tokens, errors, feedback scores) with breakdowns by name, model, provider, tags or metadata; reads dashboards a user already has; and builds new ones. Use for "chart our p99 latency", "which model costs the most", "build me a dashboard for this project", "add a cost chart to my dashboard", "what does this dashboard show", "is quality dropping". Requires the Opik MCP (dashboards have no SDK API). Not for reading individual traces (use opik-explain) or offline experiment results (use opik-evaluate).
+compatibility: Requires the Opik MCP server connected to a workspace, with the chart_data, read, list and write tools. Tested with Claude Code; works with any Agent Skills-compatible host. Dashboards are an MCP-only surface — the Opik Python/TS SDKs have no dashboard API — so without the MCP this skill can only point the user at the Opik UI.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+metadata:
+  last_updated: "2026-09-02"
+  source_commit: "2.0.0"
+  argument-hint: "[optional: what to chart, and for which project]"
+---
+
+# Dashboards — Chart Opik Metrics, and Save the Chart
+
+**Definition of done:** the user's question is answered **with numbers pulled from Opik** — and, when they asked for something durable, a dashboard exists in their workspace with those charts on it and a link to open it. A chart nobody checked before saving is not done: every chart you save is one you have already run.
+
+Operate: **query first, save second.** `chart_data` is free and reversible; a dashboard is something a person opens tomorrow.
+
+## Inputs
+
+Entry point: `/opik-dashboards`, `/opik-dashboards <what to chart>`, or any request that reads as "show me / chart / dashboard". Infer the rest; treat as optional overrides:
+
+- project (default: the user's default project, else ask) · window (default: `7d`) · breakdown (default: none) · save or not (default: **don't** — answer first, offer to save).
+
+## The four tools
+
+| You want | Call |
+| --- | --- |
+| Numbers for a question | `chart_data(metric=…, project_name=…, window="7d")` |
+| What a dashboard holds | `read("dashboard", <id or name>)` → `{dashboard, charts[]}`, each chart with its `widget_id` |
+| The workspace's dashboards | `list("dashboard")` (add `project_id` for a project's own) |
+| Save / edit | `write("dashboard.create" \| "dashboard.add_charts" \| "dashboard.remove_charts" \| "dashboard.update", …)` |
+
+Charts are described the same way everywhere — one **ChartSpec**: `{kind, metric, breakdown, sub_metric, filters, project_name, chart_type, title}`. `kind` is `metric` (time series), `stat` (single-number card) or `text` (markdown note). Call `schema("dashboard.create")` for the exact field list rather than guessing.
+
+## Activation
+
+### 1. Resolve scope
+Project name (from the request, the user's default project, or `list("project")`) and a window. Don't ask when you can infer; do ask when the workspace has several plausible projects.
+
+### 2. Pick the metric
+Say what the question is *about*, then take the metric from that entity:
+
+- **traces** — `trace_count`, `duration` (p50/p90/p99), `trace_average_duration`, `trace_error_rate`, `cost`, `token_usage`, `feedback_scores`, `guardrails_failed_count`
+- **spans** — `span_count`, `span_duration`, `span_error_rate`, `span_cost`, `span_token_usage`, `span_feedback_scores`
+- **threads** — `thread_count`, `thread_duration`, `thread_cost`, `thread_feedback_scores`
+
+"Which model / provider costs the most" is a **span** question (model and provider live on spans, so only span metrics break down by them). "Is quality dropping" is `feedback_scores`. "Are we erroring more" is `trace_error_rate`, and if you also want *which* error, `trace_count` broken down by `error_type`.
+
+### 3. Run it before you save it
+```
+chart_data(metric="span_token_usage", project_name="chatbot-prod",
+           window="14d", breakdown="model", sub_metric="completion_tokens")
+```
+Each series comes back with its points **and** a summary (`first/last/min/max/avg/total/change_pct`) over the whole window — read the summary, not the point list. An empty `series` means no data matched: check the project and widen the window before concluding anything.
+
+Breakdown rules the tool enforces (it fails with the fix in the message, so don't pre-empt them nervously): `model`/`provider`/`type` are span-only; `metadata` needs `breakdown_key`; a breakdown on `duration`, `token_usage` or any feedback-score metric needs `sub_metric` (a percentile, a usage key, or the score name) because the breakdown collapses the multi-series response to one.
+
+### 4. Answer
+Lead with the number and the movement ("p99 is 4.2s, up 38% over 14 days"), then the split if you broke it down. This step is the deliverable for most requests — stop here unless the user wants something saved.
+
+### 5. Save, if asked
+```
+write("dashboard.create", {
+  "name": "Chatbot health", "project_name": "chatbot-prod",
+  "charts": [
+    {"kind": "stat",   "metric": "trace_count", "title": "Traces"},
+    {"kind": "stat",   "metric": "error_count", "title": "Errors"},
+    {"kind": "metric", "metric": "duration", "breakdown": "name", "sub_metric": "p99"},
+    {"kind": "metric", "metric": "cost", "chart_type": "bar"}
+  ]})
+```
+- A dashboard's `project_name` scopes it to that project **and** becomes each chart's default project. Charts on a workspace dashboard with no project at all render as "not configured" — give every chart a project, or give the dashboard one.
+- Adding to an existing dashboard is `dashboard.add_charts` (pass every chart in **one** call — each call re-reads and rewrites the whole config), optionally with `section` to group them.
+- `dashboard.update` with `charts` **replaces every chart**; use it to rebuild, not to append.
+- Removing takes `widget_ids` from `read("dashboard", …)`.
+- `dry_run: true` shows the exact request without writing.
+- Report the `dashboard_url` from the result — a link the user can open beats an id.
+
+Stat cards (`kind: "stat"`) use their own names: `trace_count`, `error_count`, `duration.p50|p90|p99`, `total_estimated_cost_sum`, `usage.total_tokens`, `feedback_scores.<name>`, … A dashboard usually opens with a row of those, then the time series.
+
+### 6. Reading someone else's dashboard
+`read("dashboard", <name>)` lists every chart with a `widget_id`; `chart_data(dashboard=…, widget=…)` re-runs one and hands you its numbers, over a window you choose. That is how you answer "what is this dashboard telling me" instead of describing its titles.
+
+## Blockers
+
+Stop at the **earliest** blocker, return **exactly one** next step:
+- No Opik MCP connected → "Dashboards need the Opik MCP; connect it, or build this in the Opik UI." (Do not try the SDK — it has no dashboard API.)
+- Project ambiguous → name the candidates the tool listed and ask which.
+- Metric has no data in the window → say so, and offer the widened window rather than silently widening it.
+
+## Output
+
+**User-facing:** the answer in a sentence or two with the actual numbers, the breakdown if there is one, and — when something was saved — the dashboard link and what is on it.
+
+**Underneath** (for composition / evals):
+- `status`: `answered` | `saved` | `empty` | `blocked`
+- `scope`: `project`, `window`, `interval`
+- `charts`: `[{metric, breakdown?, summary}]`
+- `dashboard`: `{id, name, url, charts:[{widget_id, title}]}` when something was saved
+- `next_step`: exactly one
+
+Invariants: every saved chart was run first; `empty` means the query succeeded and returned no series; `blocked` carries one next step; nothing here edits the user's code.
+
+## Anti-patterns
+
+Saving a dashboard nobody asked for; saving charts you never ran; describing a dashboard by its widget titles instead of running them; charting `model`/`provider` off trace metrics (span-only); calling `dashboard.add_charts` once per chart; using `dashboard.update` to append (it replaces); inventing filter shapes — copy the `{field, operator, value}` objects Opik itself uses; reaching for `ask_ollie` when a metric query answers the question directly.
+
+## References
+
+Metric semantics, filters and the span/trace/thread model live in the `opik` skill, installed beside this one: `../opik/references/observability.md` (span and score model), `../opik/references/production.md` (what to watch in production). For triaging *which traces* are bad rather than *how much*, that is `/opik-diagnose`; for one trace's root cause, `/opik-explain`.

--- a/src/opik_mcp/skills_catalog.py
+++ b/src/opik_mcp/skills_catalog.py
@@ -92,6 +92,10 @@ SKILL_SUMMARIES: dict[str, str] = {
         '"what is broken in production", "which traces need attention", "find failing '
         'or slow traces", "triage my agent".'
     ),
+    "opik-dashboards": (
+        '"chart our p99 latency", "which model costs the most", "build me a dashboard '
+        'for this project", "what does this dashboard show".'
+    ),
     "opik-explain": (
         '"why did this trace fail", "explain this trace", "debug this trace", "why is '
         'my agent slow or wrong".'

--- a/src/opik_mcp/writes/dispatch.py
+++ b/src/opik_mcp/writes/dispatch.py
@@ -29,6 +29,7 @@ from uuid import UUID
 import httpx
 from pydantic import BaseModel, ValidationError
 
+from opik_mcp.charts import dashboard_ops
 from opik_mcp.config import Settings, get_settings
 from opik_mcp.opik_client import (
     OpikAuthError,
@@ -89,14 +90,18 @@ async def run_write(
 
     # Live path only: build the client and resolve any identifiers the wire
     # needs but the caller doesn't carry (thread comments target the BE by the
-    # thread's model UUID; the caller passes the thread_id string). dry_run stays
-    # pure — no client, no backend calls — so it never depends on config/network.
+    # thread's model UUID; the caller passes the thread_id string — dashboards
+    # take a name where the wire takes an id, and their edits need the config
+    # that is already stored). dry_run stays pure — no client, no backend calls
+    # — so it never depends on config/network.
     http_client: OpikClient | None = None
+    context: dict[str, Any] = {}
     if not dry_run:
         http_client = client if client is not None else make_opik_client(settings or get_settings())
         await _resolve_thread_comment_target(op, items, http_client)
+        context = await dashboard_ops.resolve_context(op, items[0], http_client, settings=settings)
 
-    method, path, body = _build_request_with_method(op, items, is_batch=is_batch)
+    method, path, body = _build_request_with_method(op, items, is_batch=is_batch, context=context)
 
     if dry_run:
         would_call: dict[str, Any] = {
@@ -118,11 +123,16 @@ async def run_write(
                 "thread comments resolve the thread_id string to the thread's model "
                 "UUID at execution; the live path will use /threads/{model_uuid}/comments."
             )
+        dashboard_note = dashboard_ops.preview_note(op)
+        if dashboard_note is not None:
+            would_call["note"] = dashboard_note
         return {"dry_run": True, "would_call": would_call}
 
     assert http_client is not None  # set above whenever not dry_run
     resp = await http_client.write_json(method, path, body, idempotency_key=effective_idem)
-    return _stage4_finalize(op, resp, items, is_batch=is_batch, method=method, path=path)
+    return _stage4_finalize(
+        op, resp, items, is_batch=is_batch, method=method, path=path, context=context
+    )
 
 
 async def _resolve_thread_comment_target(
@@ -378,7 +388,11 @@ def _stage3_authorize(op: WriteOperation, scopes: frozenset[str]) -> None:
 
 
 def _build_request_with_method(
-    op: WriteOperation, items: list[BaseModel], *, is_batch: bool
+    op: WriteOperation,
+    items: list[BaseModel],
+    *,
+    is_batch: bool,
+    context: dict[str, Any] | None = None,
 ) -> tuple[str, str, dict[str, Any] | list[Any]]:
     """Wrap ``_build_request`` and apply per-batch method overrides.
 
@@ -389,7 +403,7 @@ def _build_request_with_method(
     know about the per-route method asymmetry. Score's PUT batch endpoint
     is left alone (PUT is the correct method for the feedback-scores route).
     """
-    path, body = _build_request(op, items, is_batch=is_batch)
+    path, body = _build_request(op, items, is_batch=is_batch, context=context or {})
     method = op.method
     if is_batch and method == "PATCH" and op.batch_endpoint is not None:
         method = "POST"
@@ -397,7 +411,11 @@ def _build_request_with_method(
 
 
 def _build_request(
-    op: WriteOperation, items: list[BaseModel], *, is_batch: bool
+    op: WriteOperation,
+    items: list[BaseModel],
+    *,
+    is_batch: bool,
+    context: dict[str, Any] | None = None,
 ) -> tuple[str, dict[str, Any] | list[Any]]:
     """Translate validated models into ``(path, body)`` for the BE.
 
@@ -405,8 +423,18 @@ def _build_request(
     a generic dump because the BE's batch envelopes ("traces", "spans",
     "scores", "experiment_items") and path-encoded routes are operation-
     specific and trying to abstract them produces brittle indirection.
+
+    ``context`` carries what only a backend round-trip could supply (resolved
+    ids, a dashboard's current config); it is empty on the ``dry_run`` path
+    and for every operation that needs nothing resolved.
     """
     name = op.name
+
+    if name in dashboard_ops.DASHBOARD_OPERATIONS:
+        # Dashboards compile through their own module: the body is a config
+        # document assembled from ChartSpecs, and three of the four operations
+        # merge into a config fetched during resolution.
+        return dashboard_ops.build_request(op, items[0], context if context is not None else {})
 
     if name == "trace.create":
         if is_batch:
@@ -587,12 +615,13 @@ def _stage4_finalize(
     is_batch: bool,
     method: str,
     path: str,
+    context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     status = resp.status_code
     if not (200 <= status < 300):
         raise BackendError.build(op.name, status, _safe_body(resp), method=method, path=path)
     body = _safe_body(resp)
-    return {
+    envelope: dict[str, Any] = {
         "ok": True,
         "operation": op.name,
         "method": method,
@@ -602,6 +631,35 @@ def _stage4_finalize(
         "item_count": len(items),
         "backend_body": body,
     }
+    details = (context or {}).get("result")
+    if isinstance(details, dict) and details:
+        # What the caller needs to act next and cannot read off the backend
+        # body: the widget ids just created (to chart or remove them) and the
+        # dashboard's UI link. Only dashboard operations populate this.
+        envelope["details"] = _with_dashboard_link(details, body, context or {})
+    return envelope
+
+
+def _with_dashboard_link(
+    details: dict[str, Any], body: Any, context: dict[str, Any]
+) -> dict[str, Any]:
+    """Fill in the created dashboard's id/URL from the response.
+
+    ``dashboard.create`` is the one case where neither is knowable before the
+    call — the backend mints the id — so the link is completed here rather
+    than left off the one operation whose result a user most wants to open.
+    """
+    if details.get("dashboard_id") or not isinstance(body, dict):
+        return details
+    dashboard_id = body.get("id")
+    if not isinstance(dashboard_id, str):
+        return details
+    settings = context.get("settings")
+    completed = {"dashboard_id": dashboard_id, **details}
+    url = dashboard_ops.dashboard_url(dashboard_id, settings) if settings is not None else None
+    if url is not None:
+        completed["dashboard_url"] = url
+    return completed
 
 
 def _safe_body(resp: httpx.Response) -> Any:

--- a/src/opik_mcp/writes/models.py
+++ b/src/opik_mcp/writes/models.py
@@ -1,4 +1,4 @@
-"""Pydantic models for the 10 write operations (spec §3).
+"""Pydantic models for the write operations (spec §3, plus dashboards).
 
 Each operation has one model that validates a single-item payload. Batch
 form is handled at the dispatcher level by validating an array against the
@@ -27,6 +27,8 @@ from pydantic import (
     Field,
     model_validator,
 )
+
+from opik_mcp.charts.spec import ChartSpec
 
 # --- shared types --------------------------------------------------------- #
 
@@ -456,6 +458,150 @@ class ThreadOpen(_ThreadLifecycle):
     """``POST /v1/private/traces/threads/open`` — reopen a thread (→ active)."""
 
 
+# --- 13-16. dashboards --------------------------------------------------- #
+#
+# A dashboard is a name plus one opaque ``config`` document holding every
+# chart. These four models never expose that document: the caller describes
+# charts as ``ChartSpec``s and ``charts.dashboard_ops`` compiles them, because
+# the config's shape is a private frontend contract (grid geometry, a version
+# the UI migrates) that no agent should be asked to author. See
+# ``charts/config.py`` for what is actually stored.
+
+DashboardTypeLiteral = Literal["multi_project", "experiments"]
+"""opik-backend's ``DashboardType``. ``multi_project`` is the observability
+dashboard these operations build; ``experiments`` dashboards are driven by
+experiment-selection widgets this surface does not author."""
+
+_DASHBOARD_REF_DESC = (
+    "The dashboard to edit: its UUID, or its exact name. A name matching "
+    "several dashboards is refused with the ids listed."
+)
+
+
+class DashboardCreate(_StrictBase):
+    """``POST /v1/private/dashboards`` — a new dashboard, optionally with charts.
+
+    ``project_name`` / ``project_id`` scope the dashboard to one project (it
+    then shows on that project's Dashboards tab) AND become the default
+    project for any chart that doesn't name its own — a chart with no project
+    renders as "not configured" in the UI, so the inheritance is what makes a
+    one-line create produce a dashboard that actually shows data.
+    """
+
+    name: str = Field(min_length=1, max_length=120, description="Dashboard name.")
+    description: str | None = Field(default=None, max_length=1000)
+    type: DashboardTypeLiteral = Field(default="multi_project")
+    project_name: str | None = Field(
+        default=None,
+        max_length=200,
+        description=(
+            "Scope the dashboard (and its charts) to this project. Must already "
+            "exist. Mutually exclusive with project_id."
+        ),
+    )
+    project_id: UUID | None = Field(default=None, description="Same as project_name, by UUID.")
+    section_title: str = Field(
+        default="Overview",
+        max_length=120,
+        description="Title of the section holding these charts.",
+    )
+    charts: list[ChartSpec] = Field(
+        default_factory=list,
+        max_length=50,
+        description=(
+            "Charts to create the dashboard with. Each is a ChartSpec — "
+            "{kind, metric, breakdown, filters, …}; call schema('dashboard.create') "
+            "for the full field list. An empty list creates an empty dashboard."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_project_xor(self) -> DashboardCreate:
+        if self.project_name is not None and self.project_id is not None:
+            raise ValueError("project_xor: pass either `project_name` or `project_id`, not both.")
+        return self
+
+
+class DashboardUpdate(_StrictBase):
+    """``PATCH /v1/private/dashboards/{id}`` — rename, re-describe, or rebuild.
+
+    Passing ``charts`` REPLACES every chart on the dashboard (the backend
+    stores one config document and the PATCH overwrites it). To add or drop
+    individual charts without touching the rest, use ``dashboard.add_charts``
+    / ``dashboard.remove_charts``.
+    """
+
+    dashboard: str = Field(min_length=1, max_length=200, description=_DASHBOARD_REF_DESC)
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=1000)
+    type: DashboardTypeLiteral | None = Field(default=None)
+    charts: list[ChartSpec] | None = Field(
+        default=None,
+        max_length=50,
+        description="Replace every chart on the dashboard with these.",
+    )
+    section_title: str = Field(
+        default="Overview",
+        max_length=120,
+        description="Section title used when `charts` rebuilds the dashboard.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_has_change(self) -> DashboardUpdate:
+        if (
+            self.name is None
+            and self.description is None
+            and self.type is None
+            and self.charts is None
+        ):
+            raise ValueError(
+                "dashboard_update_empty: pass at least one of `name`, `description`, "
+                "`type` or `charts`."
+            )
+        return self
+
+
+class DashboardAddCharts(_StrictBase):
+    """``PATCH /v1/private/dashboards/{id}`` — append charts to a dashboard.
+
+    Read-modify-write on the live config, so every existing chart and its
+    grid position survive. Adding several charts in one call is one fetch and
+    one write; adding them one at a time is a race with anyone editing the
+    dashboard in the UI.
+    """
+
+    dashboard: str = Field(min_length=1, max_length=200, description=_DASHBOARD_REF_DESC)
+    charts: list[ChartSpec] = Field(
+        min_length=1,
+        max_length=20,
+        description="Charts to append, in order.",
+    )
+    section: str | None = Field(
+        default=None,
+        max_length=120,
+        description=(
+            "Section to append to, by title or id. Defaults to the last section; "
+            "a title that doesn't exist yet is created."
+        ),
+    )
+
+
+class DashboardRemoveCharts(_StrictBase):
+    """``PATCH /v1/private/dashboards/{id}`` — drop charts by widget id.
+
+    Widget ids come from ``read('dashboard', …)``, which lists every chart
+    with its ``widget_id``. The layout entry goes with the widget: an orphaned
+    one leaves a hole in the grid that the UI cannot fill or remove.
+    """
+
+    dashboard: str = Field(min_length=1, max_length=200, description=_DASHBOARD_REF_DESC)
+    widget_ids: list[str] = Field(
+        min_length=1,
+        max_length=50,
+        description="Widget ids to remove — from read('dashboard', …).charts[].widget_id.",
+    )
+
+
 # --- examples (used by registry + validation errors) --------------------- #
 #
 # One validated example per operation. These are the source of truth for the
@@ -539,6 +685,35 @@ EXAMPLES: dict[str, dict[str, Any]] = {
     },
     "thread.close": {"thread_id": "conversation-42", "project_name": "demo"},
     "thread.open": {"thread_id": "conversation-42", "project_name": "demo"},
+    "dashboard.create": {
+        "name": "Chatbot health",
+        "project_name": "demo",
+        "charts": [
+            {"kind": "stat", "metric": "trace_count", "title": "Traces"},
+            {"kind": "metric", "metric": "trace_count", "breakdown": "name"},
+            {"kind": "metric", "metric": "duration", "chart_type": "line"},
+            {"kind": "metric", "metric": "cost"},
+        ],
+    },
+    "dashboard.update": {"dashboard": "Chatbot health", "name": "Chatbot health (prod)"},
+    "dashboard.add_charts": {
+        "dashboard": "Chatbot health",
+        "section": "Quality",
+        "charts": [
+            {
+                "kind": "metric",
+                "metric": "feedback_scores",
+                "project_name": "demo",
+                "title": "Hallucination score",
+                "breakdown": "name",
+                "sub_metric": "hallucination",
+            }
+        ],
+    },
+    "dashboard.remove_charts": {
+        "dashboard": "Chatbot health",
+        "widget_ids": ["mcp0f3a91c2e4"],
+    },
 }
 
 
@@ -557,6 +732,10 @@ MODELS: dict[str, type[BaseModel]] = {
     "experiment_item.create": ExperimentItemCreate,
     "thread.close": ThreadClose,
     "thread.open": ThreadOpen,
+    "dashboard.create": DashboardCreate,
+    "dashboard.update": DashboardUpdate,
+    "dashboard.add_charts": DashboardAddCharts,
+    "dashboard.remove_charts": DashboardRemoveCharts,
 }
 
 
@@ -568,6 +747,11 @@ __all__ = [
     "EXAMPLES",
     "MODELS",
     "CommentCreate",
+    "DashboardAddCharts",
+    "DashboardCreate",
+    "DashboardRemoveCharts",
+    "DashboardTypeLiteral",
+    "DashboardUpdate",
     "ExperimentCreate",
     "ExperimentItem",
     "ExperimentItemCreate",

--- a/src/opik_mcp/writes/registry.py
+++ b/src/opik_mcp/writes/registry.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 from opik_mcp.writes.models import EXAMPLES, MODELS
 from opik_mcp.writes.scopes import (
+    SCOPE_DASHBOARD_EDIT,
     SCOPE_DATASET_EDIT,
     SCOPE_EXPERIMENT_CREATE,
     SCOPE_PROMPT_CREATE,
@@ -219,6 +220,82 @@ _REGISTRY: dict[str, WriteOperation] = {
         ),
         example=EXAMPLES["thread.open"],
         failure_modes=("thread_project_missing",),
+    ),
+    # --- dashboards / charts (OPIK-8210) --- #
+    #
+    # All four go through ``charts.dashboard_ops`` rather than the generic
+    # body builder: they resolve names to ids against the backend, and the
+    # three edit operations read the dashboard's current config before
+    # writing it back (opik-backend replaces ``config`` wholesale on PATCH).
+    "dashboard.create": WriteOperation(
+        name="dashboard.create",
+        pydantic_model=MODELS["dashboard.create"],
+        endpoint="/v1/private/dashboards",
+        method="POST",
+        oauth_scope=SCOPE_DASHBOARD_EDIT,
+        supports_batch=False,
+        description=(
+            "Create a dashboard, with its charts. Charts are described as "
+            "ChartSpecs ({kind, metric, breakdown, filters, …}); the widget "
+            "JSON and grid layout are generated."
+        ),
+        example=EXAMPLES["dashboard.create"],
+        failure_modes=("chart_spec_invalid", "project_not_found", "project_ambiguous"),
+    ),
+    "dashboard.update": WriteOperation(
+        name="dashboard.update",
+        pydantic_model=MODELS["dashboard.update"],
+        endpoint="/v1/private/dashboards/{id}",
+        method="PATCH",
+        oauth_scope=SCOPE_DASHBOARD_EDIT,
+        supports_batch=False,
+        parent_id_fields=("dashboard",),
+        description=(
+            "Rename / re-describe a dashboard, or rebuild it: passing `charts` "
+            "REPLACES every chart on it."
+        ),
+        example=EXAMPLES["dashboard.update"],
+        failure_modes=(
+            "dashboard_update_empty",
+            "dashboard_not_found",
+            "dashboard_ambiguous",
+            "chart_spec_invalid",
+        ),
+    ),
+    "dashboard.add_charts": WriteOperation(
+        name="dashboard.add_charts",
+        pydantic_model=MODELS["dashboard.add_charts"],
+        endpoint="/v1/private/dashboards/{id}",
+        method="PATCH",
+        oauth_scope=SCOPE_DASHBOARD_EDIT,
+        supports_batch=False,
+        parent_id_fields=("dashboard",),
+        description=(
+            "Append charts to an existing dashboard, keeping everything already "
+            "on it. Pass them all in one call — each call is a read-modify-write."
+        ),
+        example=EXAMPLES["dashboard.add_charts"],
+        failure_modes=(
+            "dashboard_not_found",
+            "dashboard_ambiguous",
+            "dashboard_config_unreadable",
+            "chart_spec_invalid",
+            "project_not_found",
+        ),
+    ),
+    "dashboard.remove_charts": WriteOperation(
+        name="dashboard.remove_charts",
+        pydantic_model=MODELS["dashboard.remove_charts"],
+        endpoint="/v1/private/dashboards/{id}",
+        method="PATCH",
+        oauth_scope=SCOPE_DASHBOARD_EDIT,
+        supports_batch=False,
+        parent_id_fields=("dashboard", "widget_ids"),
+        description=(
+            "Remove charts from a dashboard by widget id — the ids read('dashboard', …) lists."
+        ),
+        example=EXAMPLES["dashboard.remove_charts"],
+        failure_modes=("dashboard_not_found", "dashboard_ambiguous", "widget_not_found"),
     ),
 }
 

--- a/src/opik_mcp/writes/scopes.py
+++ b/src/opik_mcp/writes/scopes.py
@@ -17,6 +17,11 @@ SCOPE_TRACE_SPAN_THREAD_ANNOTATE: Final = "trace_span_thread_annotate"
 SCOPE_PROMPT_CREATE: Final = "prompt_create"
 SCOPE_DATASET_EDIT: Final = "dataset_edit"
 SCOPE_EXPERIMENT_CREATE: Final = "experiment_create"
+# Mirrors opik-backend's DASHBOARD_CREATE / DASHBOARD_EDIT permissions, which
+# the backend enforces per endpoint regardless of what we check here. One scope
+# covers create and edit because every edit operation on this surface is a
+# read-modify-write of the same `config` a create writes.
+SCOPE_DASHBOARD_EDIT: Final = "dashboard_edit"
 
 
 ALL_WRITE_SCOPES: Final[frozenset[str]] = frozenset(
@@ -26,12 +31,14 @@ ALL_WRITE_SCOPES: Final[frozenset[str]] = frozenset(
         SCOPE_PROMPT_CREATE,
         SCOPE_DATASET_EDIT,
         SCOPE_EXPERIMENT_CREATE,
+        SCOPE_DASHBOARD_EDIT,
     }
 )
 
 
 __all__ = [
     "ALL_WRITE_SCOPES",
+    "SCOPE_DASHBOARD_EDIT",
     "SCOPE_DATASET_EDIT",
     "SCOPE_EXPERIMENT_CREATE",
     "SCOPE_PROMPT_CREATE",

--- a/tests/conformance/snapshots/chart_data.json
+++ b/tests/conformance/snapshots/chart_data.json
@@ -1,0 +1,232 @@
+{
+  "properties": {
+    "breakdown": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Split the series by a dimension.",
+      "enum": [
+        "tags",
+        "metadata",
+        "name",
+        "error_info",
+        "error_type",
+        "model",
+        "provider",
+        "type",
+        "guardrail_name"
+      ],
+      "title": "Breakdown"
+    },
+    "breakdown_key": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Metadata field to group by when breakdown='metadata'.",
+      "title": "Breakdown Key"
+    },
+    "dashboard": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Replay a saved chart: the dashboard's id or name.",
+      "title": "Dashboard"
+    },
+    "end": {
+      "anyOf": [
+        {
+          "maxLength": 64,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "ISO-8601 window end. Defaults to now.",
+      "title": "End"
+    },
+    "filters": {
+      "anyOf": [
+        {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Opik filter objects \u2014 {field, operator, value, key?} \u2014 applied to the metric's own entity (traces, spans or threads).",
+      "title": "Filters"
+    },
+    "interval": {
+      "anyOf": [
+        {
+          "maxLength": 16,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Bucket size: hourly, daily, weekly, total, or 'auto' (default) to pick one from the window.",
+      "title": "Interval"
+    },
+    "max_points": {
+      "default": 90,
+      "description": "Cap on points per series (most recent kept).",
+      "maximum": 1000,
+      "minimum": 2,
+      "title": "Max Points",
+      "type": "integer"
+    },
+    "max_series": {
+      "default": 20,
+      "description": "Cap on returned series (largest kept).",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Max Series",
+      "type": "integer"
+    },
+    "metric": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Metric to chart, e.g. 'trace_count', 'duration', 'cost', 'feedback_scores', 'span_token_usage'. Optional only when replaying a saved widget via dashboard+widget.",
+      "title": "Metric"
+    },
+    "project_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Project to chart, by UUID.",
+      "title": "Project Id"
+    },
+    "project_ids": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Chart several projects at once (max 10); each is returned as its own series.",
+      "title": "Project Ids"
+    },
+    "project_name": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Project to chart, by name.",
+      "title": "Project Name"
+    },
+    "start": {
+      "anyOf": [
+        {
+          "maxLength": 64,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "ISO-8601 window start, e.g. '2026-08-01T00:00:00Z'.",
+      "title": "Start"
+    },
+    "sub_metric": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Which series to keep under a breakdown: a percentile (p50/p90/p99) for duration metrics, the score name for feedback scores, the usage key for token usage.",
+      "title": "Sub Metric"
+    },
+    "widget": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Which chart on that dashboard, by widget_id or title \u2014 from read('dashboard', \u2026).charts[]. Optional when it holds one chart.",
+      "title": "Widget"
+    },
+    "window": {
+      "anyOf": [
+        {
+          "maxLength": 16,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Relative window ending now: '24h', '7d', '4w', '3m'. Defaults to '7d'. Ignored when start/end are given.",
+      "title": "Window"
+    }
+  },
+  "title": "chart_dataArguments",
+  "type": "object"
+}

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -1,8 +1,9 @@
 {
   "properties": {
     "entity_type": {
-      "description": "One of: experiment, project, prompt, prompt_version, test_suite, test_suite_item, thread, trace.",
+      "description": "One of: dashboard, experiment, project, prompt, prompt_version, test_suite, test_suite_item, thread, trace.",
       "enum": [
+        "dashboard",
         "experiment",
         "project",
         "prompt",

--- a/tests/conformance/snapshots/read.json
+++ b/tests/conformance/snapshots/read.json
@@ -1,8 +1,9 @@
 {
   "properties": {
     "entity_type": {
-      "description": "One of: experiment, project, prompt, span, test_suite, thread, trace.",
+      "description": "One of: dashboard, experiment, project, prompt, span, test_suite, thread, trace.",
       "enum": [
+        "dashboard",
         "experiment",
         "project",
         "prompt",

--- a/tests/conformance/snapshots/schema.json
+++ b/tests/conformance/snapshots/schema.json
@@ -14,7 +14,11 @@
         "experiment.create",
         "experiment_item.create",
         "thread.close",
-        "thread.open"
+        "thread.open",
+        "dashboard.create",
+        "dashboard.update",
+        "dashboard.add_charts",
+        "dashboard.remove_charts"
       ],
       "title": "Operation",
       "type": "string"

--- a/tests/conformance/snapshots/write.json
+++ b/tests/conformance/snapshots/write.json
@@ -48,7 +48,11 @@
         "experiment.create",
         "experiment_item.create",
         "thread.close",
-        "thread.open"
+        "thread.open",
+        "dashboard.create",
+        "dashboard.update",
+        "dashboard.add_charts",
+        "dashboard.remove_charts"
       ],
       "title": "Operation",
       "type": "string"

--- a/tests/conformance/test_schema_snapshots.py
+++ b/tests/conformance/test_schema_snapshots.py
@@ -40,6 +40,7 @@ TOOLS = (
     "ask_ollie",
     "run_experiment",
     "read_skill",
+    "chart_data",
 )
 
 

--- a/tests/conformance/test_tool_inventory.py
+++ b/tests/conformance/test_tool_inventory.py
@@ -22,6 +22,10 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "schema",
         "ask_ollie",
         "run_experiment",
+        # OPIK-8210. The read half of the dashboards surface: dashboards and
+        # their charts are read through `read`/`list`, but a chart's DATA is a
+        # metric query, which no entity read can express.
+        "chart_data",
         # OPIK-7472. Resources carry the same skills, but resource browsing is a
         # host capability rather than a model one — on hosts that never surface
         # resources to the LLM, this tool is the only way an agent reaches them.

--- a/tests/test_charts/__init__.py
+++ b/tests/test_charts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the dashboards / charts surface (OPIK-8210)."""

--- a/tests/test_charts/test_chart_data.py
+++ b/tests/test_charts/test_chart_data.py
@@ -1,0 +1,408 @@
+"""``chart_data`` — window handling, summarising, and replaying saved charts.
+
+The client is a fake returning canned metric responses, so every assertion
+is on the logic this server owns: which request body it builds, what it
+reports about a series, and what it refuses to guess at.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from opik_mcp.charts.config import build_config
+from opik_mcp.charts.query import (
+    MAX_PROJECTS,
+    auto_interval,
+    build_metric_request,
+    parse_window,
+    query_from_widget,
+    resolve_window,
+    run_chart_data,
+    summarize,
+)
+from opik_mcp.charts.spec import ChartSpec
+from opik_mcp.charts.vocabulary import METRICS
+from opik_mcp.opik_client import OpikNotFoundError
+
+PROJECT_ID = "01a02549-d318-72fa-bbc5-efb80ba30486"
+#: Same project, spelled the way each side wants it: ChartSpec takes a UUID,
+#: the stored widget and every API payload carry the string.
+PROJECT_UUID = UUID(PROJECT_ID)
+OTHER_ID = "01a010be-d29f-7453-a460-53d5f9ff6aae"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class FakeClient:
+    """Records the metric requests it was asked to run."""
+
+    def __init__(
+        self,
+        *,
+        results: dict[str, list[dict[str, Any]]] | None = None,
+        projects: list[dict[str, Any]] | None = None,
+        dashboards: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._results = results or {}
+        self._projects = projects if projects is not None else [{"id": PROJECT_ID, "name": "demo"}]
+        self._dashboards = dashboards or []
+        self.requests: list[tuple[str, dict[str, Any]]] = []
+
+    async def list_projects(
+        self, *, name: str | None = None, page: int = 1, size: int = 10
+    ) -> dict[str, Any]:
+        content = [p for p in self._projects if name is None or name.lower() in p["name"].lower()]
+        return {"content": content, "total": len(content)}
+
+    async def get_project(self, project_id: str, /) -> dict[str, Any]:
+        for project in self._projects:
+            if project["id"] == project_id:
+                return project
+        raise OpikNotFoundError(f"project {project_id} not found (404).")
+
+    async def get_dashboard(self, dashboard_id: str, /) -> dict[str, Any]:
+        for dashboard in self._dashboards:
+            if dashboard["id"] == dashboard_id:
+                return dashboard
+        raise OpikNotFoundError(f"dashboard {dashboard_id} not found (404).")
+
+    async def list_dashboards(
+        self,
+        *,
+        name: str | None = None,
+        project_id: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]:
+        content = [d for d in self._dashboards if name is None or name.lower() in d["name"].lower()]
+        return {"content": content, "total": len(content)}
+
+    async def get_project_metrics(self, project_id: str, body: dict[str, Any], /) -> dict[str, Any]:
+        self.requests.append((project_id, body))
+        return {"results": self._results.get(project_id, [])}
+
+
+def _series(name: str, values: list[float | None], start: str = "2026-09-01") -> dict[str, Any]:
+    day = datetime.fromisoformat(start).replace(tzinfo=UTC)
+    return {
+        "name": name,
+        "data": [
+            {"time": (day + timedelta(days=i)).isoformat(), "value": v}
+            for i, v in enumerate(values)
+        ],
+    }
+
+
+def _payload(output: str) -> dict[str, Any]:
+    header, _, body = output.partition("\n")
+    assert header.startswith("[chart_data:")
+    payload: dict[str, Any] = json.loads(body)
+    return payload
+
+
+# --- window and interval -------------------------------------------------- #
+
+
+def test_window_phrases_beat_hand_computed_timestamps() -> None:
+    now = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+    start, end = parse_window("7d", now=now)
+    assert end == now
+    assert start == now - timedelta(days=7)
+    assert parse_window("3m", now=now)[0] == now - timedelta(days=90)
+
+
+def test_a_window_that_is_not_a_duration_says_what_one_looks_like() -> None:
+    with pytest.raises(Exception) as exc:
+        parse_window("last week")
+    assert "'7d'" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("days", "expected"),
+    [(1, "HOURLY"), (14, "DAILY"), (200, "WEEKLY")],
+)
+def test_bucket_size_follows_the_window(days: int, expected: str) -> None:
+    end = datetime(2026, 9, 2, tzinfo=UTC)
+    assert auto_interval(end - timedelta(days=days), end) == expected
+
+
+def test_explicit_timestamps_win_over_the_default_window() -> None:
+    start, end, interval = resolve_window(
+        window=None, start="2026-08-01T00:00:00Z", end="2026-08-10T00:00:00Z", interval=None
+    )
+    assert (start.day, end.day, interval) == (1, 10, "DAILY")
+
+
+def test_an_end_without_a_start_is_refused() -> None:
+    with pytest.raises(Exception) as exc:
+        resolve_window(window=None, start=None, end="2026-08-10T00:00:00Z", interval=None)
+    assert "pass `start`" in str(exc.value)
+
+
+def test_an_explicit_interval_overrides_the_automatic_one() -> None:
+    _s, _e, interval = resolve_window(window="30d", start=None, end=None, interval="hourly")
+    assert interval == "HOURLY"
+
+
+# --- request building ----------------------------------------------------- #
+
+
+def test_request_body_matches_the_backend_dto() -> None:
+    body = build_metric_request(
+        metric=METRICS["span_token_usage"],
+        start=datetime(2026, 8, 1, tzinfo=UTC),
+        end=datetime(2026, 8, 8, tzinfo=UTC),
+        interval="DAILY",
+        breakdown="model",
+        sub_metric="completion_tokens",
+        filters=[{"field": "name", "operator": "=", "value": "chat"}],
+    )
+    assert body == {
+        "metric_type": "SPAN_TOKEN_USAGE",
+        "interval": "DAILY",
+        "interval_start": "2026-08-01T00:00:00Z",
+        "interval_end": "2026-08-08T00:00:00Z",
+        "span_filters": [{"field": "name", "operator": "=", "value": "chat"}],
+        "breakdown": {"field": "model", "sub_metric": "completion_tokens"},
+    }
+
+
+def test_the_request_refuses_a_breakdown_the_backend_would_reject() -> None:
+    with pytest.raises(Exception) as exc:
+        build_metric_request(
+            metric=METRICS["cost"],
+            start=datetime(2026, 8, 1, tzinfo=UTC),
+            end=datetime(2026, 8, 8, tzinfo=UTC),
+            interval="DAILY",
+            breakdown="model",
+        )
+    assert "trace metrics" in str(exc.value)
+
+
+# --- summarising ---------------------------------------------------------- #
+
+
+def test_summary_answers_what_a_chart_is_asked() -> None:
+    summary = summarize([("t1", 10.0), ("t2", 20.0), ("t3", 15.0)])
+    assert summary["first"] == 10.0
+    assert summary["last"] == 15.0
+    assert summary["max"] == 20.0
+    assert summary["avg"] == 15.0
+    assert summary["change_pct"] == 50.0
+
+
+def test_missing_buckets_are_counted_not_zeroed() -> None:
+    """ "No data in this bucket" is not zero — averaging it as zero would
+    understate every sparse metric."""
+    summary = summarize([("t1", None), ("t2", 4.0)])
+    assert summary == {
+        "points": 2,
+        "with_data": 1,
+        "first": 4.0,
+        "last": 4.0,
+        "min": 4.0,
+        "max": 4.0,
+        "avg": 4.0,
+        "total": 4.0,
+        "change": 0.0,
+        "change_pct": 0.0,
+    }
+
+
+def test_a_series_with_no_data_has_no_statistics() -> None:
+    assert summarize([("t1", None)]) == {"points": 1, "with_data": 0}
+
+
+def test_change_pct_is_omitted_when_the_baseline_is_zero() -> None:
+    assert "change_pct" not in summarize([("t1", 0.0), ("t2", 5.0)])
+
+
+# --- the tool ------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_a_metric_over_a_named_project() -> None:
+    client = FakeClient(results={PROJECT_ID: [_series("traces", [1.0, 3.0])]})
+    payload = _payload(
+        await run_chart_data(metric="latency", project_name="demo", window="7d", client=client)
+    )
+    assert payload["metric"] == "duration"  # alias resolved
+    assert payload["projects"] == [{"id": PROJECT_ID, "name": "demo"}]
+    assert payload["series"][0]["summary"]["last"] == 3.0
+    assert payload["series"][0]["points"] == [
+        ["2026-09-01T00:00:00+00:00", 1.0],
+        ["2026-09-02T00:00:00+00:00", 3.0],
+    ]
+
+
+@pytest.mark.anyio
+async def test_several_projects_are_labelled_per_series() -> None:
+    client = FakeClient(
+        projects=[{"id": PROJECT_ID, "name": "demo"}, {"id": OTHER_ID, "name": "other"}],
+        results={PROJECT_ID: [_series("traces", [5.0])], OTHER_ID: [_series("traces", [9.0])]},
+    )
+    payload = _payload(
+        await run_chart_data(
+            metric="trace_count", project_ids=[PROJECT_ID, OTHER_ID], client=client
+        )
+    )
+    assert [s["project"] for s in payload["series"]] == ["other", "demo"]  # largest first
+
+
+@pytest.mark.anyio
+async def test_an_ambiguous_project_name_is_refused_with_the_candidates() -> None:
+    """A silently-wrong project produces a plausible chart of the wrong thing."""
+    client = FakeClient(
+        projects=[{"id": PROJECT_ID, "name": "demo-a"}, {"id": OTHER_ID, "name": "demo-b"}]
+    )
+    with pytest.raises(ToolError) as exc:
+        await run_chart_data(metric="trace_count", project_name="demo", client=client)
+    assert PROJECT_ID in str(exc.value) and OTHER_ID in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_a_chart_without_any_project_says_what_to_pass() -> None:
+    with pytest.raises(ToolError) as exc:
+        await run_chart_data(metric="trace_count", client=FakeClient())
+    assert "project_name" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_too_many_projects_is_refused_before_the_fan_out() -> None:
+    client = FakeClient()
+    with pytest.raises(ToolError):
+        await run_chart_data(
+            metric="trace_count", project_ids=[PROJECT_ID] * (MAX_PROJECTS + 1), client=client
+        )
+    assert not client.requests
+
+
+@pytest.mark.anyio
+async def test_series_are_capped_by_total_and_the_cap_is_reported() -> None:
+    client = FakeClient(
+        results={PROJECT_ID: [_series(f"s{i}", [float(i)]) for i in range(6)]},
+    )
+    payload = _payload(
+        await run_chart_data(
+            metric="trace_count", project_id=PROJECT_ID, max_series=2, client=client
+        )
+    )
+    assert [s["name"] for s in payload["series"]] == ["s5", "s4"]
+    assert any("omitted" in note for note in payload["notes"])
+
+
+@pytest.mark.anyio
+async def test_trimmed_points_keep_a_summary_over_the_whole_window() -> None:
+    """The summary is the answer; trimming points must not change it."""
+    client = FakeClient(results={PROJECT_ID: [_series("traces", [1.0, 2.0, 3.0, 4.0])]})
+    payload = _payload(
+        await run_chart_data(
+            metric="trace_count", project_id=PROJECT_ID, max_points=2, client=client
+        )
+    )
+    series = payload["series"][0]
+    assert series["summary"]["points"] == 4
+    assert series["summary"]["first"] == 1.0
+    assert len(series["points"]) == 2
+    assert series["points_omitted"] == 2
+
+
+@pytest.mark.anyio
+async def test_no_data_is_stated_rather_than_left_as_an_empty_list() -> None:
+    payload = _payload(
+        await run_chart_data(metric="trace_count", project_id=PROJECT_ID, client=FakeClient())
+    )
+    assert payload["series"] == []
+    assert any("No series" in note for note in payload["notes"])
+
+
+# --- replaying a saved chart ---------------------------------------------- #
+
+
+def _dashboard(charts: list[ChartSpec], name: str = "Health") -> dict[str, Any]:
+    return {"id": "dash-1", "name": name, "config": build_config(charts)}
+
+
+def test_query_from_widget_inverts_the_spec_compilation() -> None:
+    widget = ChartSpec(
+        metric="span_token_usage",
+        project_id=PROJECT_UUID,
+        breakdown="model",
+        sub_metric="completion_tokens",
+    ).to_widget("w1")
+    replay = query_from_widget(widget)
+    assert replay["metric"] == "span_token_usage"
+    assert replay["breakdown"] == "model"
+    assert replay["sub_metric"] == "completion_tokens"
+    assert replay["project_ids"] == [PROJECT_ID]
+
+
+def test_a_widget_this_endpoint_cannot_run_is_refused_not_approximated() -> None:
+    widget = ChartSpec(kind="stat", metric="trace_count").to_widget("w1")
+    with pytest.raises(Exception) as exc:
+        query_from_widget(widget)
+    assert "project_metrics" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_replaying_a_widget_by_dashboard_name() -> None:
+    dashboard = _dashboard([ChartSpec(metric="cost", project_id=PROJECT_UUID)])
+    client = FakeClient(dashboards=[dashboard], results={PROJECT_ID: [_series("cost", [0.5, 0.9])]})
+    payload = _payload(await run_chart_data(dashboard="Health", window="14d", client=client))
+    assert payload["metric"] == "cost"
+    assert payload["replayed"]["dashboard"] == "Health"
+    assert (
+        payload["replayed"]["widget_id"] == dashboard["config"]["sections"][0]["widgets"][0]["id"]
+    )
+
+
+@pytest.mark.anyio
+async def test_an_explicit_window_overrides_the_saved_chart() -> None:
+    """Replaying over a different window is the main reason to replay."""
+    dashboard = _dashboard([ChartSpec(metric="cost", project_id=PROJECT_UUID)])
+    client = FakeClient(dashboards=[dashboard], results={PROJECT_ID: [_series("cost", [1.0])]})
+    payload = _payload(
+        await run_chart_data(dashboard="dash-1", window="24h", interval="hourly", client=client)
+    )
+    assert payload["interval"] == "HOURLY"
+
+
+@pytest.mark.anyio
+async def test_a_multi_widget_dashboard_asks_which_chart() -> None:
+    dashboard = _dashboard(
+        [
+            ChartSpec(metric="cost", project_id=PROJECT_UUID),
+            ChartSpec(metric="trace_count", project_id=PROJECT_UUID),
+        ]
+    )
+    client = FakeClient(dashboards=[dashboard])
+    with pytest.raises(ToolError) as exc:
+        await run_chart_data(dashboard="dash-1", client=client)
+    assert "widget" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_widget_without_dashboard_is_refused() -> None:
+    with pytest.raises(ToolError) as exc:
+        await run_chart_data(metric="cost", widget="w1", client=FakeClient())
+    assert "needs `dashboard`" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_an_all_projects_widget_says_what_to_pass_instead() -> None:
+    """The workspace aggregate is a different backend endpoint; a per-project
+    fan-out labelled as one would be a wrong answer, not a partial one."""
+    dashboard = _dashboard([ChartSpec(metric="cost", all_projects=True)])
+    client = FakeClient(dashboards=[dashboard])
+    with pytest.raises(ToolError) as exc:
+        await run_chart_data(dashboard="dash-1", client=client)
+    assert "project_ids" in str(exc.value)

--- a/tests/test_charts/test_spec_and_config.py
+++ b/tests/test_charts/test_spec_and_config.py
@@ -1,0 +1,243 @@
+"""ChartSpec validation, and the widget/config documents it compiles to.
+
+The compiled config is read by the Opik frontend, not by us: a config that
+the API stores happily can still render as an empty dashboard. These tests
+pin the shapes against the frontend's own sources (``lib/dashboard/*``,
+``types/dashboard.ts``) — camelCase keys, ``version`` 4, sections owning
+both their widgets and a parallel layout array keyed by widget id.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from opik_mcp.charts.config import (
+    DASHBOARD_VERSION,
+    GRID_COLUMNS,
+    DashboardConfigError,
+    add_chart,
+    build_config,
+    flatten_charts,
+    remove_widget,
+)
+from opik_mcp.charts.spec import ChartSpec
+
+PROJECT_A = "01a02549-d318-72fa-bbc5-efb80ba30486"
+#: The spec takes a UUID for ``project_id``; the widget it compiles stores the
+#: string form, so both spellings appear here for the same project.
+PROJECT_UUID = UUID(PROJECT_A)
+
+
+# --- validation ----------------------------------------------------------- #
+
+
+def test_a_metric_chart_needs_a_metric() -> None:
+    with pytest.raises(ValidationError) as exc:
+        ChartSpec(kind="metric")
+    assert "kind='metric' needs `metric`" in str(exc.value)
+
+
+def test_vocabulary_failures_arrive_as_field_validation() -> None:
+    """A bad metric/breakdown pair must fail as a Pydantic error, so the write
+    tool folds it into the same ``validation_failed`` envelope as a missing
+    field — one error shape for "this chart cannot exist"."""
+    with pytest.raises(ValidationError) as exc:
+        ChartSpec(metric="cost", breakdown="model")
+    assert "chart_spec_invalid" in str(exc.value)
+
+
+def test_unknown_keys_are_refused() -> None:
+    """``metricType`` / ``chartType`` are the stored widget's spelling; accepting
+    them here would drop the value and render an unconfigured widget."""
+    with pytest.raises(ValidationError):
+        ChartSpec(metric="trace_count", metricType="TRACE_COUNT")  # type: ignore[call-arg]
+
+
+def test_one_project_scope_at_a_time() -> None:
+    with pytest.raises(ValidationError) as exc:
+        ChartSpec(metric="trace_count", project_ids=[PROJECT_UUID], all_projects=True)
+    assert "pick ONE project scope" in str(exc.value)
+
+
+def test_stat_cards_cannot_be_broken_down() -> None:
+    with pytest.raises(ValidationError) as exc:
+        ChartSpec(kind="stat", metric="trace_count", breakdown="name")
+    assert "one number" in str(exc.value)
+
+
+def test_text_widgets_take_text_and_no_metric() -> None:
+    ChartSpec(kind="text", text="## Notes")
+    with pytest.raises(ValidationError):
+        ChartSpec(kind="text")
+
+
+def test_breakdown_key_without_a_breakdown_is_refused() -> None:
+    with pytest.raises(ValidationError):
+        ChartSpec(metric="trace_count", breakdown_key="environment")
+
+
+# --- compilation to a widget --------------------------------------------- #
+
+
+def test_metric_widget_uses_the_frontends_key_casing() -> None:
+    widget = ChartSpec(
+        metric="span_token_usage",
+        project_id=PROJECT_UUID,
+        breakdown="model",
+        sub_metric="completion_tokens",
+        chart_type="bar",
+    ).to_widget("w1")
+    assert widget == {
+        "id": "w1",
+        "title": "Span token usage by model",
+        "type": "project_metrics",
+        "config": {
+            "metricType": "SPAN_TOKEN_USAGE",
+            "chartType": "bar",
+            "projectIds": [PROJECT_A],
+            "spanFilters": [],
+            "breakdown": {"field": "model", "subMetric": "completion_tokens"},
+        },
+    }
+
+
+def test_filters_land_under_the_metrics_own_entity() -> None:
+    trace_chart = ChartSpec(
+        metric="trace_count", filters=[{"field": "name", "operator": "=", "value": "x"}]
+    )
+    thread_chart = ChartSpec(
+        metric="thread_count", filters=[{"field": "status", "operator": "=", "value": "y"}]
+    )
+    assert "traceFilters" in trace_chart.to_widget("w")["config"]
+    assert "threadFilters" in thread_chart.to_widget("w")["config"]
+
+
+def test_all_projects_is_stored_as_the_dynamic_signal() -> None:
+    """``allProjects`` resolves at render time, so a project added tomorrow is
+    charted; freezing today's ids into ``projectIds`` would not."""
+    config = ChartSpec(metric="trace_count", all_projects=True).to_widget("w")["config"]
+    assert config["allProjects"] is True
+    assert "projectIds" not in config
+
+
+def test_stat_widget_carries_its_source_and_stat_name() -> None:
+    widget = ChartSpec(kind="stat", metric="duration.p99", project_id=PROJECT_UUID).to_widget("w")
+    assert widget["type"] == "project_stats_card"
+    assert widget["config"]["source"] == "traces"
+    assert widget["config"]["metric"] == "duration.p99"
+
+
+def test_with_project_id_replaces_the_name() -> None:
+    resolved = ChartSpec(metric="trace_count", project_name="demo").with_project_id(PROJECT_A)
+    assert resolved.project_name is None
+    assert resolved.to_widget("w")["config"]["projectIds"] == [PROJECT_A]
+
+
+# --- the dashboard config ------------------------------------------------- #
+
+
+def _spec(metric: str = "trace_count", kind: str = "metric") -> ChartSpec:
+    return ChartSpec(kind=kind, metric=metric, project_id=PROJECT_UUID)  # type: ignore[arg-type]
+
+
+def test_build_config_emits_the_current_version_and_one_section() -> None:
+    config = build_config([_spec()], section_title="Volume")
+    assert config["version"] == DASHBOARD_VERSION
+    assert isinstance(config["lastModified"], int)
+    assert len(config["sections"]) == 1
+    assert config["sections"][0]["title"] == "Volume"
+
+
+def test_an_empty_dashboard_still_gets_a_section() -> None:
+    """The UI drops widgets onto sections; zero sections means no target."""
+    assert len(build_config([])["sections"]) == 1
+
+
+def test_every_widget_has_exactly_one_layout_entry() -> None:
+    config = build_config([_spec(), _spec("cost"), _spec("trace_count", kind="stat")])
+    section = config["sections"][0]
+    assert [w["id"] for w in section["widgets"]] == [item["i"] for item in section["layout"]]
+
+
+def test_layout_stays_inside_the_grid() -> None:
+    config = build_config([_spec() for _ in range(6)])
+    for item in config["sections"][0]["layout"]:
+        assert item["x"] + item["w"] <= GRID_COLUMNS
+        assert item["y"] >= 0
+
+
+def test_charts_fill_a_row_before_starting_the_next() -> None:
+    """``findFirstAvailablePosition``: a chart is 2 columns wide, so three fit
+    on a row and the fourth wraps."""
+    layout = build_config([_spec() for _ in range(4)])["sections"][0]["layout"]
+    assert [(i["x"], i["y"]) for i in layout] == [(0, 0), (2, 0), (4, 0), (0, 4)]
+
+
+def test_add_chart_preserves_everything_already_there() -> None:
+    config = build_config([_spec()])
+    original_widget = config["sections"][0]["widgets"][0]
+    updated, added = add_chart(config, _spec("cost"))
+    assert updated["sections"][0]["widgets"][0] == original_widget
+    assert updated["sections"][0]["widgets"][1] == added
+    # The fetched config must be left alone: a failed PATCH cannot be allowed
+    # to leave the caller holding an edited copy of a dashboard it never wrote.
+    assert len(config["sections"][0]["widgets"]) == 1
+
+
+def test_add_chart_creates_a_named_section_that_does_not_exist_yet() -> None:
+    config = build_config([_spec()], section_title="Overview")
+    updated, added = add_chart(config, _spec("cost"), section="Cost")
+    assert [s["title"] for s in updated["sections"]] == ["Overview", "Cost"]
+    assert updated["sections"][1]["widgets"] == [added]
+
+
+def test_add_chart_targets_a_section_by_id_too() -> None:
+    config = build_config([_spec()])
+    section_id = config["sections"][0]["id"]
+    updated, _added = add_chart(config, _spec("cost"), section=section_id)
+    assert len(updated["sections"]) == 1
+
+
+def test_remove_widget_drops_its_layout_entry() -> None:
+    """An orphaned layout entry leaves a hole in the grid the UI cannot fill."""
+    config = build_config([_spec(), _spec("cost")])
+    victim = config["sections"][0]["widgets"][0]["id"]
+    updated, removed = remove_widget(config, victim)
+    assert removed["id"] == victim
+    section = updated["sections"][0]
+    assert victim not in [w["id"] for w in section["widgets"]]
+    assert victim not in [item["i"] for item in section["layout"]]
+
+
+def test_removing_an_unknown_widget_lists_the_real_ids() -> None:
+    config = build_config([_spec()])
+    known = config["sections"][0]["widgets"][0]["id"]
+    with pytest.raises(DashboardConfigError) as exc:
+        remove_widget(config, "nope")
+    assert known in str(exc.value)
+
+
+def test_a_config_we_cannot_read_is_refused_rather_than_overwritten() -> None:
+    with pytest.raises(DashboardConfigError):
+        add_chart("not a config", _spec())
+    with pytest.raises(DashboardConfigError):
+        add_chart({"sections": "nope"}, _spec())
+
+
+def test_flatten_charts_is_what_a_reader_needs() -> None:
+    config = build_config([_spec()], section_title="Volume")
+    (chart,) = flatten_charts(config)
+    assert chart["section"] == "Volume"
+    assert chart["type"] == "project_metrics"
+    assert chart["widget_id"] == config["sections"][0]["widgets"][0]["id"]
+    assert chart["config"]["metricType"] == "TRACE_COUNT"
+
+
+def test_flatten_charts_never_raises_on_a_foreign_config() -> None:
+    """It runs on every ``read('dashboard', …)``: a config authored by a newer
+    frontend must degrade to "no charts", never fail the read."""
+    assert flatten_charts(None) == []
+    assert flatten_charts({"sections": [{"widgets": [{"no": "id"}]}]}) == []

--- a/tests/test_charts/test_vocabulary.py
+++ b/tests/test_charts/test_vocabulary.py
@@ -1,0 +1,163 @@
+"""The chart vocabulary must agree with opik-backend's own rules.
+
+Every table in ``charts.vocabulary`` is a transcription of a backend
+validator (``MetricType``, ``BreakdownField.isCompatibleWith``,
+``BreakdownConfigValidator``). Transcriptions rot, and the failure is quiet:
+a wrong entry either rejects a chart the backend would have accepted, or
+sends one it rejects with a message naming Java field paths. These tests pin
+the rules that matter and the sentence each error gives back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opik_mcp.charts.vocabulary import (
+    BREAKDOWN_FIELDS,
+    METRIC_NAMES,
+    METRICS,
+    ChartVocabularyError,
+    check_breakdown,
+    check_stat_metric,
+    check_sub_metric,
+    request_filter_key,
+    resolve_interval,
+    resolve_metric,
+    widget_filter_key,
+)
+
+
+def test_every_metric_has_a_distinct_wire_name() -> None:
+    """The wire name is what the backend enum takes and what
+    ``query_from_widget`` maps back from — a duplicate would silently make one
+    stored widget replay as a different metric."""
+    wires = [m.wire for m in METRICS.values()]
+    assert len(set(wires)) == len(wires)
+
+
+def test_metric_names_are_lowercase_and_match_their_key() -> None:
+    for name, metric in METRICS.items():
+        assert name == metric.name == name.lower()
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("trace_count", "trace_count"),
+        ("TRACE_COUNT", "trace_count"),
+        ("  duration ", "duration"),
+        ("latency", "duration"),
+        ("errors", "trace_error_rate"),
+        ("spend", "cost"),
+    ],
+)
+def test_aliases_and_casing_resolve(given: str, expected: str) -> None:
+    assert resolve_metric(given).name == expected
+
+
+def test_unknown_metric_names_the_alternatives() -> None:
+    with pytest.raises(ChartVocabularyError) as exc:
+        resolve_metric("cost_per_trace")
+    message = str(exc.value)
+    assert "cost_per_trace" in message
+    # A wrong guess should cost one turn: the valid set is in the message.
+    assert "trace_count" in message and "cost" in message
+
+
+def test_model_breakdown_is_span_only() -> None:
+    """``BreakdownField.isCompatibleWith``: MODEL/PROVIDER/TYPE are span-only.
+
+    This is the mistake an LLM makes most — "cost by model" reads as a trace
+    question — so the message has to name the span metric that works."""
+    check_breakdown(METRICS["span_token_usage"], "model", metadata_key=None)
+    with pytest.raises(ChartVocabularyError) as exc:
+        check_breakdown(METRICS["cost"], "model", metadata_key=None)
+    assert "trace metrics" in str(exc.value)
+
+
+def test_metrics_outside_the_breakdown_sets_reject_every_breakdown() -> None:
+    """``trace_error_rate`` is a trace metric but is in no BreakdownField set,
+    so the backend rejects any breakdown on it."""
+    assert METRICS["trace_error_rate"].breakdownable is False
+    with pytest.raises(ChartVocabularyError) as exc:
+        check_breakdown(METRICS["trace_error_rate"], "name", metadata_key=None)
+    assert "does not support a breakdown" in str(exc.value)
+
+
+def test_metadata_breakdown_requires_a_key() -> None:
+    with pytest.raises(ChartVocabularyError) as exc:
+        check_breakdown(METRICS["trace_count"], "metadata", metadata_key=None)
+    assert "breakdown_key" in str(exc.value)
+    check_breakdown(METRICS["trace_count"], "metadata", metadata_key="environment")
+
+
+def test_guardrail_name_breakdown_is_pinned_to_its_metric() -> None:
+    check_breakdown(METRICS["guardrails_failed_count"], "guardrail_name", metadata_key=None)
+    with pytest.raises(ChartVocabularyError):
+        check_breakdown(METRICS["trace_count"], "guardrail_name", metadata_key=None)
+
+
+def test_unknown_breakdown_lists_the_valid_fields() -> None:
+    with pytest.raises(ChartVocabularyError) as exc:
+        check_breakdown(METRICS["trace_count"], "user_id", metadata_key=None)
+    assert all(field in str(exc.value) for field in ("tags", "metadata", "name"))
+
+
+@pytest.mark.parametrize(
+    ("metric", "hint"),
+    [
+        ("duration", "percentile"),
+        ("feedback_scores", "hallucination"),
+        ("token_usage", "completion_tokens"),
+    ],
+)
+def test_multi_series_metrics_need_a_sub_metric_under_a_breakdown(metric: str, hint: str) -> None:
+    with pytest.raises(ChartVocabularyError) as exc:
+        check_sub_metric(METRICS[metric], "name", None)
+    assert hint in str(exc.value)
+
+
+def test_single_series_metrics_need_no_sub_metric() -> None:
+    check_sub_metric(METRICS["trace_count"], "name", None)
+
+
+def test_percentile_sub_metric_is_validated() -> None:
+    check_sub_metric(METRICS["duration"], "name", "p99")
+    with pytest.raises(ChartVocabularyError) as exc:
+        check_sub_metric(METRICS["duration"], "name", "p95")
+    assert "p50, p90, p99" in str(exc.value)
+
+
+def test_intervals_round_trip_to_the_backend_enum() -> None:
+    assert resolve_interval("daily") == "DAILY"
+    assert resolve_interval(" Weekly ") == "WEEKLY"
+    with pytest.raises(ChartVocabularyError):
+        resolve_interval("monthly")
+
+
+def test_filter_keys_differ_between_the_request_and_the_stored_widget() -> None:
+    """The request body is snake_case (a Java DTO); the widget config is
+    camelCase (a frontend document). Mixing them up drops the filters
+    silently — the chart renders, just over the wrong rows."""
+    assert request_filter_key("trace") == "trace_filters"
+    assert widget_filter_key("trace") == "traceFilters"
+    assert request_filter_key("span") == "span_filters"
+    assert widget_filter_key("thread") == "threadFilters"
+
+
+def test_stat_metrics_accept_feedback_score_names() -> None:
+    check_stat_metric("feedback_scores.hallucination", "traces")
+    with pytest.raises(ChartVocabularyError):
+        check_stat_metric("feedback_scores.", "traces")
+
+
+def test_trace_only_stat_metrics_are_rejected_for_spans() -> None:
+    check_stat_metric("trace_count", "traces")
+    with pytest.raises(ChartVocabularyError) as exc:
+        check_stat_metric("trace_count", "spans")
+    assert "span_count" in str(exc.value)
+
+
+def test_public_name_tuples_match_their_tables() -> None:
+    assert set(METRIC_NAMES) == set(METRICS)
+    assert "none" not in BREAKDOWN_FIELDS, "'none' is spelled by omitting the breakdown"

--- a/tests/test_read_list/test_dashboard_entity.py
+++ b/tests/test_read_list/test_dashboard_entity.py
@@ -1,0 +1,156 @@
+"""``read`` / ``list`` for the dashboard entity (OPIK-8210).
+
+A dashboard's stored ``config`` is a nested frontend document. The read tool
+returns it flattened — metadata plus one row per chart — because that is the
+shape every follow-up call takes an id from (``chart_data``,
+``dashboard.remove_charts``), and because handing an agent the raw nesting
+spends tokens on grid geometry that answers no question.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+from opik_mcp.charts.config import build_config
+from opik_mcp.charts.spec import ChartSpec
+from opik_mcp.opik_client import OpikListClient, OpikNotFoundError, OpikReadClient
+from opik_mcp.read_list.list_tool import run_list
+from opik_mcp.read_list.read_tool import run_read
+from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, READABLE_TYPES
+
+PROJECT_ID = "01a02549-d318-72fa-bbc5-efb80ba30486"
+#: Same project, spelled the way each side wants it: ChartSpec takes a UUID,
+#: the stored widget and every API payload carry the string.
+PROJECT_UUID = UUID(PROJECT_ID)
+DASHBOARD_ID = "01a062db-06af-77fb-b12d-319b265a8800"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class FakeClient:
+    def __init__(self, dashboards: list[dict[str, Any]]) -> None:
+        self._dashboards = dashboards
+        self.list_kwargs: dict[str, Any] | None = None
+
+    async def get_dashboard(self, dashboard_id: str) -> dict[str, Any]:
+        for dashboard in self._dashboards:
+            if dashboard["id"] == dashboard_id:
+                return dashboard
+        raise OpikNotFoundError(f"dashboard {dashboard_id!r} not found (404).")
+
+    async def list_dashboards(
+        self,
+        *,
+        name: str | None = None,
+        project_id: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]:
+        self.list_kwargs = {"name": name, "project_id": project_id, "page": page, "size": size}
+        content = [d for d in self._dashboards if name is None or name in d["name"]]
+        return {"content": content, "page": page, "size": len(content), "total": len(content)}
+
+
+def _as_read_client(fake: FakeClient) -> OpikReadClient:
+    """The fake implements the two methods a dashboard read touches, not the
+    whole Protocol — the cast says that deliberately, in one place."""
+    return cast(OpikReadClient, fake)
+
+
+def _dashboard(**overrides: Any) -> dict[str, Any]:
+    return {
+        "id": DASHBOARD_ID,
+        "name": "Chatbot health",
+        "type": "multi_project",
+        "created_at": "2026-09-02T16:01:56Z",
+        "config": build_config(
+            [
+                ChartSpec(
+                    kind="stat", metric="trace_count", title="Traces", project_id=PROJECT_UUID
+                ),
+                ChartSpec(metric="cost", project_id=PROJECT_UUID),
+            ],
+            section_title="Overview",
+        ),
+        **overrides,
+    }
+
+
+def _payload(output: str) -> dict[str, Any]:
+    header, _, body = output.partition("\n")
+    assert header.startswith("[read: dashboard")
+    payload: dict[str, Any] = json.loads(body)
+    return payload
+
+
+def test_dashboard_is_readable_and_listable() -> None:
+    assert "dashboard" in READABLE_TYPES
+    assert "dashboard" in LISTABLE_TYPES
+    # Workspace-wide, unlike traces/threads: listing needs no parent id.
+    assert ENTITY_REGISTRY["dashboard"].list_required_kwargs == ()
+    assert ENTITY_REGISTRY["dashboard"].search_by_name_fn is not None
+
+
+@pytest.mark.anyio
+async def test_read_returns_metadata_and_a_flat_chart_list() -> None:
+    dashboard = _dashboard()
+    payload = _payload(
+        await run_read(
+            entity_type="dashboard",
+            id=DASHBOARD_ID,
+            client=_as_read_client(FakeClient([dashboard])),
+        )
+    )
+    assert payload["dashboard"]["name"] == "Chatbot health"
+    assert "config" not in payload["dashboard"], "the raw config is storage detail"
+    assert payload["chart_count"] == 2
+    titles = [c["title"] for c in payload["charts"]]
+    assert titles == ["Traces", "Cost"]
+    stored_ids = [w["id"] for w in dashboard["config"]["sections"][0]["widgets"]]
+    assert [c["widget_id"] for c in payload["charts"]] == stored_ids
+    assert payload["charts"][1]["config"]["metricType"] == "COST"
+    assert payload["charts"][0]["section"] == "Overview"
+
+
+@pytest.mark.anyio
+async def test_read_resolves_a_dashboard_by_name() -> None:
+    payload = _payload(
+        await run_read(
+            entity_type="dashboard",
+            id="Chatbot health",
+            client=_as_read_client(FakeClient([_dashboard()])),
+        )
+    )
+    assert payload["dashboard"]["id"] == DASHBOARD_ID
+
+
+@pytest.mark.anyio
+async def test_reading_an_empty_dashboard_says_so_rather_than_failing() -> None:
+    payload = _payload(
+        await run_read(
+            entity_type="dashboard",
+            id=DASHBOARD_ID,
+            client=_as_read_client(FakeClient([_dashboard(config={"version": 4, "sections": []})])),
+        )
+    )
+    assert payload["charts"] == []
+    assert payload["chart_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_list_shows_the_type_column_and_passes_project_scope_through() -> None:
+    client = FakeClient([_dashboard()])
+    out = await run_list(
+        entity_type="dashboard", project_id=PROJECT_ID, client=cast(OpikListClient, client)
+    )
+    assert "type" in out and "multi_project" in out
+    assert DASHBOARD_ID in out
+    assert client.list_kwargs is not None
+    assert client.list_kwargs["project_id"] == PROJECT_ID

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -29,6 +29,7 @@ class FakeOpikClient:
     test_suite_items: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
     prompt_versions: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
     threads: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
+    dashboards: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
 
     last_kwargs: dict[str, Any] = field(default_factory=dict)
 
@@ -63,6 +64,10 @@ class FakeOpikClient:
     async def list_prompt_versions(self, prompt_id: str, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = {"prompt_id": prompt_id, **kw}
         return self.prompt_versions
+
+    async def list_dashboards(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.dashboards
 
     async def list_spans(self, **_: Any) -> dict[str, Any]:
         # Not exercised by the list tool (span has no list_fn) — included to

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -111,6 +111,14 @@ class FakeOpikClient:
     async def list_prompts(self, **_: Any) -> dict[str, Any]:
         return {"content": [], "page": 1, "size": 0, "total": 0}
 
+    async def get_dashboard(self, dashboard_id: str) -> dict[str, Any]:
+        # Dashboards have their own suite (test_dashboard_entity.py); these two
+        # exist so the fake still satisfies the OpikReadClient Protocol.
+        raise OpikNotFoundError(f"dashboard {dashboard_id!r} not found (404).")
+
+    async def list_dashboards(self, **_: Any) -> dict[str, Any]:
+        return {"content": [], "page": 1, "size": 0, "total": 0}
+
     async def get_thread(
         self,
         thread_id: str,

--- a/tests/test_writes/test_dashboard_ops.py
+++ b/tests/test_writes/test_dashboard_ops.py
@@ -1,0 +1,418 @@
+"""The ``dashboard.*`` write operations, end to end through the dispatcher.
+
+These operations do two things no other write does — they resolve names
+against the backend, and they read a config before writing it back — so the
+assertions here are on the exact request that reaches Opik, with the backend
+mocked by ``respx``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+
+from opik_mcp.charts.config import build_config
+from opik_mcp.charts.spec import ChartSpec
+from opik_mcp.opik_client import OpikClient
+from opik_mcp.writes.dispatch import run_write
+from opik_mcp.writes.errors import ValidationFailedError
+from opik_mcp.writes.registry import WRITE_REGISTRY
+from opik_mcp.writes.scopes import ALL_WRITE_SCOPES, SCOPE_DASHBOARD_EDIT
+
+OPIK_BASE = "https://opik.test"
+PROJECT_ID = "01a02549-d318-72fa-bbc5-efb80ba30486"
+#: Same project, spelled the way each side wants it: ChartSpec takes a UUID,
+#: the stored widget and every API payload carry the string.
+PROJECT_UUID = UUID(PROJECT_ID)
+DASHBOARD_ID = "01a062db-06af-77fb-b12d-319b265a8800"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _client() -> OpikClient:
+    return OpikClient(base_url=OPIK_BASE, api_key="key-abc", workspace="ws")
+
+
+def _project_page(*names: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "content": [
+                {"id": PROJECT_ID if i == 0 else f"id-{i}", "name": n} for i, n in enumerate(names)
+            ],
+            "total": len(names),
+        },
+    )
+
+
+def _stored_dashboard(charts: list[ChartSpec], **overrides: Any) -> dict[str, Any]:
+    return {
+        "id": DASHBOARD_ID,
+        "name": "Chatbot health",
+        "type": "multi_project",
+        "config": build_config(charts),
+        **overrides,
+    }
+
+
+def _body(request: httpx.Request) -> dict[str, Any]:
+    body: dict[str, Any] = json.loads(request.content)
+    return body
+
+
+# --- create --------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_create_resolves_the_project_and_compiles_the_charts() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get("/v1/private/projects").mock(return_value=_project_page("demo"))
+        route = mock.post("/v1/private/dashboards").mock(
+            return_value=httpx.Response(201, json={"id": DASHBOARD_ID, "name": "Chatbot health"})
+        )
+        result = await run_write(
+            operation="dashboard.create",
+            data={
+                "name": "Chatbot health",
+                "project_name": "demo",
+                "charts": [
+                    {"kind": "stat", "metric": "trace_count", "title": "Traces"},
+                    {"kind": "metric", "metric": "cost"},
+                ],
+            },
+            client=_client(),
+        )
+
+    body = _body(route.calls[0].request)
+    assert body["name"] == "Chatbot health"
+    assert body["type"] == "multi_project"
+    assert body["project_id"] == PROJECT_ID
+    widgets = body["config"]["sections"][0]["widgets"]
+    assert [w["type"] for w in widgets] == ["project_stats_card", "project_metrics"]
+    # Charts inherit the dashboard's project: a widget with no project scope
+    # renders as "not configured" in the UI.
+    assert all(w["config"]["projectIds"] == [PROJECT_ID] for w in widgets)
+    assert result["status"] == 201
+    assert [c["title"] for c in result["details"]["charts_added"]] == ["Traces", "Cost"]
+    assert result["details"]["dashboard_id"] == DASHBOARD_ID
+
+
+@pytest.mark.anyio
+async def test_a_chart_keeps_its_own_project_over_the_dashboards() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get("/v1/private/projects").mock(return_value=_project_page("other"))
+        route = mock.post("/v1/private/dashboards").mock(
+            return_value=httpx.Response(201, json={"id": DASHBOARD_ID})
+        )
+        await run_write(
+            operation="dashboard.create",
+            data={
+                "name": "Cross-project",
+                "charts": [{"kind": "metric", "metric": "cost", "project_name": "other"}],
+            },
+            client=_client(),
+        )
+    body = _body(route.calls[0].request)
+    assert "project_id" not in body
+    assert body["config"]["sections"][0]["widgets"][0]["config"]["projectIds"] == [PROJECT_ID]
+
+
+@pytest.mark.anyio
+async def test_an_unknown_project_is_refused_rather_than_created() -> None:
+    """opik-backend would create a project for an unknown ``project_name`` —
+    which turns a typo into a permanent empty project charting nothing."""
+    # assert_all_called=False: the POST route exists to be asserted UNcalled.
+    with respx.mock(base_url=OPIK_BASE, assert_all_called=False) as mock:
+        mock.get("/v1/private/projects").mock(
+            return_value=httpx.Response(200, json={"content": [], "total": 0})
+        )
+        create = mock.post("/v1/private/dashboards")
+        with pytest.raises(ValidationFailedError) as exc:
+            await run_write(
+                operation="dashboard.create",
+                data={"name": "x", "project_name": "typo"},
+                client=_client(),
+            )
+    assert not create.called
+    issue = exc.value.to_dict()["issues"][0]
+    assert issue["code"] == "project_not_found"
+
+
+@pytest.mark.anyio
+async def test_an_ambiguous_project_lists_the_candidates() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get("/v1/private/projects").mock(return_value=_project_page("demo-a", "demo-b"))
+        with pytest.raises(ValidationFailedError) as exc:
+            await run_write(
+                operation="dashboard.create",
+                data={"name": "x", "project_name": "demo"},
+                client=_client(),
+            )
+    issue = exc.value.to_dict()["issues"][0]
+    assert issue["code"] == "project_ambiguous"
+    assert PROJECT_ID in issue["message"]
+
+
+@pytest.mark.anyio
+async def test_an_invalid_chart_fails_before_any_backend_call() -> None:
+    with respx.mock(base_url=OPIK_BASE, assert_all_called=False) as mock:
+        create = mock.post("/v1/private/dashboards")
+        with pytest.raises(ValidationFailedError) as exc:
+            await run_write(
+                operation="dashboard.create",
+                data={"name": "x", "charts": [{"metric": "cost", "breakdown": "model"}]},
+                client=_client(),
+            )
+    assert not create.called
+    assert "chart_spec_invalid" in json.dumps(exc.value.to_dict())
+
+
+# --- add / remove --------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_add_charts_reads_the_live_config_and_writes_it_back_whole() -> None:
+    stored = _stored_dashboard([ChartSpec(metric="trace_count", project_id=PROJECT_UUID)])
+    existing_id = stored["config"]["sections"][0]["widgets"][0]["id"]
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json=stored)
+        )
+        route = mock.patch(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json={"id": DASHBOARD_ID})
+        )
+        result = await run_write(
+            operation="dashboard.add_charts",
+            data={
+                "dashboard": DASHBOARD_ID,
+                "section": "Cost",
+                "charts": [{"kind": "metric", "metric": "cost", "project_id": PROJECT_ID}],
+            },
+            client=_client(),
+        )
+
+    sections = _body(route.calls[0].request)["config"]["sections"]
+    assert [s["title"] for s in sections] == ["Overview", "Cost"]
+    # The chart that was already there survives untouched.
+    assert sections[0]["widgets"][0]["id"] == existing_id
+    assert len(sections[1]["widgets"]) == 1
+    assert result["details"]["charts_added"][0]["title"] == "Cost"
+    assert result["details"]["dashboard_id"] == DASHBOARD_ID
+
+
+@pytest.mark.anyio
+async def test_a_dashboard_named_rather_than_id_d_is_looked_up() -> None:
+    stored = _stored_dashboard([])
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get("/v1/private/dashboards/Chatbot%20health").mock(
+            return_value=httpx.Response(404, json={"message": "not found"})
+        )
+        mock.get("/v1/private/dashboards").mock(
+            return_value=httpx.Response(
+                200, json={"content": [{"id": DASHBOARD_ID, "name": "Chatbot health"}], "total": 1}
+            )
+        )
+        mock.get(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json=stored)
+        )
+        route = mock.patch(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json={"id": DASHBOARD_ID})
+        )
+        await run_write(
+            operation="dashboard.add_charts",
+            data={
+                "dashboard": "Chatbot health",
+                "charts": [{"kind": "text", "text": "## Notes"}],
+            },
+            client=_client(),
+        )
+    assert route.called
+
+
+@pytest.mark.anyio
+async def test_an_unknown_dashboard_points_at_the_listing() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get("/v1/private/dashboards/nope").mock(
+            return_value=httpx.Response(404, json={"message": "not found"})
+        )
+        mock.get("/v1/private/dashboards").mock(
+            return_value=httpx.Response(200, json={"content": [], "total": 0})
+        )
+        with pytest.raises(ValidationFailedError) as exc:
+            await run_write(
+                operation="dashboard.remove_charts",
+                data={"dashboard": "nope", "widget_ids": ["w1"]},
+                client=_client(),
+            )
+    issue = exc.value.to_dict()["issues"][0]
+    assert issue["code"] == "dashboard_not_found"
+    assert "list('dashboard')" in issue["message"]
+
+
+@pytest.mark.anyio
+async def test_remove_charts_drops_the_widget_and_its_layout_entry() -> None:
+    stored = _stored_dashboard(
+        [
+            ChartSpec(metric="trace_count", project_id=PROJECT_UUID),
+            ChartSpec(metric="cost", project_id=PROJECT_UUID),
+        ]
+    )
+    victim = stored["config"]["sections"][0]["widgets"][0]["id"]
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json=stored)
+        )
+        route = mock.patch(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json={"id": DASHBOARD_ID})
+        )
+        result = await run_write(
+            operation="dashboard.remove_charts",
+            data={"dashboard": DASHBOARD_ID, "widget_ids": [victim]},
+            client=_client(),
+        )
+    section = _body(route.calls[0].request)["config"]["sections"][0]
+    assert victim not in [w["id"] for w in section["widgets"]]
+    assert victim not in [item["i"] for item in section["layout"]]
+    assert result["details"]["charts_removed"][0]["widget_id"] == victim
+
+
+@pytest.mark.anyio
+async def test_removing_an_unknown_widget_writes_nothing() -> None:
+    stored = _stored_dashboard([ChartSpec(metric="cost", project_id=PROJECT_UUID)])
+    with respx.mock(base_url=OPIK_BASE, assert_all_called=False) as mock:
+        mock.get(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json=stored)
+        )
+        patch = mock.patch(f"/v1/private/dashboards/{DASHBOARD_ID}")
+        with pytest.raises(ValidationFailedError) as exc:
+            await run_write(
+                operation="dashboard.remove_charts",
+                data={"dashboard": DASHBOARD_ID, "widget_ids": ["ghost"]},
+                client=_client(),
+            )
+    assert not patch.called
+    assert exc.value.to_dict()["issues"][0]["code"] == "widget_not_found"
+
+
+# --- update --------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_update_sends_only_what_changed() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json=_stored_dashboard([]))
+        )
+        route = mock.patch(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json={"id": DASHBOARD_ID})
+        )
+        await run_write(
+            operation="dashboard.update",
+            data={"dashboard": DASHBOARD_ID, "name": "Chatbot health (prod)"},
+            client=_client(),
+        )
+    assert _body(route.calls[0].request) == {"name": "Chatbot health (prod)"}
+
+
+@pytest.mark.anyio
+async def test_update_with_charts_replaces_the_whole_config() -> None:
+    stored = _stored_dashboard([ChartSpec(metric="trace_count", project_id=PROJECT_UUID)])
+    old_id = stored["config"]["sections"][0]["widgets"][0]["id"]
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json=stored)
+        )
+        route = mock.patch(f"/v1/private/dashboards/{DASHBOARD_ID}").mock(
+            return_value=httpx.Response(200, json={"id": DASHBOARD_ID})
+        )
+        result = await run_write(
+            operation="dashboard.update",
+            data={
+                "dashboard": DASHBOARD_ID,
+                "charts": [{"kind": "metric", "metric": "cost", "project_id": PROJECT_ID}],
+            },
+            client=_client(),
+        )
+    widgets = _body(route.calls[0].request)["config"]["sections"][0]["widgets"]
+    assert len(widgets) == 1
+    assert widgets[0]["id"] != old_id
+    assert result["details"]["charts_replaced"][0]["title"] == "Cost"
+
+
+@pytest.mark.anyio
+async def test_an_update_that_changes_nothing_is_refused() -> None:
+    with pytest.raises(ValidationFailedError) as exc:
+        await run_write(
+            operation="dashboard.update", data={"dashboard": DASHBOARD_ID}, client=_client()
+        )
+    assert "dashboard_update_empty" in json.dumps(exc.value.to_dict())
+
+
+# --- dry run and scopes --------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_dry_run_touches_no_backend_and_says_what_it_omits() -> None:
+    result = await run_write(
+        operation="dashboard.create",
+        data={
+            "name": "Chatbot health",
+            "project_name": "demo",
+            "charts": [{"kind": "metric", "metric": "trace_count"}],
+        },
+        dry_run=True,
+    )
+    call = result["would_call"]
+    assert call["method"] == "POST"
+    assert call["path"] == "/v1/private/dashboards"
+    assert call["body"]["config"]["version"] == 4
+    # The preview is honest about the part it could not compute.
+    assert "resolved to project ids at execution" in call["note"]
+
+
+@pytest.mark.anyio
+async def test_dry_run_of_an_edit_previews_the_change_not_a_fabricated_config() -> None:
+    result = await run_write(
+        operation="dashboard.add_charts",
+        data={"dashboard": "Chatbot health", "charts": [{"kind": "metric", "metric": "cost"}]},
+        dry_run=True,
+    )
+    call = result["would_call"]
+    assert call["method"] == "PATCH"
+    assert "config" not in call["body"], "a preview must not imply it read the live config"
+    assert call["body"]["charts_to_add"][0]["config"]["metricType"] == "COST"
+    assert "merged config" in call["note"]
+
+
+@pytest.mark.anyio
+async def test_dashboard_operations_require_the_dashboard_scope() -> None:
+    from opik_mcp.writes.errors import AuthorizationDeniedError
+
+    without = ALL_WRITE_SCOPES - {SCOPE_DASHBOARD_EDIT}
+    with pytest.raises(AuthorizationDeniedError):
+        await run_write(
+            operation="dashboard.create",
+            data={"name": "x"},
+            scopes=without,
+            client=_client(),
+        )
+
+
+def test_every_dashboard_operation_is_registered_with_the_dashboard_scope() -> None:
+    from opik_mcp.charts.dashboard_ops import DASHBOARD_OPERATIONS
+
+    assert set(WRITE_REGISTRY) >= DASHBOARD_OPERATIONS
+    for name in DASHBOARD_OPERATIONS:
+        op = WRITE_REGISTRY[name]
+        assert op.oauth_scope == SCOPE_DASHBOARD_EDIT
+        # Config documents are large and each edit is a read-modify-write;
+        # batching them would multiply that, not amortise it.
+        assert op.supports_batch is False


### PR DESCRIPTION
> **Draft / experimental.** The tool surface and chart-spec shape are not stable yet — opening this to unblock the stacked deletion PR and to get early eyes on the shape. Not for merge as-is.

Adds the read/write surface for Opik dashboards, plus a `chart_data` tool that runs a metric query and returns its series, summarised.

## What's here

- **`charts/`** — metric vocabulary, chart spec, query execution, dashboard ops.
- **`chart_data` tool** — metric queries over a project + window, with an optional breakdown; or replay of a saved widget via `dashboard`+`widget`.
- **`dashboard` entity** wired into `read`/`list`, and `dashboard.*` write operations.
- **`opik-dashboards` agent skill** bundled with the server.

## Status

Experimental. Known open questions before this is mergeable:

- the chart spec shape is not frozen
- the tool description is rendered from `charts.vocabulary`, which will need a review pass once the metric list settles

## Verification

`make lint`, `make typecheck`, and the full suite pass (1598 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)