### PR TITLE
[OPIK-8282] docs: lead with `uvx opik mcp configure`, keep manual install as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Opik MCP Server
 
 **The official Model Context Protocol (MCP) server for [Opik](https://github.com/comet-ml/opik), the open-source LLM observability and evaluation platform, built by [Comet](https://www.comet.com).**
-Plug your AI host (Claude Code, Cursor, VS Code Copilot, MCP Inspector) directly
-into your Opik workspace: read traces, log scores, and save prompt versions, all
-from the chat.
+Plug your AI host (Claude Code, Cursor, VS Code Copilot, Codex, opencode, or any
+MCP client) directly into your Opik workspace: read traces, log scores, and save
+prompt versions, all from the chat.
 
 Built for LLM engineers who already run Opik and want to drive it from the same
 AI assistant they code with.
@@ -22,7 +22,34 @@ Claude: → write(score.create) → done
 
 ---
 
-## Install
+## Quick start
+
+One command registers the server with the AI clients on your machine, installs
+the Opik skill pack, and verifies the connection. It needs [`uv`](https://docs.astral.sh/uv/)
+and no Opik SDK:
+
+```bash
+uvx opik mcp configure
+```
+
+It detects Claude Code, Cursor, VS Code Copilot, Codex and opencode, and uses the
+hosted server on Opik Cloud (browser sign-in, no API key stored) or this local
+server elsewhere. Any other MCP client can take the hosted URL directly:
+
+```bash
+npx add-mcp https://www.comet.com/opik/api/v1/mcp --name opik-mcp
+```
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=opik-mcp&config=eyJ1cmwiOiJodHRwczovL3d3dy5jb21ldC5jb20vb3Bpay9hcGkvdjEvbWNwIn0%3D)
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=opik-mcp&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fwww.comet.com%2Fopik%2Fapi%2Fv1%2Fmcp%22%7D)
+
+Setup guide, troubleshooting and FAQ: [comet.com/docs/opik/mcp-server](https://www.comet.com/docs/opik/mcp-server).
+The rest of this README covers the local server, which the command above sets up
+for self-hosted and open-source Opik, and which you can also configure by hand.
+
+---
+
+## Manual install
 
 `opik-mcp` is a Python package (requires Python 3.13+). The recommended way to
 run it is `uvx`, which fetches and runs the latest published version on demand —
@@ -360,6 +387,11 @@ after editing.
 **Cursor call times out at 60s** — Cursor's known bug, not `opik-mcp`. Either
 narrow the call (smaller `size`, a tighter window), or run the same operation
 on Claude Code which has no hard cap.
+
+**Server not showing, sign-in not opening, wrong workspace, `uvx` not found.**
+These are covered in the [troubleshooting section of the docs](https://www.comet.com/docs/opik/mcp-server#troubleshooting).
+`opik mcp status` (from the same `uvx opik` CLI) lists every client that has the
+server configured and whether its config has drifted.
 
 ---
 

--- a/scripts/skills_pack_readme.md.tmpl
+++ b/scripts/skills_pack_readme.md.tmpl
@@ -39,6 +39,14 @@ npx skills add comet-ml/opik-skills -g --all
 
 This works across ~40 coding agents, including Claude Code, Cursor, Codex, and GitHub Copilot.
 
+Using the [Opik MCP server](https://www.comet.com/docs/opik/mcp-server) as well? One command installs
+this skill pack together with the server for Claude Code, Cursor, VS Code Copilot, Codex and opencode,
+and needs no Opik SDK:
+
+```bash
+uvx opik mcp configure
+```
+
 ## Skills in this pack
 
 {{SKILLS_TABLE}}


### PR DESCRIPTION
## Details

Lead the README with the one-command path, `uvx opik mcp configure`, which registers this server (hosted or local) with the AI clients on the machine, installs the skill pack and verifies the result without the Opik SDK. The existing per-client manual configuration stays as "Manual install".

- New Quick start: the command, `npx add-mcp <hosted URL>` as the fallback for clients the CLI does not cover, Cursor and VS Code install badges, pointer to the docs troubleshooting.
- Intro names Codex and opencode alongside Claude Code, Cursor and VS Code.
- Troubleshooting: one entry pointing at the docs for the common failures, and `opik mcp status`.
- `scripts/skills_pack_readme.md.tmpl` (source of the generated comet-ml/opik-skills README): mention that the same command installs the pack together with the server. `npx skills add comet-ml/opik-skills -g --all` stays as the multi-agent path, so `test_readme_carries_the_install_command_the_product_shows` is unaffected.

Companion to the docs change in comet-ml/opik (same ticket).

## Change checklist
- [x] User facing
- [x] Documentation updated (if needed)
- [ ] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- OPIK-8282

## Testing

- `uvx opik mcp configure --help` on a machine with uv and no SDK (opik 2.2.53).
- `npx add-mcp --help` (2.3.0): `--name` and remote URL usage as documented.
- Could not run `tests/test_skills_pack_build.py` locally (conftest imports the app and `skills_ref`); the string it asserts on is unchanged in the template.

## Documentation

README and skills-pack README template only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
