### PR TITLE
[OPIK-8252] Answer 401 invalid_token on an expired OAuth token so hosts refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,14 +295,19 @@ Every setting is an environment variable. Required ones in **bold**.
 | `OPIK_MCP_RELOAD` | `false` | `true` to enable uvicorn `--reload` (dev only). |
 | `OPIK_MCP_AS_URL` | _unset_ | OAuth Authorization Server URL, advertised in `/.well-known/oauth-protected-resource` (RFC 9728) and used as the proxy target for AS-discovery probes. Required for MCP hosts to bootstrap the OAuth dance over HTTP. |
 | `OPIK_MCP_RESOURCE_URI` | _unset_ | Canonical public URI of this server, advertised as `resource` in the protected-resource metadata and used to derive the `WWW-Authenticate` hint. |
+| `OPIK_MCP_OAUTH_VALIDATION_CACHE_TTL_S` | `30` | How long a "valid" answer from opik-backend's token introspection is trusted before the next request on the same OAuth token asks again. Bounds the backend load added by per-request validation and the window in which an expired token is still forwarded (that window also ends on the first 401 the backend returns). Capped by the token's own `expires_at` when the backend reports one. |
 | `OPIK_MCP_LOG_LEVEL` | `INFO` | stderr logger threshold. |
 
 #### Choosing a transport
 
-opik-mcp performs **no local credential validation** on HTTP transport: any
-well-formed `Authorization: Bearer …` (an Opik API key or an `opik_mcp_at_…`
-OAuth access token) is forwarded verbatim to opik-backend, which is the
-single point of auth enforcement. Pick the transport by deployment shape:
+Two bearer shapes, two contracts on HTTP transport. An `opik_mcp_at_…` OAuth
+access token is **validated on every request** against opik-backend's token
+introspection endpoint (cached, see `OPIK_MCP_OAUTH_VALIDATION_CACHE_TTL_S`);
+an expired or revoked token gets an HTTP 401 with
+`WWW-Authenticate: Bearer error="invalid_token"`, which is what MCP hosts key
+their silent `refresh_token` grant on. An Opik API key is **not validated
+locally**: it is forwarded verbatim to opik-backend, which is its single point
+of enforcement. Pick the transport by deployment shape:
 
 | Scenario | Transport |
 |---|---|

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -22,6 +22,8 @@ of the MCP tool implementations.
 
 from contextvars import ContextVar
 
+from opik_mcp.credential_identity import forget_validation
+
 # Access-token prefix minted by opik-backend (McpOAuthTokenUtils.ACCESS_PREFIX).
 # OAuth-passthrough detection MUST match the issuer: a mismatch makes a real
 # OAuth bearer fall through to the API-key path, which then forwards a stale
@@ -155,3 +157,24 @@ def oauth_token_expired_hint() -> str | None:
         return None
     mode, _ = classify_bearer(auth)
     return OAUTH_TOKEN_EXPIRED_HINT if mode == "oauth" else None
+
+
+def note_backend_401() -> str | None:
+    """opik-backend just answered 401 to the call this request is forwarding.
+
+    Two things follow, both keyed on the inbound bearer. If it is an OAuth
+    token, its cached validation is dropped so the NEXT MCP request re-asks the
+    backend and gets the ``invalid_token`` 401 that triggers the host's refresh
+    — now, not after the cache TTL. And the returned hint (or ``None`` for an
+    API key) is what the tool error should say; see
+    :func:`oauth_token_expired_hint`. One call site per rendering layer keeps
+    the two in lockstep.
+    """
+    auth = inbound_authorization.get()
+    if not auth:
+        return None
+    mode, token = classify_bearer(auth)
+    if mode != "oauth":
+        return None
+    forget_validation(token)
+    return OAUTH_TOKEN_EXPIRED_HINT

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -22,8 +22,6 @@ of the MCP tool implementations.
 
 from contextvars import ContextVar
 
-from opik_mcp.credential_identity import forget_validation
-
 # Access-token prefix minted by opik-backend (McpOAuthTokenUtils.ACCESS_PREFIX).
 # OAuth-passthrough detection MUST match the issuer: a mismatch makes a real
 # OAuth bearer fall through to the API-key path, which then forwards a stale
@@ -42,7 +40,7 @@ inbound_authorization: ContextVar[str | None] = ContextVar("inbound_authorizatio
 inbound_workspace: ContextVar[str | None] = ContextVar("inbound_workspace", default=None)
 
 # OAuth-authorized workspace *name*, resolved from the opaque bearer via
-# ``oauth_identity.resolve_oauth_identity`` on the ``initialize`` handshake.
+# ``oauth_identity.introspect_oauth_token`` (the same call that validates it).
 # Consumed ONLY by the instructions blob (``instructions.render_instructions``)
 # so an agent can truthfully name the workspace it is operating against. Kept
 # deliberately separate from ``inbound_workspace`` so this read-only display
@@ -151,30 +149,11 @@ def oauth_token_expired_hint() -> str | None:
     no inbound bearer at all), so API-key callers keep their "check OPIK_API_KEY"
     guidance. Single source of truth for every layer that renders a backend 401
     — the read/list client, the write envelope — so the wording cannot drift.
+    Pure: the cache eviction that goes with a backend 401 lives beside the HTTP
+    call (``opik_client.note_backend_401``), not in a message helper.
     """
     auth = inbound_authorization.get()
     if not auth:
         return None
     mode, _ = classify_bearer(auth)
     return OAUTH_TOKEN_EXPIRED_HINT if mode == "oauth" else None
-
-
-def note_backend_401() -> str | None:
-    """opik-backend just answered 401 to the call this request is forwarding.
-
-    Two things follow, both keyed on the inbound bearer. If it is an OAuth
-    token, its cached validation is dropped so the NEXT MCP request re-asks the
-    backend and gets the ``invalid_token`` 401 that triggers the host's refresh
-    — now, not after the cache TTL. And the returned hint (or ``None`` for an
-    API key) is what the tool error should say; see
-    :func:`oauth_token_expired_hint`. One call site per rendering layer keeps
-    the two in lockstep.
-    """
-    auth = inbound_authorization.get()
-    if not auth:
-        return None
-    mode, token = classify_bearer(auth)
-    if mode != "oauth":
-        return None
-    forget_validation(token)
-    return OAUTH_TOKEN_EXPIRED_HINT

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -17,7 +17,14 @@ outbound :class:`OpikClient` is constructed for that request. When unset
 
 ASGI runs every request in its own asyncio task, so ``ContextVar`` gives us
 per-request isolation without threading anything through the call signatures
-of the MCP tool implementations.
+of the MCP tool implementations. One catch: a tool does NOT run in the request
+task. The SDK forks the MCP session task from the ``initialize`` request, so
+inside a tool these vars hold the handshake-time values — and an OAuth bearer
+changes mid-session once the host refreshes it (OPIK-8252). ``server.
+install_request_auth_rebinding`` therefore re-binds ``inbound_authorization``
+and ``inbound_workspace`` on every ``tools/call`` from the request the SDK
+attaches to its request context, so the outbound client forwards the bearer
+of the request that is actually being served.
 """
 
 from contextvars import ContextVar

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -5,8 +5,9 @@ When opik-mcp runs over HTTP transport with OAuth, the MCP host attaches
 per RFC 6750 and opik-mcp's job is to
 forward that bearer onward to opik-backend's data API verbatim. Permission
 enforcement lives at the data API endpoint via `@RequiredPermissions`
-annotations; opik-mcp performs no local validation and makes no separate
-validator round-trip.
+annotations. OAuth bearers are additionally validated up front by
+``BearerAuthMiddleware`` (introspection round-trip, ``invalid_token`` 401 when
+dead — OPIK-8252); API-key bearers are not validated locally.
 
 These ContextVars are set by ``BearerAuthMiddleware`` for the duration of
 each inbound HTTP request and read by ``resolve_opik_config`` when the

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -126,3 +126,32 @@ def settings_auth_mode(*, has_api_key: bool, has_as_url: bool) -> str:
     if has_as_url:
         return "oauth"
     return "none"
+
+
+# What a tool error says when opik-backend answers 401 to a call made with an
+# OAuth bearer. Worded for the MODEL, which is what reads tool errors: the
+# token — not the user's configuration — is the problem, and the fix is to
+# retry, because the retry is the request that meets ``BearerAuthMiddleware``'s
+# ``invalid_token`` 401 and triggers the host's ``refresh_token`` grant. Telling
+# the model to "reconnect" here made it send users to the settings page for a
+# recovery the client would have done on its own (OPIK-8252).
+OAUTH_TOKEN_EXPIRED_HINT = (
+    "The Opik access token is expired or revoked. Retry this call — the MCP client "
+    "refreshes the token on the next request."
+)
+
+
+def oauth_token_expired_hint() -> str | None:
+    """The 401 hint for the credential this request is forwarding, or ``None``.
+
+    Reads the inbound bearer for the current request: ``OAUTH_TOKEN_EXPIRED_HINT``
+    when it is an OAuth token, ``None`` for an API key (or stdio, where there is
+    no inbound bearer at all), so API-key callers keep their "check OPIK_API_KEY"
+    guidance. Single source of truth for every layer that renders a backend 401
+    — the read/list client, the write envelope — so the wording cannot drift.
+    """
+    auth = inbound_authorization.get()
+    if not auth:
+        return None
+    mode, _ = classify_bearer(auth)
+    return OAUTH_TOKEN_EXPIRED_HINT if mode == "oauth" else None

--- a/src/opik_mcp/config.py
+++ b/src/opik_mcp/config.py
@@ -139,6 +139,15 @@ class Settings(BaseSettings):
     # to the static workspace), so a short ceiling is safe.
     opik_mcp_oauth_introspect_timeout_s: float = 5.0
 
+    # How long a "valid" answer from that introspection is trusted before the
+    # next request on the same OAuth bearer asks opik-backend again (OPIK-8252).
+    # Bounds two things at once: the backend load added by validating every
+    # request, and the window in which a token that expired or was revoked is
+    # still forwarded (it then meets the backend's own 401 and the entry is
+    # dropped, so the window ends on the first failing call). When the backend
+    # reports ``expires_at`` the entry is capped at that instant regardless.
+    opik_mcp_oauth_validation_cache_ttl_s: float = 30.0
+
     opik_mcp_log_level: str = "INFO"
     opik_mcp_transport: str = "stdio"
     opik_mcp_host: str = "127.0.0.1"

--- a/src/opik_mcp/credential_identity.py
+++ b/src/opik_mcp/credential_identity.py
@@ -30,7 +30,7 @@ import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NamedTuple
 
 # One entry per active credential. Sized well above any realistic concurrent
 # user count for a single pod while staying trivially small in memory.
@@ -169,12 +169,27 @@ def lookup_session_digest(credential: str) -> str | None:
 # stored: a freshly refreshed token must work on its first use, and a rejection
 # is cheap. Bounded like the identity store, for the same reason.
 
-_VALIDATIONS: OrderedDict[str, tuple[float, float | None]] = OrderedDict()
+
+class _Validation(NamedTuple):
+    trust_until: float
+    """Monotonic instant until which the last "valid" answer is trusted."""
+
+    dead_from: float | None
+    """Monotonic instant the backend said the token expires, if it said."""
+
+
+# NOTE on keys: this store and the identity store are keyed on the bare OAuth
+# token (what ``classify_bearer`` returns); the session store is keyed on the
+# full ``Authorization`` header value. Same digest function, different inputs —
+# a lookup with the wrong one silently misses. Pre-dates the validation cache.
+_VALIDATIONS: OrderedDict[str, _Validation] = OrderedDict()
 
 # Clock skew allowance between opik-backend's ``expires_at`` and this pod.
 EXPIRY_SKEW_MARGIN_S = 10.0
 
-ValidationVerdict = Literal["valid", "expired"]
+# Same words as ``oauth_identity.IntrospectionStatus`` for the same verdicts, so
+# the middleware switches on one vocabulary. ``None`` from a lookup means "ask".
+ValidationVerdict = Literal["valid", "invalid"]
 
 
 def _now() -> float:
@@ -202,7 +217,7 @@ def remember_validation(
         return
     key = credential_digest(credential)
     with _LOCK:
-        _VALIDATIONS[key] = (trust_until, dead_from)
+        _VALIDATIONS[key] = _Validation(trust_until, dead_from)
         _VALIDATIONS.move_to_end(key)
         while len(_VALIDATIONS) > MAX_TRACKED_CREDENTIALS:
             _VALIDATIONS.popitem(last=False)
@@ -216,11 +231,10 @@ def lookup_validation(credential: str) -> ValidationVerdict | None:
         entry = _VALIDATIONS.get(key)
         if entry is None:
             return None
-        trust_until, dead_from = entry
-        if dead_from is not None and now >= dead_from:
+        if entry.dead_from is not None and now >= entry.dead_from:
             _VALIDATIONS.pop(key, None)
-            return "expired"
-        if now < trust_until:
+            return "invalid"
+        if now < entry.trust_until:
             _VALIDATIONS.move_to_end(key)
             return "valid"
         return None

--- a/src/opik_mcp/credential_identity.py
+++ b/src/opik_mcp/credential_identity.py
@@ -27,8 +27,10 @@ from __future__ import annotations
 
 import hashlib
 import threading
+import time
 from collections import OrderedDict
 from dataclasses import dataclass
+from typing import Literal
 
 # One entry per active credential. Sized well above any realistic concurrent
 # user count for a single pod while staying trivially small in memory.
@@ -156,20 +158,100 @@ def lookup_session_digest(credential: str) -> str | None:
         return digest
 
 
+# --- OAuth validation cache (OPIK-8252) ------------------------------------- #
+#
+# Credential digest -> (trust the token until, token is dead from). Both are
+# monotonic instants. The first is the validation-cache TTL (or the token's own
+# expiry minus a skew margin, whichever comes first); the second is the token's
+# expiry as the backend reported it, or ``None`` when it did not. A hit before
+# the first is "valid, skip the backend"; a request after the second is "dead,
+# answer 401 without asking"; in between, ask again. Only POSITIVE answers are
+# stored: a freshly refreshed token must work on its first use, and a rejection
+# is cheap. Bounded like the identity store, for the same reason.
+
+_VALIDATIONS: OrderedDict[str, tuple[float, float | None]] = OrderedDict()
+
+# Clock skew allowance between opik-backend's ``expires_at`` and this pod.
+EXPIRY_SKEW_MARGIN_S = 10.0
+
+ValidationVerdict = Literal["valid", "expired"]
+
+
+def _now() -> float:
+    """Monotonic clock for the validation cache. Module-level so tests can advance it."""
+    return time.monotonic()
+
+
+def remember_validation(
+    credential: str, *, ttl_s: float, expires_in_s: float | None = None
+) -> None:
+    """Record that opik-backend just accepted this credential.
+
+    ``expires_in_s`` is how long the backend says the token has left (from its
+    ``expires_at``), or ``None`` when it did not say. With it, trust is capped at
+    the expiry minus :data:`EXPIRY_SKEW_MARGIN_S`; an entry that would be
+    untrustworthy immediately is not stored, so the next request asks again.
+    """
+    now = _now()
+    trust_until = now + ttl_s
+    dead_from: float | None = None
+    if expires_in_s is not None:
+        dead_from = now + expires_in_s
+        trust_until = min(trust_until, dead_from - EXPIRY_SKEW_MARGIN_S)
+    if trust_until <= now:
+        return
+    key = credential_digest(credential)
+    with _LOCK:
+        _VALIDATIONS[key] = (trust_until, dead_from)
+        _VALIDATIONS.move_to_end(key)
+        while len(_VALIDATIONS) > MAX_TRACKED_CREDENTIALS:
+            _VALIDATIONS.popitem(last=False)
+
+
+def lookup_validation(credential: str) -> ValidationVerdict | None:
+    """What the cache knows about this credential right now, or ``None`` (ask)."""
+    key = credential_digest(credential)
+    now = _now()
+    with _LOCK:
+        entry = _VALIDATIONS.get(key)
+        if entry is None:
+            return None
+        trust_until, dead_from = entry
+        if dead_from is not None and now >= dead_from:
+            _VALIDATIONS.pop(key, None)
+            return "expired"
+        if now < trust_until:
+            _VALIDATIONS.move_to_end(key)
+            return "valid"
+        return None
+
+
+def forget_validation(credential: str) -> None:
+    """Drop a cached validation — opik-backend just rejected this credential."""
+    with _LOCK:
+        _VALIDATIONS.pop(credential_digest(credential), None)
+
+
 def reset_identities_for_tests() -> None:
-    """Drop every resolved identity and session pairing. Test-only."""
+    """Drop every resolved identity, session pairing and validation. Test-only."""
     with _LOCK:
         _STORE.clear()
         _SESSIONS.clear()
+        _VALIDATIONS.clear()
 
 
 __all__ = [
+    "EXPIRY_SKEW_MARGIN_S",
     "MAX_TRACKED_CREDENTIALS",
     "ResolvedIdentity",
+    "ValidationVerdict",
     "credential_digest",
+    "forget_validation",
     "lookup_identity",
     "lookup_session_digest",
+    "lookup_validation",
     "remember_identity",
     "remember_session",
+    "remember_validation",
     "reset_identities_for_tests",
 ]

--- a/src/opik_mcp/oauth_identity.py
+++ b/src/opik_mcp/oauth_identity.py
@@ -22,6 +22,8 @@ falls back to the static settings workspace and the call is reported anonymously
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from typing import Literal
 
 import httpx
 
@@ -31,6 +33,27 @@ from opik_mcp.opik_client import opik_rest_base
 
 logger = logging.getLogger("opik_mcp")
 
+IntrospectionStatus = Literal["valid", "invalid", "unknown"]
+"""Three-way outcome of asking opik-backend about a bearer.
+
+``valid`` — 200, the token is live; ``invalid`` — 401, the token is unknown,
+expired or revoked and the caller MUST be answered with HTTP 401 (MCP
+authorization spec, Token Handling); ``unknown`` — we could not get an answer
+(no REST base, network error, timeout, 5xx, malformed body). ``unknown`` is
+deliberately distinct from ``invalid``: a backend hiccup must degrade to
+"forward as before", never to a mass logout of every connected host.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class Introspection:
+    """What opik-backend said about an inbound OAuth bearer."""
+
+    status: IntrospectionStatus
+    identity: ResolvedIdentity | None = None
+    resource: str | None = None
+
+
 # JAX-RS path of opik-backend's token-introspection endpoint
 # (``OAuthConstants.OAUTH_VALIDATE_TOKEN_RESOURCE_BASE_PATH``). It is a sibling of
 # the ``/v1/private/...`` REST routes at the backend root, so it hangs off the same
@@ -38,22 +61,20 @@ logger = logging.getLogger("opik_mcp")
 _VALIDATE_TOKEN_PATH = "/opik/auth-oauth"
 
 
-async def resolve_oauth_identity(authorization: str, settings: Settings) -> ResolvedIdentity | None:
-    """Introspect an inbound OAuth bearer → the identity it stands for, or ``None``.
+async def introspect_oauth_token(authorization: str, settings: Settings) -> Introspection:
+    """Ask opik-backend whether an inbound OAuth bearer is live, and for whom.
 
     ``authorization`` is the full inbound ``Authorization`` header value
     (``"Bearer opik_mcp_at_…"``), forwarded verbatim — opik-backend re-validates
-    the token shape and resolves it server-side. Never raises; returns ``None`` on
-    any failure so the ``initialize`` handshake degrades gracefully.
+    the token shape and resolves it server-side. Never raises.
 
-    Returns ``None`` rather than an empty identity when the response carries
-    neither a workspace name nor a user name: an identity with nothing in it is
-    indistinguishable from an unresolved one to every consumer, and storing it
-    would only suppress a later retry.
+    A 200 is ``valid`` (with the identity when the body names anyone); a 401 is
+    ``invalid``; everything else is ``unknown``. See :data:`IntrospectionStatus`
+    for why the last two must not be conflated.
     """
     base = opik_rest_base(settings)
     if base is None:
-        return None
+        return Introspection(status="unknown")
     url = f"{base}{_VALIDATE_TOKEN_PATH}"
     headers = {
         "Authorization": authorization,
@@ -65,31 +86,48 @@ async def resolve_oauth_identity(authorization: str, settings: Settings) -> Reso
             timeout=settings.opik_mcp_oauth_introspect_timeout_s
         ) as client:
             resp = await client.post(url, headers=headers)
+        if resp.status_code == 401:
+            return Introspection(status="invalid")
         if resp.status_code != 200:
-            logger.debug("workspace introspection: non-200 status %s", resp.status_code)
-            return None
+            logger.debug("token introspection: non-200 status %s", resp.status_code)
+            return Introspection(status="unknown")
         body = resp.json()
     except Exception:
-        # Best-effort by contract: this runs on the ``initialize`` handshake and
-        # must NEVER raise (a failure just falls back to the static workspace).
-        # Catch broadly on purpose — beyond httpx.HTTPError + the ValueError from
-        # resp.json() on a non-JSON body, httpx raises httpx.InvalidURL (a direct
-        # Exception subclass, NOT an HTTPError) for a malformed REST base, which
-        # would otherwise escape into the middleware and 500 the handshake.
-        # Telemetry-free debug only — a failed lookup isn't worth surfacing.
-        logger.debug("workspace introspection failed", exc_info=True)
-        return None
+        # Must NEVER raise: this runs inside the auth middleware on every
+        # request. Catch broadly on purpose — beyond httpx.HTTPError + the
+        # ValueError from resp.json() on a non-JSON body, httpx raises
+        # httpx.InvalidURL (a direct Exception subclass, NOT an HTTPError) for a
+        # malformed REST base, which would otherwise 500 the request.
+        logger.debug("token introspection failed", exc_info=True)
+        return Introspection(status="unknown")
     if not isinstance(body, dict):
-        return None
+        return Introspection(status="valid")
     workspace_name = _text(body.get("workspace_name"))
     user_name = _text(body.get("user_name"))
-    if workspace_name is None and user_name is None:
-        return None
-    return ResolvedIdentity(
-        user_name=user_name,
-        workspace_name=workspace_name,
-        workspace_id=_text(body.get("workspace_id")),
+    identity = None
+    if workspace_name is not None or user_name is not None:
+        # An identity with nothing in it is indistinguishable from an unresolved
+        # one to every consumer, and storing it would only suppress a later retry.
+        identity = ResolvedIdentity(
+            user_name=user_name,
+            workspace_name=workspace_name,
+            workspace_id=_text(body.get("workspace_id")),
+        )
+    return Introspection(
+        status="valid",
+        identity=identity,
+        resource=_text(body.get("resource")),
     )
+
+
+async def resolve_oauth_identity(authorization: str, settings: Settings) -> ResolvedIdentity | None:
+    """Introspect an inbound OAuth bearer → the identity it stands for, or ``None``.
+
+    Thin best-effort view over :func:`introspect_oauth_token` for callers that
+    only care who the token stands for: any non-``valid`` outcome collapses to
+    ``None`` so the caller degrades gracefully.
+    """
+    return (await introspect_oauth_token(authorization, settings)).identity
 
 
 def _text(value: object) -> str | None:
@@ -104,4 +142,9 @@ def _text(value: object) -> str | None:
     return None
 
 
-__all__ = ["resolve_oauth_identity"]
+__all__ = [
+    "Introspection",
+    "IntrospectionStatus",
+    "introspect_oauth_token",
+    "resolve_oauth_identity",
+]

--- a/src/opik_mcp/oauth_identity.py
+++ b/src/opik_mcp/oauth_identity.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Literal
 
 import httpx
@@ -52,6 +53,11 @@ class Introspection:
     status: IntrospectionStatus
     identity: ResolvedIdentity | None = None
     resource: str | None = None
+    # Seconds until the token expires, from the backend's ``expires_at`` (an
+    # ISO-8601 instant). ``None`` when the backend did not report one — older
+    # opik-backend releases don't, and the validation cache then falls back to
+    # its TTL alone. Never negative: an already-past ``expires_at`` reads as 0.
+    expires_in_s: float | None = None
 
 
 # JAX-RS path of opik-backend's token-introspection endpoint
@@ -117,7 +123,22 @@ async def introspect_oauth_token(authorization: str, settings: Settings) -> Intr
         status="valid",
         identity=identity,
         resource=_text(body.get("resource")),
+        expires_in_s=_seconds_until(_text(body.get("expires_at"))),
     )
+
+
+def _seconds_until(expires_at: str | None) -> float | None:
+    """Seconds from now until an ISO-8601 instant, floored at 0; ``None`` if absent/unparseable."""
+    if expires_at is None:
+        return None
+    try:
+        when = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("token introspection: unparseable expires_at %r", expires_at)
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    return max(0.0, (when - datetime.now(UTC)).total_seconds())
 
 
 async def resolve_oauth_identity(authorization: str, settings: Settings) -> ResolvedIdentity | None:

--- a/src/opik_mcp/oauth_identity.py
+++ b/src/opik_mcp/oauth_identity.py
@@ -10,13 +10,16 @@ which cannot attribute a call without a user and a workspace.
 
 opik-backend exposes a purpose-built introspection endpoint for exactly this —
 ``POST /opik/auth-oauth`` (``OAuthValidateTokenResource``) returns the full
-``ValidatedToken``: ``user_name``, ``workspace_id`` and ``workspace_name``. We
-call it once per token, on the ``initialize`` handshake, forwarding the inbound
-bearer verbatim, and keep the whole answer in ``credential_identity``.
+``ValidatedToken``: ``user_name``, ``workspace_id`` and ``workspace_name``. Since
+OPIK-8252 the same call is also how opik-mcp discharges its resource-server duty
+(MCP authorization spec, Token Handling): ``BearerAuthMiddleware`` asks it on
+every request carrying an OAuth bearer (cached, see ``credential_identity``)
+and answers ``invalid_token`` 401 when the backend says the token is dead.
 
-This is best-effort: any failure (unconfigured base, non-200, network error,
-malformed body) returns ``None`` so the handshake never breaks — the blob simply
-falls back to the static settings workspace and the call is reported anonymously.
+The outcome is three-way on purpose — see :data:`IntrospectionStatus`. A
+definite 401 is the only rejection; any failure to get an answer (unconfigured
+base, non-200, network error, malformed body) is ``unknown``, so the request
+is forwarded as before and the blob falls back to the static workspace.
 """
 
 from __future__ import annotations
@@ -107,7 +110,10 @@ async def introspect_oauth_token(authorization: str, settings: Settings) -> Intr
         logger.debug("token introspection failed", exc_info=True)
         return Introspection(status="unknown")
     if not isinstance(body, dict):
-        return Introspection(status="valid")
+        # A 200 whose body is not the ValidatedToken object is malformed, and a
+        # malformed answer is no answer: fail open and cache nothing.
+        logger.debug("token introspection: non-object body %r", type(body).__name__)
+        return Introspection(status="unknown")
     workspace_name = _text(body.get("workspace_name"))
     user_name = _text(body.get("user_name"))
     identity = None
@@ -141,16 +147,6 @@ def _seconds_until(expires_at: str | None) -> float | None:
     return max(0.0, (when - datetime.now(UTC)).total_seconds())
 
 
-async def resolve_oauth_identity(authorization: str, settings: Settings) -> ResolvedIdentity | None:
-    """Introspect an inbound OAuth bearer → the identity it stands for, or ``None``.
-
-    Thin best-effort view over :func:`introspect_oauth_token` for callers that
-    only care who the token stands for: any non-``valid`` outcome collapses to
-    ``None`` so the caller degrades gracefully.
-    """
-    return (await introspect_oauth_token(authorization, settings)).identity
-
-
 def _text(value: object) -> str | None:
     """A non-empty string from the introspection body, or ``None``.
 
@@ -167,5 +163,4 @@ __all__ = [
     "Introspection",
     "IntrospectionStatus",
     "introspect_oauth_token",
-    "resolve_oauth_identity",
 ]

--- a/src/opik_mcp/oauth_identity.py
+++ b/src/opik_mcp/oauth_identity.py
@@ -98,21 +98,39 @@ async def introspect_oauth_token(authorization: str, settings: Settings) -> Intr
         if resp.status_code == 401:
             return Introspection(status="invalid")
         if resp.status_code != 200:
-            logger.debug("token introspection: non-200 status %s", resp.status_code)
+            # WARNING, not DEBUG: an ``unknown`` here means the request is
+            # forwarded UNVALIDATED (fail-open). A run of these in production is
+            # the difference between "the token died inside the cache window"
+            # and "the resource server cannot reach its introspection endpoint"
+            # — invisible at the default INFO level otherwise.
+            logger.warning(
+                "OAuth token introspection failed open: %s %s returned %s",
+                "POST",
+                url,
+                resp.status_code,
+            )
             return Introspection(status="unknown")
         body = resp.json()
-    except Exception:
+    except Exception as exc:
         # Must NEVER raise: this runs inside the auth middleware on every
         # request. Catch broadly on purpose — beyond httpx.HTTPError + the
         # ValueError from resp.json() on a non-JSON body, httpx raises
         # httpx.InvalidURL (a direct Exception subclass, NOT an HTTPError) for a
         # malformed REST base, which would otherwise 500 the request.
-        logger.debug("token introspection failed", exc_info=True)
+        logger.warning(
+            "OAuth token introspection failed open: POST %s raised %s",
+            url,
+            type(exc).__name__,
+        )
         return Introspection(status="unknown")
     if not isinstance(body, dict):
         # A 200 whose body is not the ValidatedToken object is malformed, and a
         # malformed answer is no answer: fail open and cache nothing.
-        logger.debug("token introspection: non-object body %r", type(body).__name__)
+        logger.warning(
+            "OAuth token introspection failed open: POST %s returned a %s, not an object",
+            url,
+            type(body).__name__,
+        )
         return Introspection(status="unknown")
     workspace_name = _text(body.get("workspace_name"))
     user_name = _text(body.get("user_name"))

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -22,9 +22,10 @@ import httpx
 
 from opik_mcp.auth_context import (
     OAUTH_ACCESS_TOKEN_PREFIX,
+    classify_bearer,
     inbound_authorization,
     inbound_workspace,
-    note_backend_401,
+    oauth_token_expired_hint,
 )
 from opik_mcp.config import (
     DEFAULT_WORKSPACE,
@@ -34,6 +35,7 @@ from opik_mcp.config import (
     looks_unsubstituted,
     unfilled_workspace_error,
 )
+from opik_mcp.credential_identity import forget_validation
 from opik_mcp.error_kinds import ErrorKind
 
 # --- errors --------------------------------------------------------------- #
@@ -816,7 +818,7 @@ def opik_rest_base(settings: Settings) -> str | None:
     Single source of truth for the rule: an explicit ``OPIK_URL`` override wins;
     otherwise derive from ``COMET_URL_OVERRIDE + "/opik/api"``. Shared by
     ``resolve_opik_config`` (which treats ``None`` as a fatal misconfig) and
-    ``oauth_identity.resolve_oauth_identity`` (which treats ``None`` as "skip,
+    ``oauth_identity.introspect_oauth_token`` (which treats ``None`` as "skip,
     fall back to the static workspace"), so both agree on where Opik lives.
     """
     if settings.opik_url:
@@ -835,6 +837,25 @@ def make_opik_client(settings: Settings) -> OpikClient:
 def _score_body(score: FeedbackScore) -> dict[str, Any]:
     """FeedbackScore → JSON body with ``None`` fields stripped."""
     return _drop_none(asdict(score))
+
+
+def note_backend_401() -> str | None:
+    """opik-backend just answered 401 to the call this request is forwarding.
+
+    If the inbound bearer is an OAuth token, its cached validation is dropped so
+    the NEXT MCP request re-asks the backend and gets the ``invalid_token`` 401
+    that triggers the host's refresh — now, not after the cache TTL. Returns the
+    tool-error hint for that bearer (``None`` for an API key); see
+    ``auth_context.oauth_token_expired_hint``. Called from every place a backend
+    401 is turned into an error: here for reads/lists, ``writes.dispatch`` for
+    writes.
+    """
+    auth = inbound_authorization.get()
+    if auth:
+        mode, token = classify_bearer(auth)
+        if mode == "oauth":
+            forget_validation(token)
+    return oauth_token_expired_hint()
 
 
 def _raise_for_status(resp: httpx.Response, entity_hint: str) -> None:

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -24,6 +24,7 @@ from opik_mcp.auth_context import (
     OAUTH_ACCESS_TOKEN_PREFIX,
     inbound_authorization,
     inbound_workspace,
+    oauth_token_expired_hint,
 )
 from opik_mcp.config import (
     DEFAULT_WORKSPACE,
@@ -45,7 +46,8 @@ from opik_mcp.error_kinds import ErrorKind
 
 
 class OpikAuthError(RuntimeError):
-    """Opik rejected the API key (401)."""
+    """Opik rejected the credential (401): a bad API key, or an OAuth access token
+    that expired or was revoked (see ``auth_context.oauth_token_expired_hint``)."""
 
     error_kind: ClassVar[ErrorKind] = "auth"
     http_status: ClassVar[int | None] = 401
@@ -842,9 +844,8 @@ def _raise_for_status(resp: httpx.Response, entity_hint: str) -> None:
     detail = _error_detail(resp)
     suffix = f" — {detail}" if detail else ""
     if status == 401:
-        raise OpikAuthError(
-            f"Opik rejected the request (401). Check OPIK_API_KEY and OPIK_WORKSPACE.{suffix}"
-        )
+        hint = oauth_token_expired_hint() or "Check OPIK_API_KEY and OPIK_WORKSPACE."
+        raise OpikAuthError(f"Opik rejected the request (401). {hint}{suffix}")
     if status == 403:
         raise OpikPermissionError(
             f"Opik rejected the request (403). The API key is valid but lacks "

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -24,7 +24,7 @@ from opik_mcp.auth_context import (
     OAUTH_ACCESS_TOKEN_PREFIX,
     inbound_authorization,
     inbound_workspace,
-    oauth_token_expired_hint,
+    note_backend_401,
 )
 from opik_mcp.config import (
     DEFAULT_WORKSPACE,
@@ -844,7 +844,7 @@ def _raise_for_status(resp: httpx.Response, entity_hint: str) -> None:
     detail = _error_detail(resp)
     suffix = f" — {detail}" if detail else ""
     if status == 401:
-        hint = oauth_token_expired_hint() or "Check OPIK_API_KEY and OPIK_WORKSPACE."
+        hint = note_backend_401() or "Check OPIK_API_KEY and OPIK_WORKSPACE."
         raise OpikAuthError(f"Opik rejected the request (401). {hint}{suffix}")
     if status == 403:
         raise OpikPermissionError(

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -23,6 +23,7 @@ from opik_mcp.config import Settings, get_settings
 from opik_mcp.opik_client import (
     OpikAuthError,
     OpikNotFoundError,
+    OpikPermissionError,
     OpikReadClient,
     OpikServerError,
     OpikValidationError,
@@ -77,12 +78,18 @@ def _format_client_error(
             "Verify the ID is a valid UUID and belongs to the current workspace. "
             f"Detail: {exc}"
         )
-    if isinstance(exc, OpikAuthError):
+    if isinstance(exc, OpikPermissionError):
         return (
             f"Permission denied fetching {entity_type} '{entity_id}'. "
             "The current workspace may not have access to this entity. "
             f"Detail: {exc}"
         )
+    if isinstance(exc, OpikAuthError):
+        # A 401 is about the credential, not the workspace: an expired OAuth
+        # token or a bad API key. The client error already says which and what
+        # to do about it; wrapping it in "permission denied" sent users (and the
+        # model) hunting for workspace access that was never the problem.
+        return f"Authentication failed fetching {entity_type} '{entity_id}'. Detail: {exc}"
     if isinstance(exc, OpikValidationError):
         return (
             f"Validation error fetching {entity_type} '{entity_id}': "

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -39,7 +39,7 @@ from opik_mcp.auth_context import (
 from opik_mcp.config import Settings, get_settings
 from opik_mcp.credential_identity import remember_identity, remember_session
 from opik_mcp.instructions import render_instructions
-from opik_mcp.oauth_identity import resolve_oauth_identity
+from opik_mcp.oauth_identity import introspect_oauth_token
 from opik_mcp.read_list import run_list, run_read
 from opik_mcp.read_list.registry import LISTABLE_TYPES, READABLE_TYPES
 from opik_mcp.read_list.uri import looks_like_thread_url
@@ -523,16 +523,18 @@ _READY_PROBE_TIMEOUT_S = 2.0
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
-    """Bearer-shape check + per-request bearer-capture for outbound forwarding.
+    """Bearer-shape check, OAuth token validation, and per-request bearer-capture.
 
-    opik-mcp performs **no local credential validation**. Any well-formed
-    ``Authorization: Bearer …`` header is accepted; the full header value is
-    captured into a ContextVar and forwarded verbatim on the outbound call to
-    opik-backend (see :mod:`opik_mcp.auth_context`). opik-backend's
-    ``AuthFilter`` is the single point of auth enforcement — it validates the
-    bearer (API key or an ``OAUTH_ACCESS_TOKEN_PREFIX``-prefixed OAuth token) and enforces
-    ``@RequiredPermissions`` on the data API endpoint. Deployments where the
-    backend enforces auth are protected end-to-end; OSS installs without
+    Two bearer shapes, two contracts. An ``OAUTH_ACCESS_TOKEN_PREFIX``-prefixed
+    OAuth token is validated against opik-backend's introspection endpoint on
+    every request and answered with an ``invalid_token`` 401 when dead — the
+    resource-server duty the MCP authorization spec puts on us, and the only
+    signal a host has to refresh (OPIK-8252). Any other well-formed
+    ``Authorization: Bearer …`` is an API key and is **not validated locally**:
+    the full header value is captured into a ContextVar and forwarded verbatim
+    on the outbound call to opik-backend (see :mod:`opik_mcp.auth_context`),
+    whose ``AuthFilter`` is its single point of enforcement. Deployments where
+    the backend enforces auth are protected end-to-end; OSS installs without
     backend auth are as open via MCP as via their own REST API.
 
     Missing/empty ``Authorization`` returns 401 with a ``WWW-Authenticate``
@@ -573,21 +575,52 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             # clean recovery path instead of an opaque upstream 401.
             return self._unauthorized()
 
+        auth_mode, oauth_token = classify_bearer(auth)
+        mcp_session_id = request.headers.get("mcp-session-id")
+        # OAuth bearers are validated on EVERY request to the MCP path before
+        # anything is forwarded (MCP authorization spec 2026-07-28, Token
+        # Handling: the resource server MUST validate the access token and MUST
+        # answer 401 for an invalid or expired one). That 401 is the only signal
+        # a host has to run the ``refresh_token`` grant — a dead token that
+        # reached opik-backend used to come back as a tool error inside HTTP 200,
+        # and hosts kept a "connected" connector that could not make a call.
+        # API-key bearers are forwarded untouched: opik-backend's AuthFilter is
+        # their single point of enforcement.
+        identity = None
+        if auth_mode == "oauth":
+            settings = get_settings()
+            introspection = await introspect_oauth_token(auth, settings)
+            if introspection.status == "invalid":
+                return self._invalid_token()
+            # ``unknown`` (no REST base, network, 5xx) falls through: a backend
+            # hiccup must degrade to "forward as before", never to a mass logout.
+            identity = introspection.identity
+            # RFC 8707 audience check, observe-only for now: the AS and opik-mcp
+            # are configured independently, and a strict reject on a mismatch
+            # (even a trailing slash) would lock every host out in one deploy.
+            # The warning is how we confirm the two agree before enforcing.
+            expected_resource = settings.opik_mcp_resource_uri
+            if (
+                introspection.resource
+                and expected_resource
+                and introspection.resource.rstrip("/") != expected_resource.rstrip("/")
+            ):
+                logger.warning(
+                    "OAuth token bound to resource %r but this server is %r",
+                    introspection.resource,
+                    expected_resource,
+                )
+            if identity is not None:
+                # Held against the token, not this request: the analytics layer
+                # builds events in the MCP session task and never sees a request,
+                # and a second session on the same token needs no second lookup.
+                remember_identity(oauth_token, identity)
+
         # Capture the inbound auth + workspace headers for the duration of
         # this request so the outbound :class:`OpikClient` can forward them.
         auth_token = inbound_authorization.set(auth)
         workspace = request.headers.get("comet-workspace")
         workspace_token = inbound_workspace.set(workspace)
-        # On the session-creating request — the MCP ``initialize`` handshake is
-        # the only one without an ``Mcp-Session-Id`` — resolve the OAuth-authorized
-        # workspace NAME so the per-session instructions blob can name it. In OAuth
-        # mode the host sends no ``Comet-Workspace`` header and the token is opaque
-        # to us, so we introspect it here (once per session); tool calls carry a
-        # session id and skip this. Best-effort: a failure leaves the blob on its
-        # static fallback and never blocks the handshake.
-        resolved_token = None
-        auth_mode, oauth_token = classify_bearer(auth)
-        mcp_session_id = request.headers.get("mcp-session-id")
         # TELEMETRY ONLY — see ``auth_context.inbound_mcp_session_id``. The
         # session id is the stable unit the hosted funnel needs: a client keeps it
         # across OAuth token refreshes, so an 8-hour session counts once instead of
@@ -601,15 +634,14 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         # `None` for the life of the session. `remember_session` below closes
         # that gap by keying the id to the credential instead; the ContextVar
         # still serves events emitted inside a request, such as `auth_rejected`.
-        if mcp_session_id is None and auth_mode == "oauth":
-            identity = await resolve_oauth_identity(auth, get_settings())
-            if identity is not None:
-                # Held against the token, not this request: the analytics layer
-                # builds events in the MCP session task and never sees a request,
-                # and a second session on the same token needs no second lookup.
-                remember_identity(oauth_token, identity)
-                if identity.workspace_name:
-                    resolved_token = resolved_workspace_name.set(identity.workspace_name)
+        #
+        # The OAuth-authorized workspace NAME feeds the per-session instructions
+        # blob so an agent can truthfully say which workspace it operates against.
+        # In OAuth mode the host sends no ``Comet-Workspace`` header, so this is
+        # the only place the name is known.
+        resolved_token = None
+        if identity is not None and identity.workspace_name:
+            resolved_token = resolved_workspace_name.set(identity.workspace_name)
         try:
             response = await call_next(request)
             if mcp_session_id is None:
@@ -628,15 +660,41 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
                 resolved_workspace_name.reset(resolved_token)
 
     def _unauthorized(self) -> Response:
-        # RFC 6750 §3 + RFC 9728: pointing MCP hosts at protected-resource
-        # metadata is what kicks off automatic OAuth discovery — without
-        # this, hosts have no way to find the AS without out-of-band config.
-        headers: dict[str, str] = {}
-        if self._resource_metadata_url:
-            headers["WWW-Authenticate"] = (
-                f'Bearer realm="opik-mcp", resource_metadata="{self._resource_metadata_url}"'
-            )
-        return JSONResponse({"error": "unauthorized"}, status_code=401, headers=headers)
+        # No credentials presented: RFC 6750 §3.1 says the challenge carries no
+        # ``error`` parameter in that case. Pointing MCP hosts at protected-
+        # resource metadata (RFC 9728) is what kicks off automatic OAuth
+        # discovery — without it, hosts have no way to find the AS without
+        # out-of-band config.
+        return JSONResponse(
+            {"error": "unauthorized"}, status_code=401, headers=self._challenge_headers()
+        )
+
+    def _invalid_token(self) -> Response:
+        # A well-formed bearer that opik-backend no longer accepts. RFC 6750 §3.1
+        # ``invalid_token`` is the code hosts key their refresh on: the token is
+        # expired or revoked, re-run the ``refresh_token`` grant (or re-authorize
+        # if that fails too) — as opposed to a bare 401 that reads as "start the
+        # discovery dance from scratch".
+        description = "The access token is invalid or expired"
+        return JSONResponse(
+            {"error": "invalid_token", "error_description": description},
+            status_code=401,
+            headers=self._challenge_headers(error="invalid_token", error_description=description),
+        )
+
+    def _challenge_headers(self, **params: str) -> dict[str, str]:
+        """``WWW-Authenticate: Bearer …`` per RFC 6750 §3 + RFC 9728, or nothing.
+
+        Omitted entirely when no resource-metadata URL is configured: a
+        challenge that cannot point at the metadata gives a host nothing to act
+        on, and some host parsers reject a bare/empty value outright.
+        """
+        if not self._resource_metadata_url:
+            return {}
+        parts = ['realm="opik-mcp"']
+        parts.extend(f'{key}="{value}"' for key, value in params.items())
+        parts.append(f'resource_metadata="{self._resource_metadata_url}"')
+        return {"WWW-Authenticate": "Bearer " + ", ".join(parts)}
 
 
 def _has_absolute_resource_metadata_url(settings: Settings) -> bool:
@@ -671,9 +729,9 @@ def _classify_rejection_reason(status_code: int, auth_header: str) -> str:
         return "not_bearer"
     if not auth_header[len("bearer ") :].strip():
         return "empty_token"
-    # A well-formed bearer that still got a 401 — BearerAuthMiddleware forwards
-    # those onward, so today this only arises if a downstream layer 401s a valid
-    # shape. Its own bucket (never echoes the token) so BI doesn't conflate it
+    # A well-formed bearer that still got a 401: an OAuth token opik-backend's
+    # introspection reported dead (expired/revoked) — the refresh trigger for
+    # hosts. Its own bucket (never echoes the token) so BI doesn't conflate it
     # with genuinely-missing-header rejections.
     return "token_rejected"
 

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -38,6 +38,7 @@ from opik_mcp.auth_context import (
 )
 from opik_mcp.config import Settings, get_settings
 from opik_mcp.credential_identity import (
+    ResolvedIdentity,
     forget_validation,
     lookup_identity,
     lookup_validation,
@@ -595,54 +596,10 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         # their single point of enforcement.
         identity = None
         if auth_mode == "oauth":
-            settings = get_settings()
-            verdict = lookup_validation(oauth_token)
-            if verdict == "expired":
-                # The backend told us when this token dies and that instant has
-                # passed: no need to ask again.
-                return self._invalid_token()
-            if verdict == "valid":
-                # Trusted from an earlier request. A second handshake on the
-                # same token (host reconnect) still needs the identity for the
-                # instructions blob; it was remembered when the token was first
-                # validated.
-                identity = lookup_identity(oauth_token)
-            else:
-                introspection = await introspect_oauth_token(auth, settings)
-                if introspection.status == "invalid":
-                    forget_validation(oauth_token)
-                    return self._invalid_token()
-                # ``unknown`` (no REST base, network, 5xx) falls through and
-                # caches nothing: a backend hiccup must degrade to "forward as
-                # before", never to a mass logout.
-                if introspection.status == "valid":
-                    remember_validation(
-                        oauth_token,
-                        ttl_s=settings.opik_mcp_oauth_validation_cache_ttl_s,
-                        expires_in_s=introspection.expires_in_s,
-                    )
-                identity = introspection.identity
-                # RFC 8707 audience check, observe-only for now: the AS and
-                # opik-mcp are configured independently, and a strict reject on a
-                # mismatch (even a trailing slash) would lock every host out in
-                # one deploy. The warning is how we confirm the two agree before
-                # enforcing.
-                expected_resource = settings.opik_mcp_resource_uri
-                if (
-                    introspection.resource
-                    and expected_resource
-                    and introspection.resource.rstrip("/") != expected_resource.rstrip("/")
-                ):
-                    logger.warning(
-                        "OAuth token bound to resource %r but this server is %r",
-                        introspection.resource,
-                        expected_resource,
-                    )
-            if identity is not None:
-                # Held against the token, not this request: the analytics layer
-                # builds events in the MCP session task and never sees a request,
-                # and a second session on the same token needs no second lookup.
-                remember_identity(oauth_token, identity)
+            outcome = await self._validate_oauth_bearer(auth, oauth_token)
+            if isinstance(outcome, Response):
+                return outcome
+            identity = outcome
 
         # Capture the inbound auth + workspace headers for the duration of
         # this request so the outbound :class:`OpikClient` can forward them.
@@ -686,6 +643,58 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             inbound_mcp_session_id.reset(session_id_token)
             if resolved_token is not None:
                 resolved_workspace_name.reset(resolved_token)
+
+    async def _validate_oauth_bearer(
+        self, auth: str, oauth_token: str
+    ) -> Response | ResolvedIdentity | None:
+        """Validate an OAuth bearer: the 401 to send, or the identity it stands for.
+
+        Cache first, opik-backend's introspection endpoint on a miss. A definite
+        "invalid" (cached expiry, or a 401 from introspection) is answered with
+        ``_invalid_token``; ``unknown`` (no REST base, network, 5xx) falls
+        through and caches nothing — a backend hiccup must degrade to "forward
+        as before", never to a mass logout. A "valid" answer is remembered for
+        the configured TTL, capped at the backend's ``expires_at``. The identity
+        (``None`` when the backend named nobody) is remembered against the
+        token: the analytics layer builds events in the MCP session task and
+        never sees a request, and a second handshake on the same token (host
+        reconnect) reads it back instead of asking again.
+        """
+        settings = get_settings()
+        verdict = lookup_validation(oauth_token)
+        if verdict == "invalid":
+            return self._invalid_token()
+        if verdict == "valid":
+            return lookup_identity(oauth_token)
+        introspection = await introspect_oauth_token(auth, settings)
+        if introspection.status == "invalid":
+            forget_validation(oauth_token)
+            return self._invalid_token()
+        if introspection.status == "valid":
+            remember_validation(
+                oauth_token,
+                ttl_s=settings.opik_mcp_oauth_validation_cache_ttl_s,
+                expires_in_s=introspection.expires_in_s,
+            )
+            # RFC 8707 audience check, observe-only for now: the AS and opik-mcp
+            # are configured independently, and a strict reject on a mismatch
+            # would lock every host out in one deploy. Compared exactly as
+            # configured — a trailing-slash difference is precisely what a
+            # strict check would trip on, so the warning must show it.
+            expected_resource = settings.opik_mcp_resource_uri
+            if (
+                introspection.resource
+                and expected_resource
+                and introspection.resource != expected_resource
+            ):
+                logger.warning(
+                    "OAuth token bound to resource %r but this server is %r",
+                    introspection.resource,
+                    expected_resource,
+                )
+        if introspection.identity is not None:
+            remember_identity(oauth_token, introspection.identity)
+        return introspection.identity
 
     def _unauthorized(self) -> Response:
         # No credentials presented: RFC 6750 §3.1 says the challenge carries no

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -10,6 +10,7 @@ import httpx
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import CallToolRequest
 from pydantic import Field
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -1131,9 +1132,69 @@ def install_session_instructions(server: FastMCP) -> None:
     lowlevel.create_initialization_options = create_initialization_options  # type: ignore[method-assign]
 
 
+def _current_http_request() -> Request | None:
+    """The HTTP request behind the MCP request being handled, or ``None`` (stdio)."""
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+
+        request = request_ctx.get().request
+    except (LookupError, AttributeError):
+        return None
+    return request if isinstance(request, Request) else None
+
+
+def install_request_auth_rebinding(server: FastMCP) -> None:
+    """Forward the bearer of the CURRENT request on ``tools/call``, not the handshake's.
+
+    ``BearerAuthMiddleware`` sets the inbound-auth ContextVars on the request
+    task, but a tool runs in the MCP session task, which the SDK forks from the
+    ``initialize`` request — so inside a tool those vars still hold the
+    handshake-time values. Harmless while a bearer never changes during a
+    session; fatal once it does: after the ``invalid_token`` 401 (OPIK-8252)
+    the host refreshes and re-sends with a NEW access token, the middleware
+    validates that one, and the outbound client would forward the OLD, dead
+    one — every call after a refresh meets the backend's 401 and the connector
+    never recovers, which is exactly the failure the 401 exists to fix.
+
+    The SDK attaches the Starlette request of each ``tools/call`` to its
+    request context and handles each message in its own task, so re-binding
+    the vars there is both current and isolated. stdio has no request and is
+    left untouched. Mirrors ``install_tools_listed_emitter``'s in-place swap.
+    """
+    try:
+        lowlevel = server._mcp_server
+    except AttributeError:
+        logger.debug("install_request_auth_rebinding: mcp has no _mcp_server attribute")
+        return
+    original = lowlevel.request_handlers.get(CallToolRequest)
+    if original is None:
+        logger.debug("install_request_auth_rebinding: no CallToolRequest handler registered")
+        return
+
+    async def wrapped(req: Any) -> Any:
+        request = _current_http_request()
+        if request is None:
+            return await original(req)
+        auth = request.headers.get("authorization")
+        if not auth:
+            # Cannot happen behind BearerAuthMiddleware (it 401s first); if it
+            # ever does, leave the vars as the middleware set them.
+            return await original(req)
+        auth_token = inbound_authorization.set(auth)
+        workspace_token = inbound_workspace.set(request.headers.get("comet-workspace"))
+        try:
+            return await original(req)
+        finally:
+            inbound_workspace.reset(workspace_token)
+            inbound_authorization.reset(auth_token)
+
+    lowlevel.request_handlers[CallToolRequest] = wrapped
+
+
 def build_app() -> ASGIApp:
     install_tools_listed_emitter(mcp)
     install_session_instructions(mcp)
+    install_request_auth_rebinding(mcp)
     install_skill_resources(mcp)
     s = get_settings()
     # Serve the transport at the configured path so it matches the advertised

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -37,7 +37,14 @@ from opik_mcp.auth_context import (
     settings_auth_mode,
 )
 from opik_mcp.config import Settings, get_settings
-from opik_mcp.credential_identity import remember_identity, remember_session
+from opik_mcp.credential_identity import (
+    forget_validation,
+    lookup_identity,
+    lookup_validation,
+    remember_identity,
+    remember_session,
+    remember_validation,
+)
 from opik_mcp.instructions import render_instructions
 from opik_mcp.oauth_identity import introspect_oauth_token
 from opik_mcp.read_list import run_list, run_read
@@ -589,27 +596,48 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         identity = None
         if auth_mode == "oauth":
             settings = get_settings()
-            introspection = await introspect_oauth_token(auth, settings)
-            if introspection.status == "invalid":
+            verdict = lookup_validation(oauth_token)
+            if verdict == "expired":
+                # The backend told us when this token dies and that instant has
+                # passed: no need to ask again.
                 return self._invalid_token()
-            # ``unknown`` (no REST base, network, 5xx) falls through: a backend
-            # hiccup must degrade to "forward as before", never to a mass logout.
-            identity = introspection.identity
-            # RFC 8707 audience check, observe-only for now: the AS and opik-mcp
-            # are configured independently, and a strict reject on a mismatch
-            # (even a trailing slash) would lock every host out in one deploy.
-            # The warning is how we confirm the two agree before enforcing.
-            expected_resource = settings.opik_mcp_resource_uri
-            if (
-                introspection.resource
-                and expected_resource
-                and introspection.resource.rstrip("/") != expected_resource.rstrip("/")
-            ):
-                logger.warning(
-                    "OAuth token bound to resource %r but this server is %r",
-                    introspection.resource,
-                    expected_resource,
-                )
+            if verdict == "valid":
+                # Trusted from an earlier request. A second handshake on the
+                # same token (host reconnect) still needs the identity for the
+                # instructions blob; it was remembered when the token was first
+                # validated.
+                identity = lookup_identity(oauth_token)
+            else:
+                introspection = await introspect_oauth_token(auth, settings)
+                if introspection.status == "invalid":
+                    forget_validation(oauth_token)
+                    return self._invalid_token()
+                # ``unknown`` (no REST base, network, 5xx) falls through and
+                # caches nothing: a backend hiccup must degrade to "forward as
+                # before", never to a mass logout.
+                if introspection.status == "valid":
+                    remember_validation(
+                        oauth_token,
+                        ttl_s=settings.opik_mcp_oauth_validation_cache_ttl_s,
+                        expires_in_s=introspection.expires_in_s,
+                    )
+                identity = introspection.identity
+                # RFC 8707 audience check, observe-only for now: the AS and
+                # opik-mcp are configured independently, and a strict reject on a
+                # mismatch (even a trailing slash) would lock every host out in
+                # one deploy. The warning is how we confirm the two agree before
+                # enforcing.
+                expected_resource = settings.opik_mcp_resource_uri
+                if (
+                    introspection.resource
+                    and expected_resource
+                    and introspection.resource.rstrip("/") != expected_resource.rstrip("/")
+                ):
+                    logger.warning(
+                        "OAuth token bound to resource %r but this server is %r",
+                        introspection.resource,
+                        expected_resource,
+                    )
             if identity is not None:
                 # Held against the token, not this request: the analytics layer
                 # builds events in the MCP session task and never sees a request,

--- a/src/opik_mcp/writes/dispatch.py
+++ b/src/opik_mcp/writes/dispatch.py
@@ -37,6 +37,7 @@ from opik_mcp.opik_client import (
     OpikServerError,
     OpikValidationError,
     make_opik_client,
+    note_backend_401,
 )
 from opik_mcp.writes.errors import (
     AuthorizationDeniedError,
@@ -590,6 +591,10 @@ def _stage4_finalize(
 ) -> dict[str, Any]:
     status = resp.status_code
     if not (200 <= status < 300):
+        if status == 401:
+            # Drop the cached OAuth validation so the next request re-validates
+            # and meets the 401 that triggers the host's refresh (OPIK-8252).
+            note_backend_401()
         raise BackendError.build(op.name, status, _safe_body(resp), method=method, path=path)
     body = _safe_body(resp)
     return {

--- a/src/opik_mcp/writes/errors.py
+++ b/src/opik_mcp/writes/errors.py
@@ -13,6 +13,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Final, Literal
 
+from opik_mcp.auth_context import oauth_token_expired_hint
 from opik_mcp.error_kinds import ErrorKind
 
 ErrorCode = Literal[
@@ -165,9 +166,12 @@ class BackendError(WriteError):
         method: str,
         path: str,
     ) -> BackendError:
+        message = f"Backend rejected {method} {path} with status {status}."
+        if status == 401 and (hint := oauth_token_expired_hint()):
+            message = f"{message} {hint}"
         return cls(
             operation=operation,
-            message=f"Backend rejected {method} {path} with status {status}.",
+            message=message,
             extra={
                 "backend_error": {
                     "status": status,

--- a/src/opik_mcp/writes/errors.py
+++ b/src/opik_mcp/writes/errors.py
@@ -13,7 +13,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Final, Literal
 
-from opik_mcp.auth_context import oauth_token_expired_hint
+from opik_mcp.auth_context import note_backend_401
 from opik_mcp.error_kinds import ErrorKind
 
 ErrorCode = Literal[
@@ -167,7 +167,7 @@ class BackendError(WriteError):
         path: str,
     ) -> BackendError:
         message = f"Backend rejected {method} {path} with status {status}."
-        if status == 401 and (hint := oauth_token_expired_hint()):
+        if status == 401 and (hint := note_backend_401()):
             message = f"{message} {hint}"
         return cls(
             operation=operation,

--- a/src/opik_mcp/writes/errors.py
+++ b/src/opik_mcp/writes/errors.py
@@ -13,7 +13,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Final, Literal
 
-from opik_mcp.auth_context import note_backend_401
+from opik_mcp.auth_context import oauth_token_expired_hint
 from opik_mcp.error_kinds import ErrorKind
 
 ErrorCode = Literal[
@@ -167,7 +167,7 @@ class BackendError(WriteError):
         path: str,
     ) -> BackendError:
         message = f"Backend rejected {method} {path} with status {status}."
-        if status == 401 and (hint := note_backend_401()):
+        if status == 401 and (hint := oauth_token_expired_hint()):
             message = f"{message} {hint}"
         return cls(
             operation=operation,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def _disable_workspace_introspection() -> Generator[None]:
     """Stub OAuth workspace introspection to a no-op by default.
 
     The ``initialize`` handshake resolves the caller's identity by POSTing to
-    opik-backend's ``/opik/auth-oauth`` (``server.resolve_oauth_identity``).
+    opik-backend's ``/opik/auth-oauth`` (``server.introspect_oauth_token``).
     Left live, every test that sends a session-less OAuth bearer to ``/mcp`` would
     fire a real network call — slow, flaky, and able to land in another test's
     ``@respx.mock`` window. Stubbed to ``unknown`` by default — the fail-open

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,9 +83,11 @@ def _disable_workspace_introspection() -> Generator[None]:
     opik-backend's ``/opik/auth-oauth`` (``server.resolve_oauth_identity``).
     Left live, every test that sends a session-less OAuth bearer to ``/mcp`` would
     fire a real network call — slow, flaky, and able to land in another test's
-    ``@respx.mock`` window. Disabled by default (mirrors the analytics default
-    above); tests that exercise resolution ``monkeypatch.setattr`` this, and the
-    ``resolve_oauth_identity`` unit tests call the real function directly.
+    ``@respx.mock`` window. Stubbed to ``unknown`` by default — the fail-open
+    outcome, so the request is forwarded exactly as with no introspection at
+    all (mirrors the analytics default above); tests that exercise validation
+    ``monkeypatch.setattr`` the real function back, and the ``oauth_identity``
+    unit tests call it directly.
 
     Uses a standalone ``pytest.MonkeyPatch()`` rather than the ``monkeypatch``
     *fixture* on purpose: depending on that fixture from an autouse fixture pulls
@@ -95,11 +97,13 @@ def _disable_workspace_introspection() -> Generator[None]:
     on ``cache_info``). A self-owned instance keeps fixture ordering untouched.
     """
 
-    async def _none(*_args: object, **_kwargs: object) -> None:
-        return None
+    from opik_mcp.oauth_identity import Introspection
+
+    async def _unknown(*_args: object, **_kwargs: object) -> Introspection:
+        return Introspection(status="unknown")
 
     mp = pytest.MonkeyPatch()
-    mp.setattr("opik_mcp.server.resolve_oauth_identity", _none)
+    mp.setattr("opik_mcp.server.introspect_oauth_token", _unknown)
     try:
         yield
     finally:

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,10 +1,13 @@
 """Integration tests for inbound auth on the HTTP transport.
 
-opik-mcp performs no local credential validation — any well-formed
-``Authorization: Bearer …`` is accepted and forwarded verbatim to
-opik-backend, which is the single point of auth enforcement. The middleware
-only rejects requests that carry no usable bearer at all (missing header or
-a non-Bearer scheme), returning 401 so MCP hosts bootstrap the OAuth dance.
+Two bearer shapes, two contracts. An ``opik_mcp_at_``-prefixed OAuth token is
+validated against opik-backend on every request and rejected with an
+``invalid_token`` 401 when dead (OPIK-8252; see
+``test_oauth_token_validation.py`` for that contract). Any other well-formed
+``Authorization: Bearer …`` is an API key: accepted and forwarded verbatim to
+opik-backend, which is its single point of enforcement. Requests that carry no
+usable bearer at all (missing header or a non-Bearer scheme) get a 401 so MCP
+hosts bootstrap the OAuth dance.
 """
 
 import httpx
@@ -40,11 +43,12 @@ async def test_non_bearer_scheme_returns_401(http_client: httpx.AsyncClient) -> 
 
 
 @pytest.mark.anyio
-async def test_any_bearer_initializes(http_client: httpx.AsyncClient) -> None:
-    """No local validation: opik-mcp accepts the bearer and forwards it.
-
-    ``initialize`` makes no outbound opik-backend call, so it succeeds
-    regardless of whether the token would later be accepted upstream.
+async def test_api_key_bearer_initializes(http_client: httpx.AsyncClient) -> None:
+    """API keys are not validated locally: opik-mcp accepts the bearer and
+    forwards it. ``initialize`` makes no outbound opik-backend call, so it
+    succeeds regardless of whether the key would later be accepted upstream.
+    (The OAuth-shaped bearer below is still accepted here only because conftest
+    stubs introspection to ``unknown`` — the fail-open outcome.)
     """
     r = await http_client.post(
         "/mcp",
@@ -71,15 +75,19 @@ async def test_initialize_names_oauth_workspace(
     """
 
     from opik_mcp.credential_identity import ResolvedIdentity, lookup_identity
+    from opik_mcp.oauth_identity import Introspection
 
-    async def fake_resolve(_auth: str, _settings: object) -> ResolvedIdentity:
-        return ResolvedIdentity(
-            user_name="andrei",
-            workspace_name="andreicautisanu",
-            workspace_id="ws-uuid-e2e",
+    async def fake_resolve(_auth: str, _settings: object) -> Introspection:
+        return Introspection(
+            status="valid",
+            identity=ResolvedIdentity(
+                user_name="andrei",
+                workspace_name="andreicautisanu",
+                workspace_id="ws-uuid-e2e",
+            ),
         )
 
-    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", fake_resolve)
+    monkeypatch.setattr("opik_mcp.server.introspect_oauth_token", fake_resolve)
     r = await http_client.post(
         "/mcp",
         json=INITIALIZE,

--- a/tests/test_oauth_identity.py
+++ b/tests/test_oauth_identity.py
@@ -1,9 +1,10 @@
-"""Unit tests for OAuth token → workspace-name introspection.
+"""Unit tests for OAuth token introspection.
 
-``resolve_oauth_identity`` POSTs the inbound bearer to opik-backend's
-``/opik/auth-oauth`` introspection endpoint and pulls ``workspace_name`` out of
-the ``ValidatedToken`` response. It is best-effort: any failure resolves to
-``None`` so the ``initialize`` handshake never breaks.
+``introspect_oauth_token`` POSTs the inbound bearer to opik-backend's
+``/opik/auth-oauth`` endpoint and reads the ``ValidatedToken`` response into a
+three-way outcome: ``valid`` (with whatever identity the body names),
+``invalid`` (a definite 401), or ``unknown`` (no answer could be had). Only the
+second may ever be turned into a rejection; the third fails open.
 """
 
 import httpx
@@ -11,7 +12,7 @@ import pytest
 import respx
 
 from opik_mcp.config import Settings
-from opik_mcp.oauth_identity import resolve_oauth_identity
+from opik_mcp.oauth_identity import introspect_oauth_token
 
 AUTH = "Bearer opik_mcp_at_abc123"
 
@@ -41,7 +42,9 @@ async def test_resolves_workspace_name_on_200() -> None:
             },
         )
     )
-    identity = await resolve_oauth_identity(AUTH, _settings())
+    result = await introspect_oauth_token(AUTH, _settings())
+    assert result.status == "valid"
+    identity = result.identity
     assert identity is not None
     assert identity.workspace_name == "andreicautisanu"
     # The whole ValidatedToken is retained now — BI needs the user and the
@@ -55,9 +58,9 @@ async def test_resolves_workspace_name_on_200() -> None:
 
 @pytest.mark.anyio
 @respx.mock
-async def test_returns_none_on_401() -> None:
+async def test_401_is_a_definite_invalid() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(return_value=httpx.Response(401))
-    assert await resolve_oauth_identity(AUTH, _settings()) is None
+    assert (await introspect_oauth_token(AUTH, _settings())).status == "invalid"
 
 
 @pytest.mark.anyio
@@ -70,7 +73,7 @@ async def test_returns_none_on_invalid_url() -> None:
     request-build time (before any transport / respx mock is consulted).
     """
     s = _settings(opik_url="http://exa mple.com/api")
-    assert await resolve_oauth_identity(AUTH, s) is None
+    assert (await introspect_oauth_token(AUTH, s)).status == "unknown"
 
 
 @pytest.mark.anyio
@@ -79,7 +82,7 @@ async def test_returns_none_on_network_error() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(
         side_effect=httpx.ConnectError("backend unreachable")
     )
-    assert await resolve_oauth_identity(AUTH, _settings()) is None
+    assert (await introspect_oauth_token(AUTH, _settings())).status == "unknown"
 
 
 @pytest.mark.anyio
@@ -88,7 +91,18 @@ async def test_returns_none_on_non_json_body() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(
         return_value=httpx.Response(200, text="<html>not json</html>")
     )
-    assert await resolve_oauth_identity(AUTH, _settings()) is None
+    assert (await introspect_oauth_token(AUTH, _settings())).status == "unknown"
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_returns_unknown_on_non_object_body() -> None:
+    """A 200 carrying JSON that is not the ValidatedToken object is malformed:
+    no answer, so nothing may be cached on it."""
+    respx.post("https://opik.test/api/opik/auth-oauth").mock(
+        return_value=httpx.Response(200, json=["not", "an", "object"])
+    )
+    assert (await introspect_oauth_token(AUTH, _settings())).status == "unknown"
 
 
 @pytest.mark.anyio
@@ -104,7 +118,7 @@ async def test_keeps_a_user_only_response() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(
         return_value=httpx.Response(200, json={"user_name": "u"})
     )
-    identity = await resolve_oauth_identity(AUTH, _settings())
+    identity = (await introspect_oauth_token(AUTH, _settings())).identity
     assert identity is not None
     assert identity.user_name == "u"
     assert identity.workspace_name is None
@@ -112,11 +126,14 @@ async def test_keeps_a_user_only_response() -> None:
 
 @pytest.mark.anyio
 @respx.mock
-async def test_returns_none_when_the_body_identifies_nobody() -> None:
+async def test_a_body_identifying_nobody_is_valid_but_anonymous() -> None:
     respx.post("https://opik.test/api/opik/auth-oauth").mock(
         return_value=httpx.Response(200, json={"resource": "https://opik.test/api/v1/mcp"})
     )
-    assert await resolve_oauth_identity(AUTH, _settings()) is None
+    result = await introspect_oauth_token(AUTH, _settings())
+    assert result.status == "valid"
+    assert result.identity is None
+    assert result.resource == "https://opik.test/api/v1/mcp"
 
 
 @pytest.mark.anyio
@@ -128,7 +145,7 @@ async def test_blank_fields_collapse_to_none_not_empty_strings() -> None:
             200, json={"user_name": "u", "workspace_name": "   ", "workspace_id": ""}
         )
     )
-    identity = await resolve_oauth_identity(AUTH, _settings())
+    identity = (await introspect_oauth_token(AUTH, _settings())).identity
     assert identity is not None
     assert identity.workspace_name is None
     assert identity.workspace_id is None
@@ -140,9 +157,11 @@ async def test_derives_url_from_comet_url_override() -> None:
     route = respx.post("https://demo.comet.com/opik/api/opik/auth-oauth").mock(
         return_value=httpx.Response(200, json={"workspace_name": "demo-ws"})
     )
-    identity = await resolve_oauth_identity(
-        AUTH, Settings(opik_url=None, comet_url_override="https://demo.comet.com/")
-    )
+    identity = (
+        await introspect_oauth_token(
+            AUTH, Settings(opik_url=None, comet_url_override="https://demo.comet.com/")
+        )
+    ).identity
     assert identity is not None
     assert identity.workspace_name == "demo-ws"
     assert route.called
@@ -153,4 +172,4 @@ async def test_returns_none_when_base_unconfigured() -> None:
     # No OPIK_URL and an explicitly empty COMET_URL_OVERRIDE → no base → skip
     # without any network call.
     s = Settings(opik_url=None, comet_url_override="")
-    assert await resolve_oauth_identity(AUTH, s) is None
+    assert (await introspect_oauth_token(AUTH, s)).status == "unknown"

--- a/tests/test_oauth_identity.py
+++ b/tests/test_oauth_identity.py
@@ -173,3 +173,19 @@ async def test_returns_none_when_base_unconfigured() -> None:
     # without any network call.
     s = Settings(opik_url=None, comet_url_override="")
     assert (await introspect_oauth_token(AUTH, s)).status == "unknown"
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_fail_open_is_logged_at_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """An ``unknown`` outcome forwards the request unvalidated. That must be
+    visible at the default INFO level, or a resource server that cannot reach
+    its introspection endpoint looks identical to one whose tokens simply expire."""
+    respx.post("https://opik.test/api/opik/auth-oauth").mock(return_value=httpx.Response(503))
+    with caplog.at_level("WARNING", logger="opik_mcp"):
+        assert (await introspect_oauth_token(AUTH, _settings())).status == "unknown"
+    assert any(
+        "failed open" in rec.message and "503" in rec.message
+        for rec in caplog.records
+        if rec.levelname == "WARNING"
+    )

--- a/tests/test_oauth_passthrough_mode.py
+++ b/tests/test_oauth_passthrough_mode.py
@@ -3,6 +3,9 @@
 The middleware is exercised here by driving it directly with stub call_next
 + manually constructed Starlette ``Request`` objects, asserting the
 ContextVar capture/reset behavior the integration suite can't observe.
+Introspection is stubbed at ``server.introspect_oauth_token``; the HTTP-level
+contract (real resolver against a mocked backend) lives in
+``test_oauth_token_validation.py``.
 """
 
 from typing import Any
@@ -21,6 +24,7 @@ from opik_mcp.credential_identity import (
     lookup_session_digest,
     reset_identities_for_tests,
 )
+from opik_mcp.oauth_identity import Introspection
 from opik_mcp.server import BearerAuthMiddleware
 
 
@@ -112,14 +116,17 @@ async def test_resolves_workspace_on_session_creating_oauth_request(
     from opik_mcp.auth_context import resolved_workspace_name
     from opik_mcp.credential_identity import ResolvedIdentity
 
-    async def fake_resolve(_auth: str, _settings: object) -> ResolvedIdentity:
-        return ResolvedIdentity(
-            user_name="u",
-            workspace_name="andreicautisanu",
-            workspace_id="ws-id",
+    async def fake_resolve(_auth: str, _settings: object) -> Introspection:
+        return Introspection(
+            status="valid",
+            identity=ResolvedIdentity(
+                user_name="u",
+                workspace_name="andreicautisanu",
+                workspace_id="ws-id",
+            ),
         )
 
-    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", fake_resolve)
+    monkeypatch.setattr("opik_mcp.server.introspect_oauth_token", fake_resolve)
     mw = _build_middleware()
     request = _make_request({"authorization": f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}abc"})
 
@@ -136,20 +143,23 @@ async def test_resolves_workspace_on_session_creating_oauth_request(
 
 
 @pytest.mark.anyio
-async def test_skips_resolution_when_session_already_exists(
+async def test_validates_requests_that_already_carry_a_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Requests carrying an Mcp-Session-Id are tool calls, not the handshake —
-    they must not pay the introspection round-trip."""
+    """Every request with an OAuth bearer is validated, tool calls included
+    (OPIK-8252): the access token can expire mid-session, and the 401 that
+    tells the host to refresh has to come from the request that hit the dead
+    token. The identity is not re-published on those requests; the blob only
+    reads it on the handshake."""
     from opik_mcp.auth_context import resolved_workspace_name
 
     calls: list[str] = []
 
-    async def spy_resolve(auth: str, _settings: object) -> None:
+    async def spy_resolve(auth: str, _settings: object) -> Introspection:
         calls.append(auth)
-        return None
+        return Introspection(status="valid")
 
-    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", spy_resolve)
+    monkeypatch.setattr("opik_mcp.server.introspect_oauth_token", spy_resolve)
     mw = _build_middleware()
     request = _make_request(
         {
@@ -164,8 +174,9 @@ async def test_skips_resolution_when_session_already_exists(
         captured["resolved"] = resolved_workspace_name.get()
         return JSONResponse({"ok": True})
 
-    await mw.dispatch(request, call_next)
-    assert calls == []
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 200
+    assert calls == [f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}abc"]
     assert captured["resolved"] is None
 
 
@@ -175,11 +186,11 @@ async def test_skips_resolution_for_api_key_bearer(monkeypatch: pytest.MonkeyPat
     an API-key-shaped bearer keeps the legacy header/settings workspace path."""
     calls: list[str] = []
 
-    async def spy_resolve(auth: str, _settings: object) -> None:
+    async def spy_resolve(auth: str, _settings: object) -> Introspection:
         calls.append(auth)
-        return None
+        return Introspection(status="valid")
 
-    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", spy_resolve)
+    monkeypatch.setattr("opik_mcp.server.introspect_oauth_token", spy_resolve)
     mw = _build_middleware()
     request = _make_request({"authorization": "Bearer some-static-api-key"})
 
@@ -309,10 +320,10 @@ async def test_handshake_stores_the_resolved_identity_against_the_token(
         workspace_id="ws-uuid-1",
     )
 
-    async def _resolve(*_a: object, **_k: object) -> ResolvedIdentity:
-        return resolved
+    async def _resolve(*_a: object, **_k: object) -> Introspection:
+        return Introspection(status="valid", identity=resolved)
 
-    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", _resolve)
+    monkeypatch.setattr("opik_mcp.server.introspect_oauth_token", _resolve)
 
     mw = _build_middleware()
     request = _make_request({"authorization": f"Bearer {token}"})
@@ -331,18 +342,19 @@ async def test_handshake_stores_the_resolved_identity_against_the_token(
 
 
 @pytest.mark.anyio
-async def test_tool_call_requests_do_not_reintrospect(
+async def test_tool_call_on_a_dead_token_is_answered_401(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Only the session-creating request introspects. Every later request carries
-    an ``Mcp-Session-Id`` and must not pay a round-trip for an answer we hold."""
-    calls: list[str] = []
+    """A token that expires mid-session dies on a tool call, not on a handshake.
+    That request must get the ``invalid_token`` 401 (OPIK-8252) — it is the only
+    signal the host has to run the ``refresh_token`` grant — and nothing may be
+    forwarded on the dead credential."""
+    forwarded: list[str] = []
 
-    async def _resolve(*_a: object, **_k: object) -> None:
-        calls.append("resolved")
-        return None
+    async def _resolve(*_a: object, **_k: object) -> Introspection:
+        return Introspection(status="invalid")
 
-    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", _resolve)
+    monkeypatch.setattr("opik_mcp.server.introspect_oauth_token", _resolve)
 
     mw = _build_middleware()
     request = _make_request(
@@ -353,23 +365,29 @@ async def test_tool_call_requests_do_not_reintrospect(
     )
 
     async def call_next(_r: Request) -> Response:
+        forwarded.append("called")
         return JSONResponse({"ok": True})
 
-    await mw.dispatch(request, call_next)
-    assert calls == []
+    resp = await mw.dispatch(request, call_next)
+    assert resp.status_code == 401
+    assert forwarded == []
+    assert 'error="invalid_token"' in resp.headers["WWW-Authenticate"]
+    # Nothing leaks past a rejected request.
+    assert inbound_authorization.get() is None
 
 
 @pytest.mark.anyio
 async def test_failed_introspection_leaves_the_handshake_working(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Telemetry and display niceties must never cost a session."""
+    """A backend hiccup (network, 5xx: ``unknown``) must never cost a session —
+    only a definite ``invalid`` answer is a rejection."""
     from opik_mcp.credential_identity import lookup_identity
 
-    async def _resolve(*_a: object, **_k: object) -> None:
-        return None
+    async def _resolve(*_a: object, **_k: object) -> Introspection:
+        return Introspection(status="unknown")
 
-    monkeypatch.setattr("opik_mcp.server.resolve_oauth_identity", _resolve)
+    monkeypatch.setattr("opik_mcp.server.introspect_oauth_token", _resolve)
 
     token = f"{OAUTH_ACCESS_TOKEN_PREFIX}unresolvable"
     mw = _build_middleware()

--- a/tests/test_oauth_token_rotation.py
+++ b/tests/test_oauth_token_rotation.py
@@ -1,0 +1,183 @@
+"""A refreshed OAuth bearer must be the one forwarded to opik-backend (OPIK-8252).
+
+After ``BearerAuthMiddleware`` answers ``invalid_token`` 401, the MCP host runs
+the ``refresh_token`` grant and re-sends the SAME session's next request with a
+NEW bearer. Tool handlers run in the MCP session task, which is forked from the
+``initialize`` request — so any ContextVar they read holds the handshake-time
+value unless the request-time value is threaded through some other way. If the
+outbound client forwards the handshake-time bearer, every call after a refresh
+meets the backend's 401 and the connector never recovers, which is exactly the
+symptom the 401 was introduced to fix.
+
+Seam: the real ASGI app over ``http_client``; opik-backend mocked with respx at
+introspection (always valid) and at the data endpoint, which records which
+bearer actually arrived.
+"""
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+import respx
+
+from opik_mcp import oauth_identity
+from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
+from opik_mcp.config import get_settings
+from opik_mcp.opik_client import opik_rest_base
+
+PROJECT_ID = "0f1c1a2b-3d4e-4f60-8a9b-0c1d2e3f4a5b"
+HANDSHAKE_TOKEN = f"{OAUTH_ACCESS_TOKEN_PREFIX}minted-at-connect"
+REFRESHED_TOKEN = f"{OAUTH_ACCESS_TOKEN_PREFIX}minted-by-refresh"
+
+INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "pytest", "version": "0"},
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _live_introspection(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(
+        "opik_mcp.server.introspect_oauth_token", oauth_identity.introspect_oauth_token
+    )
+    yield
+
+
+def _headers(token: str, session_id: str | None = None) -> dict[str, str]:
+    h = {"Authorization": f"Bearer {token}", "Accept": "application/json, text/event-stream"}
+    if session_id:
+        h["Mcp-Session-Id"] = session_id
+    return h
+
+
+@pytest.mark.anyio
+async def test_data_call_forwards_the_bearer_of_the_current_request(
+    http_client: httpx.AsyncClient,
+) -> None:
+    base = opik_rest_base(get_settings())
+    seen: list[str] = []
+
+    def record(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("Authorization", ""))
+        return httpx.Response(200, json={"id": PROJECT_ID, "name": "p"})
+
+    with respx.mock(assert_all_called=False) as mock:
+        mock.post(f"{base}/opik/auth-oauth").mock(
+            return_value=httpx.Response(200, json={"workspace_name": "ws", "user_name": "u"})
+        )
+        mock.get(f"{base}/v1/private/projects/{PROJECT_ID}").mock(side_effect=record)
+
+        init = await http_client.post("/mcp", json=INITIALIZE, headers=_headers(HANDSHAKE_TOKEN))
+        assert init.status_code == 200, init.text
+        session = init.headers["mcp-session-id"]
+        await http_client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            headers=_headers(HANDSHAKE_TOKEN, session),
+        )
+        # The host refreshed: same session, new bearer.
+        r = await http_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "read",
+                    "arguments": {"entity_type": "project", "id": PROJECT_ID},
+                },
+            },
+            headers=_headers(REFRESHED_TOKEN, session),
+        )
+        assert r.status_code == 200, r.text
+
+    assert seen, "the data endpoint was never called"
+    assert seen[-1] == f"Bearer {REFRESHED_TOKEN}", (
+        f"outbound call carried {seen[-1]!r}: the handshake-time bearer, not the refreshed one"
+    )
+
+
+# --- the rebinding hook itself ------------------------------------------------ #
+
+
+@pytest.mark.anyio
+async def test_rebinding_is_a_no_op_without_an_http_request() -> None:
+    """stdio: there is no request behind a tool call, so the vars the caller
+    set (or left unset) must be exactly what the tool sees."""
+    from types import SimpleNamespace
+
+    from mcp.types import CallToolRequest
+
+    from opik_mcp.auth_context import inbound_authorization, inbound_workspace
+    from opik_mcp.server import install_request_auth_rebinding
+
+    seen: list[tuple[str | None, str | None]] = []
+
+    async def original(_req: object) -> str:
+        seen.append((inbound_authorization.get(), inbound_workspace.get()))
+        return "ok"
+
+    fake = SimpleNamespace(
+        _mcp_server=SimpleNamespace(request_handlers={CallToolRequest: original})
+    )
+    install_request_auth_rebinding(fake)  # type: ignore[arg-type]
+    wrapped = fake._mcp_server.request_handlers[CallToolRequest]
+    assert wrapped is not original
+
+    assert await wrapped(object()) == "ok"
+    assert seen == [(None, None)]
+
+
+@pytest.mark.anyio
+async def test_rebinding_uses_the_current_request_and_resets_after() -> None:
+    from types import SimpleNamespace
+
+    from mcp.server.lowlevel.server import request_ctx
+    from mcp.types import CallToolRequest
+    from starlette.requests import Request
+
+    from opik_mcp.auth_context import inbound_authorization, inbound_workspace
+    from opik_mcp.server import install_request_auth_rebinding
+
+    seen: list[tuple[str | None, str | None]] = []
+
+    async def original(_req: object) -> str:
+        seen.append((inbound_authorization.get(), inbound_workspace.get()))
+        return "ok"
+
+    fake = SimpleNamespace(
+        _mcp_server=SimpleNamespace(request_handlers={CallToolRequest: original})
+    )
+    install_request_auth_rebinding(fake)  # type: ignore[arg-type]
+    wrapped = fake._mcp_server.request_handlers[CallToolRequest]
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [
+            (b"authorization", f"Bearer {REFRESHED_TOKEN}".encode()),
+            (b"comet-workspace", b"ws-from-request"),
+        ],
+    }
+    # What the session task inherited from the handshake.
+    outer_auth = inbound_authorization.set(f"Bearer {HANDSHAKE_TOKEN}")
+    outer_ws = inbound_workspace.set(None)
+    ctx_token = request_ctx.set(SimpleNamespace(request=Request(scope)))  # type: ignore[arg-type]
+    try:
+        assert await wrapped(object()) == "ok"
+        # Reset: the session task's view is back to the handshake values.
+        assert inbound_authorization.get() == f"Bearer {HANDSHAKE_TOKEN}"
+        assert inbound_workspace.get() is None
+    finally:
+        request_ctx.reset(ctx_token)
+        inbound_workspace.reset(outer_ws)
+        inbound_authorization.reset(outer_auth)
+
+    assert seen == [(f"Bearer {REFRESHED_TOKEN}", "ws-from-request")]

--- a/tests/test_oauth_token_validation.py
+++ b/tests/test_oauth_token_validation.py
@@ -266,3 +266,131 @@ async def test_upstream_403_keeps_the_permission_wording(http_client: httpx.Asyn
     text = _error_text(result)
     assert "permission denied" in text.lower()
     assert "expired" not in text.lower()
+
+
+# --- validation cache ----------------------------------------------------------- #
+
+
+class _Clock:
+    """Monotonic clock the validation cache reads; tests advance it by hand."""
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> _Clock:
+    c = _Clock()
+    monkeypatch.setattr("opik_mcp.credential_identity._now", c)
+    return c
+
+
+def _session_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}{token}",
+        "Accept": "application/json, text/event-stream",
+        "Mcp-Session-Id": "session-held-by-the-host",
+    }
+
+
+@pytest.mark.anyio
+async def test_valid_token_is_cached_for_the_ttl(
+    http_client: httpx.AsyncClient, clock: _Clock
+) -> None:
+    """Validating on every request must not double the load on opik-backend:
+    inside the TTL the answer is remembered, after it the backend is asked again."""
+    ttl = get_settings().opik_mcp_oauth_validation_cache_ttl_s
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post(_introspection_url()).mock(return_value=_valid_introspection())
+        headers = _session_headers("cached")
+
+        await http_client.post("/mcp", json=INITIALIZE, headers=headers)
+        clock.advance(ttl / 2)
+        await http_client.post("/mcp", json=INITIALIZE, headers=headers)
+        assert route.call_count == 1
+
+        clock.advance(ttl)
+        await http_client.post("/mcp", json=INITIALIZE, headers=headers)
+        assert route.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_upstream_401_evicts_the_cached_validation(
+    http_client: httpx.AsyncClient, clock: _Clock
+) -> None:
+    """A token that dies inside the cache window reaches opik-backend once. That
+    401 must drop the cache entry so the very next MCP request re-validates and
+    gets the ``invalid_token`` 401 — not after the TTL, now."""
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post(_introspection_url()).mock(return_value=_valid_introspection())
+        mock.get(_project_url()).mock(return_value=httpx.Response(401))
+        await _read_project(http_client, f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}dies-in-window")
+        assert route.call_count == 1
+
+        clock.advance(1)
+        await http_client.post("/mcp", json=INITIALIZE, headers=_session_headers("dies-in-window"))
+        assert route.call_count == 2
+
+
+def _introspection_with_expiry(seconds_from_now: float) -> httpx.Response:
+    from datetime import UTC, datetime, timedelta
+
+    expires_at = (datetime.now(UTC) + timedelta(seconds=seconds_from_now)).isoformat()
+    body = _valid_introspection().json()
+    return httpx.Response(200, json={**body, "expires_at": expires_at})
+
+
+@pytest.mark.anyio
+async def test_cache_is_capped_by_the_backend_expires_at(
+    http_client: httpx.AsyncClient, clock: _Clock
+) -> None:
+    """Once opik-backend reports ``expires_at`` the entry is trusted until that
+    instant minus a skew margin, not the whole TTL; and a request landing after
+    the expiry is answered 401 from the cache without asking the backend."""
+    from opik_mcp.credential_identity import EXPIRY_SKEW_MARGIN_S
+
+    ttl = get_settings().opik_mcp_oauth_validation_cache_ttl_s
+    expires_in = ttl - 5
+    assert expires_in - EXPIRY_SKEW_MARGIN_S > 0
+    headers = _session_headers("short-lived")
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post(_introspection_url()).mock(
+            return_value=_introspection_with_expiry(expires_in)
+        )
+        await http_client.post("/mcp", json=INITIALIZE, headers=headers)
+        assert route.call_count == 1
+
+        # Past (expires_at - margin) but inside the TTL: ask again. (The SDK
+        # answers 404 for a session id it never minted — that is after the
+        # middleware, which is all this test observes.)
+        clock.advance(expires_in - EXPIRY_SKEW_MARGIN_S + 1)
+        r = await http_client.post("/mcp", json=INITIALIZE, headers=headers)
+        assert r.status_code != 401
+        assert route.call_count == 2
+
+    # Fresh entry, then time runs out entirely: 401 straight from the cache.
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post(_introspection_url()).mock(
+            return_value=_introspection_with_expiry(expires_in)
+        )
+        await http_client.post("/mcp", json=INITIALIZE, headers=_session_headers("doomed"))
+        assert route.call_count == 1
+        clock.advance(expires_in + 1)
+        r = await http_client.post("/mcp", json=INITIALIZE, headers=_session_headers("doomed"))
+        assert r.status_code == 401
+        assert 'error="invalid_token"' in r.headers["WWW-Authenticate"]
+        assert route.call_count == 1
+
+
+def test_validation_cache_ttl_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    from opik_mcp.config import Settings
+
+    assert Settings().opik_mcp_oauth_validation_cache_ttl_s == 30.0
+    monkeypatch.setenv("OPIK_MCP_OAUTH_VALIDATION_CACHE_TTL_S", "5")
+    assert Settings().opik_mcp_oauth_validation_cache_ttl_s == 5.0

--- a/tests/test_oauth_token_validation.py
+++ b/tests/test_oauth_token_validation.py
@@ -76,8 +76,13 @@ async def test_expired_oauth_token_gets_401_with_invalid_token_challenge(
 @pytest.mark.anyio
 @pytest.mark.parametrize(
     "outcome",
-    [httpx.Response(503), httpx.ConnectError("backend down")],
-    ids=["5xx", "connection-error"],
+    [
+        httpx.Response(503),
+        httpx.ConnectError("backend down"),
+        httpx.Response(200, text="<html>not json</html>"),
+        httpx.Response(200, json=["not", "an", "object"]),
+    ],
+    ids=["5xx", "connection-error", "non-json-200", "non-object-200"],
 )
 async def test_introspection_failure_fails_open(
     http_client: httpx.AsyncClient, outcome: httpx.Response | Exception

--- a/tests/test_oauth_token_validation.py
+++ b/tests/test_oauth_token_validation.py
@@ -1,0 +1,148 @@
+"""OAuth access-token validation at the HTTP boundary (OPIK-8252).
+
+opik-mcp is the OAuth resource server for the hosted connector. Per the MCP
+authorization spec (2026-07-28, "Token Handling") it MUST validate every
+access token and MUST answer HTTP 401 for an invalid or expired one — that 401
+is the only signal an MCP host has to run the ``refresh_token`` grant. Before
+this suite existed a dead token surfaced as a tool error inside HTTP 200, the
+host never refreshed, and users lost the connector an hour after connecting.
+
+Seam: the real ASGI app over ``http_client``; opik-backend mocked with respx at
+the introspection endpoint (``POST {rest_base}/opik/auth-oauth``). Tests assert
+only what a host observes — status, ``WWW-Authenticate``, body, and how many
+times the backend was asked.
+"""
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+import respx
+
+from opik_mcp import oauth_identity
+from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX
+from opik_mcp.config import get_settings
+from opik_mcp.opik_client import opik_rest_base
+
+INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "pytest", "version": "0"},
+    },
+}
+
+OAUTH_HEADERS = {
+    "Authorization": f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}expired-token",
+    "Accept": "application/json, text/event-stream",
+}
+
+
+def _introspection_url() -> str:
+    base = opik_rest_base(get_settings())
+    assert base is not None
+    return f"{base}/opik/auth-oauth"
+
+
+@pytest.fixture(autouse=True)
+def _live_introspection(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Undo conftest's no-op stub so the real introspection runs against respx."""
+    monkeypatch.setattr(
+        "opik_mcp.server.introspect_oauth_token", oauth_identity.introspect_oauth_token
+    )
+    yield
+
+
+@pytest.mark.anyio
+async def test_expired_oauth_token_gets_401_with_invalid_token_challenge(
+    http_client: httpx.AsyncClient,
+) -> None:
+    """opik-backend says the token is dead → the host gets a real 401 it can act on."""
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post(_introspection_url()).mock(return_value=httpx.Response(401))
+        r = await http_client.post("/mcp", json=INITIALIZE, headers=OAUTH_HEADERS)
+
+    assert r.status_code == 401
+    challenge = r.headers["WWW-Authenticate"]
+    assert challenge.startswith("Bearer ")
+    assert 'error="invalid_token"' in challenge
+    assert "resource_metadata=" in challenge
+    assert r.json()["error"] == "invalid_token"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "outcome",
+    [httpx.Response(503), httpx.ConnectError("backend down")],
+    ids=["5xx", "connection-error"],
+)
+async def test_introspection_failure_fails_open(
+    http_client: httpx.AsyncClient, outcome: httpx.Response | Exception
+) -> None:
+    """A backend hiccup must not log out every connected host: only a definite
+    401 from introspection is a rejection; anything else forwards as before."""
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post(_introspection_url())
+        if isinstance(outcome, Exception):
+            route.mock(side_effect=outcome)
+        else:
+            route.mock(return_value=outcome)
+        r = await http_client.post("/mcp", json=INITIALIZE, headers=OAUTH_HEADERS)
+
+    assert r.status_code == 200
+    assert "opik-mcp" in r.text
+
+
+@pytest.mark.anyio
+async def test_api_key_bearer_is_never_introspected(http_client: httpx.AsyncClient) -> None:
+    """Validation is for OAuth tokens only. API-key bearers keep the legacy
+    passthrough: opik-backend's AuthFilter is their single point of enforcement."""
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.post(_introspection_url()).mock(return_value=httpx.Response(401))
+        r = await http_client.post(
+            "/mcp",
+            json=INITIALIZE,
+            headers={
+                "Authorization": "Bearer some-static-api-key",
+                "Accept": "application/json, text/event-stream",
+            },
+        )
+
+    assert r.status_code == 200
+    assert not route.called
+
+
+@pytest.mark.anyio
+async def test_handshake_validates_once_and_names_the_workspace(
+    http_client: httpx.AsyncClient,
+) -> None:
+    """The session-creating request pays exactly one introspection round-trip,
+    which both validates the token and tells the instructions blob which
+    workspace the agent is operating against."""
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post(_introspection_url()).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "user_name": "andrei",
+                    "workspace_id": "ws-uuid",
+                    "workspace_name": "andreicautisanu",
+                    "resource": "https://www.comet.com/opik/api/v1/mcp",
+                },
+            )
+        )
+        r = await http_client.post(
+            "/mcp",
+            json=INITIALIZE,
+            headers={
+                "Authorization": f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}live-token",
+                "Accept": "application/json, text/event-stream",
+            },
+        )
+
+    assert r.status_code == 200
+    assert route.call_count == 1
+    assert "andreicautisanu" in r.text

--- a/tests/test_oauth_token_validation.py
+++ b/tests/test_oauth_token_validation.py
@@ -146,3 +146,123 @@ async def test_handshake_validates_once_and_names_the_workspace(
     assert r.status_code == 200
     assert route.call_count == 1
     assert "andreicautisanu" in r.text
+
+
+# --- tool errors on an upstream 401 ------------------------------------------ #
+
+PROJECT_ID = "0f1c1a2b-3d4e-4f60-8a9b-0c1d2e3f4a5b"
+
+
+def _valid_introspection() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "user_name": "andrei",
+            "workspace_id": "ws-uuid",
+            "workspace_name": "andreicautisanu",
+            "resource": "https://www.comet.com/opik/api/v1/mcp",
+        },
+    )
+
+
+def _project_url() -> str:
+    base = opik_rest_base(get_settings())
+    return f"{base}/v1/private/projects/{PROJECT_ID}"
+
+
+def _jsonrpc_result(r: httpx.Response) -> dict[str, object]:
+    """The JSON-RPC result out of either a JSON or an SSE-framed response."""
+    if r.headers.get("content-type", "").startswith("text/event-stream"):
+        payloads = [
+            line[len("data:") :].strip() for line in r.text.splitlines() if line.startswith("data:")
+        ]
+        assert payloads, r.text
+        body = httpx.Response(200, content=payloads[-1]).json()
+    else:
+        body = r.json()
+    assert "result" in body, body
+    result: dict[str, object] = body["result"]
+    return result
+
+
+async def _read_project(http_client: httpx.AsyncClient, authorization: str) -> dict[str, object]:
+    """Run ``read(project, PROJECT_ID)`` over a fresh MCP session as the host would."""
+    headers = {"Authorization": authorization, "Accept": "application/json, text/event-stream"}
+    init = await http_client.post("/mcp", json=INITIALIZE, headers=headers)
+    assert init.status_code == 200, init.text
+    session = {**headers, "Mcp-Session-Id": init.headers["mcp-session-id"]}
+    await http_client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers=session,
+    )
+    r = await http_client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "read",
+                "arguments": {"entity_type": "project", "id": PROJECT_ID},
+            },
+        },
+        headers=session,
+    )
+    assert r.status_code == 200, r.text
+    return _jsonrpc_result(r)
+
+
+def _error_text(result: dict[str, object]) -> str:
+    assert result.get("isError") is True, result
+    content = result["content"]
+    assert isinstance(content, list)
+    return " ".join(str(part.get("text", "")) for part in content if isinstance(part, dict))
+
+
+@pytest.mark.anyio
+async def test_upstream_401_in_oauth_mode_says_token_expired_retry(
+    http_client: httpx.AsyncClient,
+) -> None:
+    """A token that dies inside the validation window still reaches opik-backend
+    once. The tool error must tell the model the *token* expired and to retry —
+    not to check API keys, and not to tell the user to reconnect — because the
+    retry is what runs into the 401 that triggers the host's refresh."""
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post(_introspection_url()).mock(return_value=_valid_introspection())
+        mock.get(_project_url()).mock(return_value=httpx.Response(401))
+        result = await _read_project(
+            http_client, f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}dies-mid-window"
+        )
+
+    text = _error_text(result)
+    assert "access token" in text.lower()
+    assert "expired" in text.lower()
+    assert "retry" in text.lower()
+    assert "OPIK_API_KEY" not in text
+    assert "permission denied" not in text.lower()
+
+
+@pytest.mark.anyio
+async def test_upstream_401_in_api_key_mode_keeps_the_api_key_wording(
+    http_client: httpx.AsyncClient,
+) -> None:
+    with respx.mock(assert_all_called=True) as mock:
+        mock.get(_project_url()).mock(return_value=httpx.Response(401))
+        result = await _read_project(http_client, "Bearer some-static-api-key")
+
+    text = _error_text(result)
+    assert "OPIK_API_KEY" in text
+
+
+@pytest.mark.anyio
+async def test_upstream_403_keeps_the_permission_wording(http_client: httpx.AsyncClient) -> None:
+    """403 really is about workspace access; only the 401 wording changed."""
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post(_introspection_url()).mock(return_value=_valid_introspection())
+        mock.get(_project_url()).mock(return_value=httpx.Response(403))
+        result = await _read_project(http_client, f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}no-access")
+
+    text = _error_text(result)
+    assert "permission denied" in text.lower()
+    assert "expired" not in text.lower()

--- a/tests/test_writes/test_backend_error_oauth_hint.py
+++ b/tests/test_writes/test_backend_error_oauth_hint.py
@@ -1,0 +1,45 @@
+"""The write envelope's 401 carries the same OAuth-expiry hint as the read path.
+
+``BackendError`` is what every write tool returns for a rejected backend call;
+its message is the only text the model sees. Under an OAuth bearer a 401 means
+the access token died, and the hint has to say so (OPIK-8252) — one source of
+truth with the read/list client so the two paths cannot drift.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+from opik_mcp.auth_context import (
+    OAUTH_ACCESS_TOKEN_PREFIX,
+    OAUTH_TOKEN_EXPIRED_HINT,
+    inbound_authorization,
+)
+from opik_mcp.writes.errors import BackendError
+
+
+@pytest.fixture
+def _inbound(request: pytest.FixtureRequest) -> Iterator[None]:
+    token = inbound_authorization.set(request.param)
+    try:
+        yield
+    finally:
+        inbound_authorization.reset(token)
+
+
+@pytest.mark.parametrize("_inbound", [f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}dead"], indirect=True)
+def test_401_under_oauth_bearer_says_token_expired(_inbound: None) -> None:
+    err = BackendError.build("score.create", 401, {}, method="PUT", path="/v1/private/x")
+    assert OAUTH_TOKEN_EXPIRED_HINT in err.message
+
+
+@pytest.mark.parametrize("_inbound", ["Bearer some-static-api-key"], indirect=True)
+def test_401_under_api_key_keeps_the_bare_message(_inbound: None) -> None:
+    err = BackendError.build("score.create", 401, {}, method="PUT", path="/v1/private/x")
+    assert err.message == "Backend rejected PUT /v1/private/x with status 401."
+
+
+@pytest.mark.parametrize("_inbound", [f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}live"], indirect=True)
+def test_non_401_never_carries_the_hint(_inbound: None) -> None:
+    err = BackendError.build("score.create", 403, {}, method="PUT", path="/v1/private/x")
+    assert OAUTH_TOKEN_EXPIRED_HINT not in err.message


### PR DESCRIPTION
## Details

Hosted-connector users lost the Opik MCP connector about an hour after connecting: the OAuth access token expired, opik-backend answered 401 on the data call, and opik-mcp wrapped that into a tool error inside an HTTP 200. The MCP host never saw a 401 on the MCP request, so it never ran the `refresh_token` grant it holds a valid refresh token for, and Claude kept showing a "connected" connector that could not make a single call. Reconnecting in account settings did not help an open conversation.

opik-mcp is the OAuth resource server here, and the MCP authorization spec (2026-07-28, Token Handling) is explicit: validate the access token on every request, answer HTTP 401 for an invalid or expired one.

- `BearerAuthMiddleware` validates every `opik_mcp_at_…` bearer on the MCP path against opik-backend's `POST /opik/auth-oauth` before forwarding. A definite 401 from introspection becomes `401` + `WWW-Authenticate: Bearer realm="opik-mcp", error="invalid_token", error_description="…", resource_metadata="…"` (RFC 6750 §3.1, the code hosts key their refresh on). Missing/malformed `Authorization` keeps its current shape.
- Introspection is a three-way outcome (`valid` / `invalid` / `unknown`). Network error, timeout, 5xx or a malformed body are `unknown` and fail open, so a backend hiccup degrades to "forward as before", never to a mass logout. Each fail-open is logged once at WARNING with the cause, so an unreachable introspection endpoint is distinguishable from ordinary expiry at the default log level.
- Positive answers are cached per token digest for `OPIK_MCP_OAUTH_VALIDATION_CACHE_TTL_S` (default 30 s), capped at the backend's `expires_at` minus a 10 s skew margin when reported. Negative answers are never cached. A 401 from a data call evicts the entry so the next MCP request re-validates immediately.
- **The bearer of the current request is forwarded on `tools/call`, not the handshake's.** Tools run in the MCP session task, which the SDK forks from `initialize`, so the inbound-auth ContextVars inside a tool held handshake-time values. Harmless while a token never changed mid-session; fatal once the 401 above makes hosts refresh: the middleware validated the new token and the outbound client forwarded the old one, so every call after a refresh met the backend's 401. `install_request_auth_rebinding` re-binds the vars from the SDK's per-request context on each `tools/call`; stdio is untouched. Found on staging in the end-to-end test, reproduced by `tests/test_oauth_token_rotation.py`.
- The session-creating request still makes exactly one call, which now both validates and feeds the instructions blob and analytics.
- Under an OAuth bearer, a 401 tool error now says "The Opik access token is expired or revoked. Retry this call — the MCP client refreshes the token on the next request." instead of "Check OPIK_API_KEY and OPIK_WORKSPACE" (read/list client and write envelope, one source of truth). The read tool reserves "Permission denied" for 403; a 401 for API-key callers now reads "Authentication failed … Check OPIK_API_KEY …", a wording change for them too.
- API-key bearers are not validated locally, exactly as before.
- Token `resource` vs `OPIK_MCP_RESOURCE_URI` mismatch is logged at warning level only. Strict RFC 8707 audience rejection is a follow-up once production confirms the two agree.

Companion PR comet-ml/opik#8153 adds `expires_at` to the introspection response (additive); this PR reads it when present and falls back to the TTL otherwise. Either can deploy first.

Follow-up, not in this PR: `inbound_mcp_session_id` is frozen in the session task the same way, so after a refresh the analytics session pairing keyed on the new header misses. Telemetry only.

## Change checklist
- [x] User facing
- [x] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-8252

## Testing

- `uv run pytest -q` → 1222 passed. `uv run ruff check src tests`, `uv run ruff format --check .`, `uv run mypy` clean.
- `tests/test_oauth_token_validation.py` drives the real ASGI app over HTTP with opik-backend mocked by respx at the introspection and data endpoints: expired token → 401 with the `invalid_token` challenge; 5xx / connection error / non-JSON 200 / non-object 200 fail open; API-key bearer never introspected; handshake makes one call and names the workspace; cache honours TTL, is evicted on upstream 401, is capped by `expires_at` and answers 401 from cache after expiry; OAuth-mode vs API-key 401 wording; 403 keeps the permission wording.
- `tests/test_oauth_token_rotation.py`: `initialize` with token A, `tools/call` with token B → the data call carries B. Failed before the rebinding commit with A on the wire.
- Manual, staging (`staging.dev.comet.com`, backend with `expires_at`): live OAuth handshake names the workspace, `list(project)` works, dead token → `401 invalid_token`, no `Authorization` → challenge without `error=`. After the access token expired, the build without the rebinding fix reproduced the user-reported failure on retry; the fixed image (`sha-13f3bd4c902b`) is the one to deploy for the post-expiry check.
- Field check after deploy: `grant_type=refresh_token` in opik-backend logs after the first hour of a Claude.ai session, and no tool error on the following call.

## Documentation

README transport section now states the two-bearer contract and documents `OPIK_MCP_OAUTH_VALIDATION_CACHE_TTL_S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)