### PR TITLE
[OPIK-8285] Expose Diagnostics (Agent Insights) issues through read/list

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,12 @@ read(entity_type="trace", id="7f2e3c8a-…")
 read(entity_type="project", id="demo")          # name lookup
 read(entity_type="trace", id="opik://traces/7f2e3c8a-…")
 read(entity_type="agent_insights_issue", id="<issue-uuid>", project_id="<project-uuid>")
+read(entity_type="agent_insights_issue", id="https://www.comet.com/opik/<ws>/projects/<pid>/diagnostics?issue=<id>")
 ```
+
+A link copied from the Opik UI works as the `id`: a thread link or a
+Diagnostics page link carries the project, so no `project_id` is needed and
+the entity type is taken from the link.
 
 An `agent_insights_issue` read returns `{issue, example_trace_ids, details}`:
 the Diagnostics issue record (name, description, cause, suggested fix,

--- a/README.md
+++ b/README.md
@@ -255,7 +255,9 @@ severity, status), the deduplicated ids of the traces that exhibit it (the
 same sample the Diagnostics page shows — open one with `read("trace", id)`),
 and the per-day breakdown. Trace bodies are not inlined, so the read stays one
 backend call. `from_date` / `to_date` narrow the per-day rows; the default is
-all-time.
+all-time. When the Opik URL is configured the read also carries `url` (the
+issue's Diagnostics page) and `trace_url_template` (a deep link for any of the
+example traces), so the assistant can hand you something clickable.
 
 ### `list`
 

--- a/README.md
+++ b/README.md
@@ -255,9 +255,11 @@ severity, status), the deduplicated ids of the traces that exhibit it (the
 same sample the Diagnostics page shows — open one with `read("trace", id)`),
 and the per-day breakdown. Trace bodies are not inlined, so the read stays one
 backend call. `from_date` / `to_date` narrow the per-day rows; the default is
-all-time. When the Opik URL is configured the read also carries `url` (the
-issue's Diagnostics page) and `trace_url_template` (a deep link for any of the
-example traces), so the assistant can hand you something clickable.
+all-time. When the server knows the Opik URL and the session's workspace, the
+read also carries `url` (the issue's Diagnostics page) and `trace_url_template`
+(a deep link for any of the example traces), so the assistant can hand you
+something clickable; under an OAuth session whose workspace could not be
+resolved the links are omitted rather than guessed.
 
 ### `list`
 

--- a/README.md
+++ b/README.md
@@ -243,13 +243,26 @@ read(entity_type="trace", id="opik://traces/7f2e3c8a-…")
 ### `list`
 
 Browse a collection with optional name filter and pagination. Project-scoped
-types (`trace`, `test_suite_item`, `prompt_version`) require their parent UUID.
+types (`trace`, `thread`, `agent_insights_issue`) take `project_id` or
+`project_name`; sub-collections (`test_suite_item`, `prompt_version`) require
+their parent UUID.
 
 ```python
 list(entity_type="experiment", page=1, size=25)
 list(entity_type="experiment", name="rerank")          # name substring filter
 list(entity_type="trace", project_id="<project-uuid>") # traces of one project
+list(entity_type="agent_insights_issue", project_name="demo")             # open Diagnostics issues
+list(entity_type="agent_insights_issue", project_id="<uuid>", status="resolved")
 ```
+
+**Diagnostics issues.** `agent_insights_issue` is the Diagnostics page over
+the MCP: the recurring failures Opik's Diagnostics job grouped for a project,
+ranked as the UI ranks them (most recently seen first). Columns are `severity`,
+`status`, `total_occurrences` (all-time sum), `latest_count` (the most recent
+report day, the number the issue's own description refers to) and `last_seen`.
+Open issues are listed by default; pass `status="resolved"` or `"closed"` for
+the rest. Counts are all-time so they match the UI; `from_date` / `to_date`
+(ISO dates) narrow the window.
 
 ### `write`
 

--- a/README.md
+++ b/README.md
@@ -227,18 +227,30 @@ lifecycle (read → annotate → curate → author → iterate).
 
 One tool for any "show me X" question. Takes an `entity_type` plus an `id`
 (UUID or, for nameable types, a name) or a full `opik://` URI. Composite reads
-(`trace`, `prompt`) inline their children so a single call returns the full
-picture.
+(`trace`, `prompt`, `thread`, `agent_insights_issue`) inline their children so
+a single call returns the full picture.
 
 **Supported entities:** `project`, `trace`, `span`, `test_suite`, `experiment`,
-`prompt`. Name-based lookup is available for `project`, `experiment`, `prompt`,
-`test_suite` (slower — two API calls — and may return multiple matches).
+`prompt`, `thread`, `agent_insights_issue`. Name-based lookup is available for
+`project`, `experiment`, `prompt`, `test_suite` (slower — two API calls — and
+may return multiple matches). `thread` and `agent_insights_issue` are
+project-scoped: pass `project_id` or `project_name`, or a link/URI that carries
+the project.
 
 ```python
 read(entity_type="trace", id="7f2e3c8a-…")
 read(entity_type="project", id="demo")          # name lookup
 read(entity_type="trace", id="opik://traces/7f2e3c8a-…")
+read(entity_type="agent_insights_issue", id="<issue-uuid>", project_id="<project-uuid>")
 ```
+
+An `agent_insights_issue` read returns `{issue, example_trace_ids, details}`:
+the Diagnostics issue record (name, description, cause, suggested fix,
+severity, status), the deduplicated ids of the traces that exhibit it (the
+same sample the Diagnostics page shows — open one with `read("trace", id)`),
+and the per-day breakdown. Trace bodies are not inlined, so the read stays one
+backend call. `from_date` / `to_date` narrow the per-day rows; the default is
+all-time.
 
 ### `list`
 

--- a/src/opik_mcp/auth_context.py
+++ b/src/opik_mcp/auth_context.py
@@ -48,12 +48,14 @@ inbound_workspace: ContextVar[str | None] = ContextVar("inbound_workspace", defa
 
 # OAuth-authorized workspace *name*, resolved from the opaque bearer via
 # ``oauth_identity.introspect_oauth_token`` (the same call that validates it).
-# Consumed ONLY by the instructions blob (``instructions.render_instructions``)
-# so an agent can truthfully name the workspace it is operating against. Kept
-# deliberately separate from ``inbound_workspace`` so this read-only display
-# value never leaks into the outbound ``Comet-Workspace`` header / data routing
-# (which stays token-derived server-side). ``None`` means "not resolved; fall
-# back to the static settings workspace".
+# Consumed ONLY for display: the instructions blob (``instructions.
+# render_instructions``) so an agent can truthfully name the workspace it is
+# operating against, and the UI links a ``read`` attaches
+# (``read_list.ui_links``). Kept deliberately separate from
+# ``inbound_workspace`` so this read-only display value never leaks into the
+# outbound ``Comet-Workspace`` header / data routing (which stays
+# token-derived server-side). ``None`` means "not resolved; the blob falls
+# back to the static settings workspace, links are omitted".
 resolved_workspace_name: ContextVar[str | None] = ContextVar(
     "resolved_workspace_name", default=None
 )

--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -46,7 +46,11 @@ project, experiment, prompt, test_suite, thread. Composite reads (trace, prompt,
 thread) inline their child collections so one call usually gets the full picture. \
 For a thread, pass the thread link/URI or a project_id — read('thread', …) \
 returns the messages list, and list('thread', project_id=…) enumerates a \
-project's threads.
+project's threads. For "what is broken in production", \
+list('agent_insights_issue', project_name=…) returns the project's Diagnostics \
+(Agent Insights) issues — recurring failures already grouped and ranked, open \
+ones by default, counts all-time unless from_date/to_date narrow them — instead \
+of ranking raw traces yourself.
 - Direct writes — use when the user's intent is concrete and well-defined \
 ("score this trace 0.8 on helpfulness", "comment 'retry with temperature=0' \
 on span X"). The full write surface is two tools: write (takes \

--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -28,9 +28,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from opik_mcp.auth_context import inbound_workspace, resolved_workspace_name
-from opik_mcp.config import DEFAULT_WORKSPACE, Settings, get_settings
-from opik_mcp.opik_client import opik_rest_base
+from opik_mcp.config import Settings, get_settings
+from opik_mcp.read_list.ui_links import current_workspace, opik_ui_base
 from opik_mcp.skills_catalog import skill_names
 from opik_mcp.writes.registry import WRITE_OPERATIONS
 
@@ -72,18 +71,11 @@ Today's date is {date}.\
 def _opik_ui_url(s: Settings) -> str:
     """Opik **UI** base URL for the blob, or a generic placeholder if unconfigured.
 
-    Derived from :func:`opik_rest_base` — the single source of truth for where
-    Opik lives (``OPIK_URL`` override, else ``COMET_URL_OVERRIDE + "/opik/api"``)
-    — so the UI link can never drift from where REST calls actually go. That base
-    is the REST **API** base (``…/opik/api``); the UI lives at the same origin
-    without the trailing ``/api`` segment, so we strip it.
+    Shares :func:`opik_ui_base` with the links a ``read`` attaches, so the blob
+    and the per-entity links can never disagree about where the UI lives.
     """
-    base = opik_rest_base(s)
-    if base is None:
-        return "(Opik URL not configured)"
-    if base.endswith("/api"):
-        base = base[: -len("/api")]
-    return base
+    base = opik_ui_base(s)
+    return base if base is not None else "(Opik URL not configured)"
 
 
 def _render_default_project_clause(s: Settings) -> str:
@@ -115,12 +107,7 @@ def render_instructions(
     ``resolved_workspace_name`` → the static ``Settings`` workspace → ``"default"``.
     """
     s = settings if settings is not None else get_settings()
-    workspace = (
-        inbound_workspace.get()
-        or resolved_workspace_name.get()
-        or s.comet_workspace
-        or DEFAULT_WORKSPACE
-    )
+    workspace = current_workspace(s)
     opik_url = _opik_ui_url(s)
 
     user_clause = f" as {user_email}" if user_email else ""

--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -50,7 +50,9 @@ project's threads. For "what is broken in production", \
 list('agent_insights_issue', project_name=…) returns the project's Diagnostics \
 (Agent Insights) issues — recurring failures already grouped and ranked, open \
 ones by default, counts all-time unless from_date/to_date narrow them — instead \
-of ranking raw traces yourself.
+of ranking raw traces yourself; read('agent_insights_issue', id, project_id=…) \
+adds the cause, the suggested fix and example_trace_ids to open with \
+read('trace', …).
 - Direct writes — use when the user's intent is concrete and well-defined \
 ("score this trace 0.8 on helpfulness", "comment 'retry with temperature=0' \
 on span X"). The full write surface is two tools: write (takes \

--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -42,8 +42,9 @@ Tool selection:
 - read / list: use for any "show me X" or "what is Y" — these are the cheapest \
 reads. read takes (entity_type, id_or_name_or_uri); list takes (entity_type, \
 optional name filter, page, size). Readable entity types include trace, span, \
-project, experiment, prompt, test_suite, thread. Composite reads (trace, prompt, \
-thread) inline their child collections so one call usually gets the full picture. \
+project, experiment, prompt, test_suite, thread, agent_insights_issue. Composite \
+reads (trace, prompt, thread, agent_insights_issue) inline their child collections \
+so one call usually gets the full picture. \
 For a thread, pass the thread link/URI or a project_id — read('thread', …) \
 returns the messages list, and list('thread', project_id=…) enumerates a \
 project's threads. For "what is broken in production", \

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -170,6 +170,17 @@ class OpikListClient(Protocol):
         self, prompt_id: str, /, *, page: int = 1, size: int = 10
     ) -> dict[str, Any]: ...
 
+    async def list_agent_insights_issues(
+        self,
+        *,
+        project_id: str,
+        status: str | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]: ...
+
 
 class OpikReadClient(OpikListClient, Protocol):
     """Adds singleton ``get_*`` endpoints to ``OpikListClient`` for the read tool.
@@ -602,6 +613,41 @@ class OpikClient:
             f"/v1/private/prompts/{prompt_id}/versions",
             params={"page": page, "size": size},
             entity_hint=f"prompt {prompt_id!r} versions",
+        )
+
+    # -- agent insights (the UI's "Diagnostics") --
+
+    async def list_agent_insights_issues(
+        self,
+        *,
+        project_id: str,
+        status: str | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        page: int = 1,
+        size: int = 10,
+    ) -> dict[str, Any]:
+        """``GET /v1/private/agent-insights/issues`` — a project's Diagnostics issues.
+
+        The backend takes ``project_id`` only (no ``project_name``), so name
+        resolution is the caller's job. ``status`` filters open/resolved/closed;
+        ``from_date`` / ``to_date`` (ISO dates) bound the aggregation window.
+        Omitted filters are not sent, which the backend reads as all statuses
+        and all-time — exactly what the Diagnostics page shows.
+        """
+        return await self._get_json(
+            "/v1/private/agent-insights/issues",
+            params=_drop_none(
+                {
+                    "project_id": project_id,
+                    "status": status,
+                    "from_date": from_date,
+                    "to_date": to_date,
+                    "page": page,
+                    "size": size,
+                }
+            ),
+            entity_hint="agent insights issues",
         )
 
     # -- internals --

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -212,6 +212,16 @@ class OpikReadClient(OpikListClient, Protocol):
         truncate: bool = False,
     ) -> dict[str, Any]: ...
 
+    async def get_agent_insights_issue(
+        self,
+        issue_id: str,
+        /,
+        *,
+        project_id: str,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict[str, Any]: ...
+
 
 # --- client --------------------------------------------------------------- #
 
@@ -648,6 +658,29 @@ class OpikClient:
                 }
             ),
             entity_hint="agent insights issues",
+        )
+
+    async def get_agent_insights_issue(
+        self,
+        issue_id: str,
+        *,
+        project_id: str,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict[str, Any]:
+        """``GET /v1/private/agent-insights/issues/{id}`` — one issue + per-day details.
+
+        An issue id is unique, but the backend still requires ``project_id`` as
+        a query parameter (it scopes the tenancy check). ``details`` is one row
+        per report day inside the window, ascending; each row's free-form
+        ``metadata`` is where the Diagnostics job puts ``example_trace_ids``.
+        """
+        return await self._get_json(
+            f"/v1/private/agent-insights/issues/{issue_id}",
+            params=_drop_none(
+                {"project_id": project_id, "from_date": from_date, "to_date": to_date}
+            ),
+            entity_hint=f"agent insights issue {issue_id!r}",
         )
 
     # -- internals --

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -106,6 +106,11 @@ async def run_list(
 
     try:
         page_body = await handler.list_fn(opik, **kw)
+    except EntityArgValidationError as e:
+        # A list_fn may reject its own arguments (e.g. a project_name that
+        # resolves to no or several projects). Surface it as the same typed
+        # validation error the tool raises for a missing parent id.
+        raise ToolError(str(e)) from e
     except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as e:
         raise ToolError(f"Failed to list {entity_type}s: {e}") from e
 

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -27,7 +27,6 @@ backend aggregates by day.
 
 from __future__ import annotations
 
-import difflib
 import json
 import logging
 import math
@@ -56,6 +55,7 @@ from opik_mcp.read_list.oql import (
     compile_filters,
     render_filters,
 )
+from opik_mcp.read_list.project_scope import project_rows, unknown_project_message
 from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, EntityHandler
 from opik_mcp.read_list.sorting import SortError, compile_sort
 from opik_mcp.read_list.window import (
@@ -235,7 +235,7 @@ async def run_list(
         # The backend's 404 for a misspelled project names it ("Project name: X
         # not found"); only that case gets the did-you-mean recovery.
         if kw.get("project_name") and kw["project_name"] in str(e):
-            raise ToolError(await _unknown_project_message(opik, kw["project_name"])) from e
+            raise ToolError(await unknown_project_message(opik, kw["project_name"])) from e
         raise ToolError(f"Failed to list {entity_type}s: {e}") from e
     except (OpikAuthError, OpikValidationError, OpikServerError) as e:
         raise ToolError(f"Failed to list {entity_type}s: {e}") from e
@@ -310,7 +310,7 @@ async def _empty_message(
     if from_time is None:
         return f"{empty} {_SOURCE_HINT}" if unconstrained else empty
 
-    rows = await _project_rows(opik, name=project_name)
+    rows = await project_rows(opik, name=project_name)
     match = [
         p
         for p in rows
@@ -337,44 +337,6 @@ def _window_echo(raw: str, resolved: str) -> str:
     if is_relative(raw):
         return f"{raw.strip()} ({minute})"
     return minute
-
-
-async def _project_rows(opik: OpikListClient, *, name: str | None = None) -> list[dict[str, Any]]:
-    """One page of projects for the side lookups (did-you-mean, last-trace hint).
-
-    ``name`` is the backend's substring filter, so the caller still matches
-    exactly. Failures are logged and yield ``[]``: these lookups decorate an
-    answer the agent already has and must never replace it with an error.
-    """
-    try:
-        body = (
-            await opik.list_projects(name=name, size=100)
-            if name
-            else await opik.list_projects(size=100)
-        )
-    except (
-        OpikAuthError,
-        OpikNotFoundError,
-        OpikValidationError,
-        OpikServerError,
-        httpx.HTTPError,
-    ):
-        logger.debug("project lookup for a list hint failed; skipping the hint", exc_info=True)
-        return []
-    return [p for p in body.get("content") or [] if isinstance(p, dict)]
-
-
-async def _unknown_project_message(opik: OpikListClient, project_name: str) -> str:
-    """One extra call on a project-name 404: the names that do exist, and the
-    closest one. The backend matches names exactly, so a typo is the common case."""
-    names = [p["name"] for p in await _project_rows(opik) if isinstance(p.get("name"), str)]
-    message = f"Project {project_name!r} not found."
-    close = difflib.get_close_matches(project_name, names, n=1, cutoff=0.6)
-    if close:
-        message += f" Did you mean {close[0]!r}?"
-    if names:
-        message += f" Projects: {', '.join(names)}."
-    return message
 
 
 # Filter fields that make no sense as a table column: bodies (never shown in a

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -5,9 +5,12 @@ table (mirrors ollie's format) — easier for the LLM to scan than nested
 JSON and lossless for the columns we care about (id, name, plus a few
 entity-specific fields like ``created_at`` / ``dataset_name``).
 
-Project-scoped lists (``trace``, ``test_suite_item``, ``prompt_version``)
-require their parent id via ``project_id`` / ``test_suite_id`` /
-``prompt_id`` — enforced via the registry's ``list_required_kwargs``.
+Project-scoped lists (``trace``, ``thread``, ``agent_insights_issue``,
+``test_suite_item``, ``prompt_version``) require their parent id via
+``project_id`` / ``test_suite_id`` / ``prompt_id`` — enforced via the
+registry's ``list_required_kwargs``. Entity-specific filters (``status``,
+``from_date``, ``to_date`` for Diagnostics issues) are forwarded only to the
+entity that declares them in ``list_optional_kwargs``.
 """
 
 from __future__ import annotations
@@ -45,6 +48,9 @@ async def run_list(
     project_name: str | None = None,
     test_suite_id: str | None = None,
     prompt_id: str | None = None,
+    status: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
     settings: Settings | None = None,
     client: OpikListClient | None = None,
 ) -> str:
@@ -74,6 +80,9 @@ async def run_list(
         "project_name": project_name,
         "test_suite_id": test_suite_id,
         "prompt_id": prompt_id,
+        "status": status,
+        "from_date": from_date,
+        "to_date": to_date,
     }
     for key, value in candidates.items():
         if value is not None and key in accepted:

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -61,17 +61,23 @@ async def run_list(
     kw: dict[str, Any] = {"page": page, "size": size}
     if name:
         kw["name"] = name
-    if project_id is not None:
-        kw["project_id"] = project_id
-    # Only project-scoped lists (trace, thread) take project_name; forwarding it
-    # to a workspace-wide list_fn (projects/experiments/…) would be an unexpected
-    # kwarg. Gate on the same signal the required-check uses.
-    if project_name is not None and "project_id" in handler.list_required_kwargs:
-        kw["project_name"] = project_name
-    if test_suite_id is not None:
-        kw["test_suite_id"] = test_suite_id
-    if prompt_id is not None:
-        kw["prompt_id"] = prompt_id
+    # Entity-specific kwargs are forwarded only when the registry entry declares
+    # them (required or optional). A parent id meant for another entity, or
+    # project scope on a workspace-wide list, would otherwise reach the client
+    # as an unexpected kwarg. ``project_name`` rides along with ``project_id``:
+    # every project-scoped client method accepts either.
+    accepted = set(handler.list_required_kwargs) | set(handler.list_optional_kwargs)
+    if "project_id" in accepted:
+        accepted.add("project_name")
+    candidates: dict[str, Any] = {
+        "project_id": project_id,
+        "project_name": project_name,
+        "test_suite_id": test_suite_id,
+        "prompt_id": prompt_id,
+    }
+    for key, value in candidates.items():
+        if value is not None and key in accepted:
+            kw[key] = value
 
     for required in handler.list_required_kwargs:
         if kw.get(required) is None:

--- a/src/opik_mcp/read_list/project_scope.py
+++ b/src/opik_mcp/read_list/project_scope.py
@@ -15,6 +15,7 @@ substring hit would read the wrong project's Diagnostics with nothing to say so.
 
 from __future__ import annotations
 
+import hashlib
 import time
 from typing import Any
 
@@ -29,25 +30,36 @@ _LOOKUP_PAGE_SIZE = 100
 # The agent's normal flow is list-then-read with the same project_name, and
 # each call used to pay the projects round trip again (~370 ms on cloud). A
 # project's id never changes, and a rename is rare, so a short-lived cache is
-# safe. Keyed by the client's REST base + workspace as well as the name: in
-# hosted mode one process serves many workspaces, and the same name means a
-# different project in each.
+# safe. The key is the client's REST base, workspace AND a hash of its
+# credential, plus the name: in hosted mode one process serves many tenants,
+# the same name means a different project in each, and under OAuth
+# passthrough the workspace is token-derived server-side and may be unknown
+# here — the credential is then the only thing that tells tenants apart.
 _CACHE_TTL_SECONDS = 300.0
 _CACHE_MAX_ENTRIES = 512
-_cache: dict[tuple[str | None, str | None, str], tuple[str, float]] = {}
+_CacheKey = tuple[str | None, str | None, str | None, str]
+_cache: dict[_CacheKey, tuple[str, float]] = {}
 
 
-def _cache_key(client: OpikListClient, project_name: str) -> tuple[str | None, str | None, str]:
-    base_url = getattr(client, "_base_url", None)
-    workspace = getattr(client, "_workspace", None)
+def _str_attr(client: OpikListClient, name: str) -> str | None:
+    value = getattr(client, name, None)
+    return value if isinstance(value, str) and value else None
+
+
+def _cache_key(client: OpikListClient, project_name: str) -> _CacheKey:
+    credential = _str_attr(client, "_api_key")
+    credential_hash = (
+        hashlib.sha256(credential.encode()).hexdigest()[:16] if credential is not None else None
+    )
     return (
-        base_url if isinstance(base_url, str) else None,
-        workspace if isinstance(workspace, str) else None,
+        _str_attr(client, "_base_url"),
+        _str_attr(client, "_workspace"),
+        credential_hash,
         project_name,
     )
 
 
-def _cache_get(key: tuple[str | None, str | None, str]) -> str | None:
+def _cache_get(key: _CacheKey) -> str | None:
     hit = _cache.get(key)
     if hit is None:
         return None
@@ -58,7 +70,7 @@ def _cache_get(key: tuple[str | None, str | None, str]) -> str | None:
     return project_id
 
 
-def _cache_put(key: tuple[str | None, str | None, str], project_id: str) -> None:
+def _cache_put(key: _CacheKey, project_id: str) -> None:
     if len(_cache) >= _CACHE_MAX_ENTRIES:
         # Bounded and rarely full; dropping the oldest insertion is enough.
         _cache.pop(next(iter(_cache)), None)
@@ -66,6 +78,8 @@ def _cache_put(key: tuple[str | None, str | None, str], project_id: str) -> None
 
 
 def reset_project_cache_for_tests() -> None:
+    """Drop every cached project id. Test-only: fakes carry no credential, so
+    they all share one key and one test's resolution would satisfy the next."""
     _cache.clear()
 
 

--- a/src/opik_mcp/read_list/project_scope.py
+++ b/src/opik_mcp/read_list/project_scope.py
@@ -51,8 +51,28 @@ async def resolve_project_id(client: OpikListClient, project_name: str) -> str:
         f"to one of these (or ask the user which they mean):",
     ]
     for item in exact[:10]:
-        lines.append(f"  - project_id={item['id']}")
+        lines.append(f"  - project_id={item['id']}, name={item.get('name', '')!r}")
     raise EntityArgValidationError("\n".join(lines))
 
 
-__all__ = ["resolve_project_id"]
+async def require_project_id(
+    client: OpikListClient,
+    *,
+    project_id: str | None,
+    project_name: str | None,
+    caller: str,
+) -> str:
+    """Project scope for an endpoint that wants a UUID: the explicit id wins,
+    otherwise the name is resolved, otherwise it is a validation error.
+
+    ``caller`` names the tool call in the error (``"read('agent_insights_issue')"``)
+    so the agent sees which argument list to fix.
+    """
+    if project_id is not None:
+        return project_id
+    if project_name is None:
+        raise EntityArgValidationError(f"{caller} requires project_id or project_name.")
+    return await resolve_project_id(client, project_name)
+
+
+__all__ = ["require_project_id", "resolve_project_id"]

--- a/src/opik_mcp/read_list/project_scope.py
+++ b/src/opik_mcp/read_list/project_scope.py
@@ -1,0 +1,58 @@
+"""Resolve a project name to its UUID for endpoints that take ``project_id`` only.
+
+Traces and threads accept ``project_name`` natively, so the MCP passes it
+through. The agent-insights (Diagnostics) endpoints do not, and the ``read`` /
+``list`` contract already advertises ``project_name`` as an alternative to the
+UUID for every project-scoped entity — so the MCP resolves it here rather than
+teaching the agent an exception.
+
+Resolution is deliberately strict. The projects endpoint is a substring search
+(``name=demo`` also matches ``demo-2``), so only an exact, case-sensitive name
+match counts. One match is used; several are listed back so the agent retries
+with ``project_id``; none is a clear error. Silently picking the first
+substring hit would read the wrong project's Diagnostics with nothing to say so.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from opik_mcp.opik_client import OpikListClient
+from opik_mcp.read_list.errors import EntityArgValidationError
+
+# Enough to see every exact match in any realistic workspace while keeping
+# the lookup a single page. The substring search may return more than this
+# many *partial* matches; exact ones are the only ones we keep.
+_LOOKUP_PAGE_SIZE = 100
+
+
+async def resolve_project_id(client: OpikListClient, project_name: str) -> str:
+    """Exact-name project lookup. Raises ``EntityArgValidationError`` unless
+    exactly one project carries ``project_name``."""
+    page = await client.list_projects(name=project_name, page=1, size=_LOOKUP_PAGE_SIZE)
+    exact: list[dict[str, Any]] = [
+        item
+        for item in page.get("content") or []
+        if isinstance(item, dict)
+        and item.get("name") == project_name
+        and isinstance(item.get("id"), str)
+        and item["id"]
+    ]
+    if len(exact) == 1:
+        return str(exact[0]["id"])
+    if not exact:
+        raise EntityArgValidationError(
+            f"No project named {project_name!r} in this workspace. Check the "
+            f"spelling (the match is exact and case-sensitive), or find it with "
+            f"list('project', name={project_name!r}) and pass its project_id."
+        )
+    lines = [
+        f"Multiple projects are named {project_name!r}. Retry with project_id set "
+        f"to one of these (or ask the user which they mean):",
+    ]
+    for item in exact[:10]:
+        lines.append(f"  - project_id={item['id']}")
+    raise EntityArgValidationError("\n".join(lines))
+
+
+__all__ = ["resolve_project_id"]

--- a/src/opik_mcp/read_list/project_scope.py
+++ b/src/opik_mcp/read_list/project_scope.py
@@ -16,12 +16,24 @@ listed back so the agent retries with ``project_id``; none is a clear error.
 
 from __future__ import annotations
 
+import difflib
 import hashlib
+import logging
 import time
 from typing import Any
 
-from opik_mcp.opik_client import OpikListClient
+import httpx
+
+from opik_mcp.opik_client import (
+    OpikAuthError,
+    OpikListClient,
+    OpikNotFoundError,
+    OpikServerError,
+    OpikValidationError,
+)
 from opik_mcp.read_list.errors import EntityArgValidationError
+
+logger = logging.getLogger("opik_mcp.read_list.project_scope")
 
 # Enough to see every exact match in any realistic workspace while keeping
 # the lookup a single page. The substring search may return more than this
@@ -78,6 +90,46 @@ def _cache_put(key: _CacheKey, project_id: str) -> None:
     _cache[key] = (project_id, time.monotonic() + _CACHE_TTL_SECONDS)
 
 
+async def project_rows(client: OpikListClient, *, name: str | None = None) -> list[dict[str, Any]]:
+    """One page of projects for the side lookups (did-you-mean, last-trace hint).
+
+    ``name`` is the backend's substring filter, so the caller still matches
+    the whole name. Failures are logged and yield ``[]``: these lookups
+    decorate an answer the agent already has and must never replace it with
+    an error.
+    """
+    try:
+        body = (
+            await client.list_projects(name=name, size=_LOOKUP_PAGE_SIZE)
+            if name
+            else await client.list_projects(size=_LOOKUP_PAGE_SIZE)
+        )
+    except (
+        OpikAuthError,
+        OpikNotFoundError,
+        OpikValidationError,
+        OpikServerError,
+        httpx.HTTPError,
+    ):
+        logger.debug("project lookup for a hint failed; skipping the hint", exc_info=True)
+        return []
+    return [p for p in body.get("content") or [] if isinstance(p, dict)]
+
+
+async def unknown_project_message(client: OpikListClient, project_name: str) -> str:
+    """One extra call when a project name resolves to nothing: the names that
+    do exist, and the closest one. A typo is the common case, and every
+    project-scoped entity answers it with the same words."""
+    names = [p["name"] for p in await project_rows(client) if isinstance(p.get("name"), str)]
+    message = f"Project {project_name!r} not found."
+    close = difflib.get_close_matches(project_name, names, n=1, cutoff=0.6)
+    if close:
+        message += f" Did you mean {close[0]!r}?"
+    if names:
+        message += f" Projects: {', '.join(names)}."
+    return message
+
+
 def reset_project_cache_for_tests() -> None:
     """Drop every cached project id. Test-only: fakes carry no credential, so
     they all share one key and one test's resolution would satisfy the next."""
@@ -123,11 +175,7 @@ async def _lookup_project_id(client: OpikListClient, project_name: str) -> str:
     if len(matches) == 1:
         return str(matches[0]["id"])
     if not matches:
-        raise EntityArgValidationError(
-            f"No project named {project_name!r} in this workspace. Check the "
-            f"spelling (the whole name must match), or find it with "
-            f"list('project', name={project_name!r}) and pass its project_id."
-        )
+        raise EntityArgValidationError(await unknown_project_message(client, project_name))
     lines = [
         f"Multiple projects match the name {project_name!r}. Retry with project_id "
         f"set to one of these (or ask the user which they mean):",
@@ -157,4 +205,10 @@ async def require_project_id(
     return await resolve_project_id(client, project_name)
 
 
-__all__ = ["require_project_id", "reset_project_cache_for_tests", "resolve_project_id"]
+__all__ = [
+    "project_rows",
+    "require_project_id",
+    "reset_project_cache_for_tests",
+    "resolve_project_id",
+    "unknown_project_message",
+]

--- a/src/opik_mcp/read_list/project_scope.py
+++ b/src/opik_mcp/read_list/project_scope.py
@@ -15,6 +15,7 @@ substring hit would read the wrong project's Diagnostics with nothing to say so.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from opik_mcp.opik_client import OpikListClient
@@ -25,10 +26,67 @@ from opik_mcp.read_list.errors import EntityArgValidationError
 # many *partial* matches; exact ones are the only ones we keep.
 _LOOKUP_PAGE_SIZE = 100
 
+# The agent's normal flow is list-then-read with the same project_name, and
+# each call used to pay the projects round trip again (~370 ms on cloud). A
+# project's id never changes, and a rename is rare, so a short-lived cache is
+# safe. Keyed by the client's REST base + workspace as well as the name: in
+# hosted mode one process serves many workspaces, and the same name means a
+# different project in each.
+_CACHE_TTL_SECONDS = 300.0
+_CACHE_MAX_ENTRIES = 512
+_cache: dict[tuple[str | None, str | None, str], tuple[str, float]] = {}
+
+
+def _cache_key(client: OpikListClient, project_name: str) -> tuple[str | None, str | None, str]:
+    base_url = getattr(client, "_base_url", None)
+    workspace = getattr(client, "_workspace", None)
+    return (
+        base_url if isinstance(base_url, str) else None,
+        workspace if isinstance(workspace, str) else None,
+        project_name,
+    )
+
+
+def _cache_get(key: tuple[str | None, str | None, str]) -> str | None:
+    hit = _cache.get(key)
+    if hit is None:
+        return None
+    project_id, expires_at = hit
+    if time.monotonic() >= expires_at:
+        _cache.pop(key, None)
+        return None
+    return project_id
+
+
+def _cache_put(key: tuple[str | None, str | None, str], project_id: str) -> None:
+    if len(_cache) >= _CACHE_MAX_ENTRIES:
+        # Bounded and rarely full; dropping the oldest insertion is enough.
+        _cache.pop(next(iter(_cache)), None)
+    _cache[key] = (project_id, time.monotonic() + _CACHE_TTL_SECONDS)
+
+
+def reset_project_cache_for_tests() -> None:
+    _cache.clear()
+
 
 async def resolve_project_id(client: OpikListClient, project_name: str) -> str:
     """Exact-name project lookup. Raises ``EntityArgValidationError`` unless
-    exactly one project carries ``project_name``."""
+    exactly one project carries ``project_name``.
+
+    Successful resolutions are cached per (REST base, workspace, name) for a
+    few minutes; misses and ambiguities are not, since the project may be
+    created or renamed a moment later.
+    """
+    key = _cache_key(client, project_name)
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
+    project_id = await _lookup_project_id(client, project_name)
+    _cache_put(key, project_id)
+    return project_id
+
+
+async def _lookup_project_id(client: OpikListClient, project_name: str) -> str:
     page = await client.list_projects(name=project_name, page=1, size=_LOOKUP_PAGE_SIZE)
     exact: list[dict[str, Any]] = [
         item
@@ -75,4 +133,4 @@ async def require_project_id(
     return await resolve_project_id(client, project_name)
 
 
-__all__ = ["require_project_id", "resolve_project_id"]
+__all__ = ["require_project_id", "reset_project_cache_for_tests", "resolve_project_id"]

--- a/src/opik_mcp/read_list/project_scope.py
+++ b/src/opik_mcp/read_list/project_scope.py
@@ -6,11 +6,12 @@ through. The agent-insights (Diagnostics) endpoints do not, and the ``read`` /
 UUID for every project-scoped entity — so the MCP resolves it here rather than
 teaching the agent an exception.
 
-Resolution is deliberately strict. The projects endpoint is a substring search
-(``name=demo`` also matches ``demo-2``), so only an exact, case-sensitive name
-match counts. One match is used; several are listed back so the agent retries
-with ``project_id``; none is a clear error. Silently picking the first
-substring hit would read the wrong project's Diagnostics with nothing to say so.
+Resolution matches the whole name, the way the backend matches ``project_name``
+on the trace/thread endpoints (case-insensitively), so the same argument
+behaves the same on every project-scoped entity. The projects endpoint is a
+substring search (``name=demo`` also matches ``demo-2``), so substring hits
+are never used: one whole-name match is used (exact case first); several are
+listed back so the agent retries with ``project_id``; none is a clear error.
 """
 
 from __future__ import annotations
@@ -101,29 +102,38 @@ async def resolve_project_id(client: OpikListClient, project_name: str) -> str:
 
 
 async def _lookup_project_id(client: OpikListClient, project_name: str) -> str:
+    """Whole-name match, the way the backend matches ``project_name`` on the
+    trace/thread endpoints: case-insensitive, never a substring. An exact-case
+    match wins over a case-insensitive one so ``demo`` and ``Demo`` can coexist;
+    several case-insensitive matches are listed back rather than guessed."""
     page = await client.list_projects(name=project_name, page=1, size=_LOOKUP_PAGE_SIZE)
-    exact: list[dict[str, Any]] = [
+    named: list[dict[str, Any]] = [
         item
         for item in page.get("content") or []
         if isinstance(item, dict)
-        and item.get("name") == project_name
+        and isinstance(item.get("name"), str)
         and isinstance(item.get("id"), str)
         and item["id"]
     ]
+    exact = [item for item in named if item["name"] == project_name]
     if len(exact) == 1:
         return str(exact[0]["id"])
-    if not exact:
+    folded = project_name.casefold()
+    matches = exact or [item for item in named if item["name"].casefold() == folded]
+    if len(matches) == 1:
+        return str(matches[0]["id"])
+    if not matches:
         raise EntityArgValidationError(
             f"No project named {project_name!r} in this workspace. Check the "
-            f"spelling (the match is exact and case-sensitive), or find it with "
+            f"spelling (the whole name must match), or find it with "
             f"list('project', name={project_name!r}) and pass its project_id."
         )
     lines = [
-        f"Multiple projects are named {project_name!r}. Retry with project_id set "
-        f"to one of these (or ask the user which they mean):",
+        f"Multiple projects match the name {project_name!r}. Retry with project_id "
+        f"set to one of these (or ask the user which they mean):",
     ]
-    for item in exact[:10]:
-        lines.append(f"  - project_id={item['id']}, name={item.get('name', '')!r}")
+    for item in matches[:10]:
+        lines.append(f"  - project_id={item['id']}, name={item['name']!r}")
     raise EntityArgValidationError("\n".join(lines))
 
 

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -182,6 +182,10 @@ async def run_read(
         # here rather than inside the fetcher, and before compression so every
         # tier can decide what to keep.
         data.update(handler.link_fn(resolved_settings, data))
+    # Underscore-prefixed keys are a fetcher's private hand-off to link_fn
+    # (e.g. the project an issue was read under); they are never the agent's.
+    for private_key in [key for key in data if key.startswith("_")]:
+        del data[private_key]
 
     compressed_text, tier = compress_for(handler, data, max_tokens)
     full_json = compact_json(data)

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -37,7 +37,7 @@ from opik_mcp.read_list.registry import (
     EntityHandler,
     compress_for,
 )
-from opik_mcp.read_list.uri import InvalidURI, looks_like_thread_url, looks_like_uri
+from opik_mcp.read_list.uri import InvalidURI, looks_like_opik_link, looks_like_uri
 from opik_mcp.read_list.uri import parse as parse_uri
 
 logger = logging.getLogger("opik_mcp.read_list.read")
@@ -122,11 +122,12 @@ async def run_read(
     branch → fetch → compress. Each branch surfaces errors as ``ToolError`` so
     the host LLM gets the structured guidance.
     """
-    # Accept ``opik://…`` URIs and pasted web thread links as id input. When the
-    # URI encodes its own entity_type we trust it and override the explicit
-    # argument — that way the agent can paste a URI into either slot. A parsed
-    # thread URI/link also carries the project, which overrides the explicit arg.
-    if looks_like_uri(id) or looks_like_thread_url(id):
+    # Accept ``opik://…`` URIs and pasted web links (thread panel, Diagnostics
+    # page) as id input. When the URI encodes its own entity_type we trust it
+    # and override the explicit argument — that way the agent can paste a URI
+    # into either slot. A parsed project-scoped URI/link also carries the
+    # project, which overrides the explicit arg.
+    if looks_like_uri(id) or looks_like_opik_link(id):
         try:
             parsed = parse_uri(id)
         except InvalidURI as e:

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -114,6 +114,7 @@ async def run_read(
     project_name: str | None = None,
     settings: Settings | None = None,
     client: OpikReadClient | None = None,
+    **entity_kwargs: Any,
 ) -> str:
     """Read tool entrypoint. See ``server.py`` for the registered tool.
 
@@ -155,15 +156,24 @@ async def run_read(
 
     if handler.needs_project and project_id is None and project_name is None:
         err = EntityArgValidationError(
-            f"read({entity_type!r}) requires project scope. Pass the full thread "
-            f"link/URI, or a project_id — e.g. "
-            f"read('{entity_type}', '<{entity_type}_id>', project_id='<uuid>')."
+            f"read({entity_type!r}) requires project scope. Pass project_id or "
+            f"project_name, or paste the {entity_type}'s Opik link/URI as the id — "
+            f"e.g. read('{entity_type}', '<{entity_type}_id>', project_id='<uuid>')."
         )
         raise ToolError(str(err)) from err
 
+    # Entity-specific kwargs reach the fetcher only when its registry entry
+    # declares them — same gate as ``list``, so a kwarg meant for one entity is
+    # dropped rather than crashing another's fetcher.
+    extra = {
+        key: value
+        for key, value in entity_kwargs.items()
+        if value is not None and key in handler.read_optional_kwargs
+    }
+
     opik = client if client is not None else make_opik_client(settings or get_settings())
     data = await _fetch_with_name_lookup(
-        handler, opik, id, project_id=project_id, project_name=project_name
+        handler, opik, id, project_id=project_id, project_name=project_name, extra=extra
     )
 
     compressed_text, tier = compress_for(handler, data, max_tokens)
@@ -181,6 +191,7 @@ async def _fetch_with_name_lookup(
     *,
     project_id: str | None = None,
     project_name: str | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Resolve name → id when the input doesn't look like a UUID.
 
@@ -209,12 +220,13 @@ async def _fetch_with_name_lookup(
         # 0 candidates: fall through with the raw id; the fetch call below
         # will 404 with a clear message if it really doesn't exist.
 
+    extra = extra or {}
     try:
         if handler.needs_project:
             return await handler.fetch_fn(
-                client, entity_id, project_id=project_id, project_name=project_name
+                client, entity_id, project_id=project_id, project_name=project_name, **extra
             )
-        return await handler.fetch_fn(client, entity_id)
+        return await handler.fetch_fn(client, entity_id, **extra)
     except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as e:
         raise ToolError(_format_client_error(handler.entity_type, entity_id, e)) from e
 

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -227,6 +227,11 @@ async def _fetch_with_name_lookup(
                 client, entity_id, project_id=project_id, project_name=project_name, **extra
             )
         return await handler.fetch_fn(client, entity_id, **extra)
+    except EntityArgValidationError as e:
+        # A fetcher may reject its own scope (e.g. a project_name that resolves
+        # to no or several projects). Same typed cause as the tool's own
+        # argument checks, so analytics buckets it as validation/400.
+        raise ToolError(str(e)) from e
     except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as e:
         raise ToolError(_format_client_error(handler.entity_type, entity_id, e)) from e
 

--- a/src/opik_mcp/read_list/read_tool.py
+++ b/src/opik_mcp/read_list/read_tool.py
@@ -172,10 +172,16 @@ async def run_read(
         if value is not None and key in handler.read_optional_kwargs
     }
 
-    opik = client if client is not None else make_opik_client(settings or get_settings())
+    resolved_settings = settings or get_settings()
+    opik = client if client is not None else make_opik_client(resolved_settings)
     data = await _fetch_with_name_lookup(
         handler, opik, id, project_id=project_id, project_name=project_name, extra=extra
     )
+    if handler.link_fn is not None:
+        # UI links are session facts (UI base, workspace), so they are attached
+        # here rather than inside the fetcher, and before compression so every
+        # tier can decide what to keep.
+        data.update(handler.link_fn(resolved_settings, data))
 
     compressed_text, tier = compress_for(handler, data, max_tokens)
     full_json = compact_json(data)

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from opik_mcp.opik_client import OpikListClient, OpikReadClient
+from opik_mcp.opik_client import OpikListClient, OpikReadClient, OpikValidationError
 from opik_mcp.read_list.compression import (
     TOKEN_FULL_THRESHOLD,
     TOKEN_SKELETON_THRESHOLD,
@@ -88,13 +88,14 @@ class EntityHandler:
     saves one round-trip on every non-UUID input for traces/spans/etc.
     """
     needs_project: bool = False
-    """True if ``fetch_fn`` needs project scope (thread only).
+    """True if ``fetch_fn`` needs project scope (thread, agent_insights_issue).
 
-    A thread id is unique only within a project, so ``read`` must pass
-    ``project_id`` / ``project_name`` into the fetcher. The read tool branches
-    on this flag: when set it calls ``fetch_fn(client, id, project_id=…,
-    project_name=…)`` and requires one of them; otherwise it calls
-    ``fetch_fn(client, id)`` exactly as before. Orthogonal to ``id_only``.
+    A thread id is unique only within a project, and the agent-insights
+    endpoints require ``project_id`` as a query parameter, so ``read`` must
+    pass ``project_id`` / ``project_name`` into the fetcher. The read tool
+    branches on this flag: when set it calls ``fetch_fn(client, id,
+    project_id=…, project_name=…)`` and requires one of them; otherwise it
+    calls ``fetch_fn(client, id)`` exactly as before. Orthogonal to ``id_only``.
     """
 
 
@@ -258,6 +259,70 @@ async def _fetch_thread(
         "thread": thread,
         "messages": _thread_messages(traces),
         "messagesTruncated": truncated,
+    }
+
+
+def _example_trace_ids(details: list[dict[str, Any]]) -> list[str]:
+    """Deduplicated union of each per-day row's ``metadata.example_trace_ids``.
+
+    First-seen order over the rows as the backend returns them (ascending
+    report day), which is what the Diagnostics page's affected-traces sample
+    shows. ``metadata`` is free-form JSON written by the Diagnostics job — a
+    row without it, or with a non-object value, contributes nothing rather
+    than failing the read.
+    """
+    seen: dict[str, None] = {}
+    for row in details:
+        metadata = row.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        ids = metadata.get("example_trace_ids")
+        if not isinstance(ids, list):
+            continue
+        for trace_id in ids:
+            if isinstance(trace_id, str) and trace_id:
+                seen.setdefault(trace_id, None)
+    return list(seen)
+
+
+async def _fetch_agent_insights_issue(
+    client: OpikReadClient,
+    entity_id: str,
+    *,
+    project_id: str | None = None,
+    project_name: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+) -> dict[str, Any]:
+    """Diagnostics issue + deduped example trace ids + per-day breakdown.
+
+    One backend call. Returns ``{issue, example_trace_ids, details}``: the
+    issue record without its ``details`` array, the trace ids the agent can
+    open with ``read('trace', id)``, and the per-day rows unchanged. Trace
+    bodies are deliberately not inlined — that would turn one read into N+1
+    calls and blow the default budget on any issue with several examples.
+    """
+    if project_id is None:
+        # The agent-insights endpoints take project_id only. Name resolution
+        # is the next slice; until then say so instead of sending nothing.
+        raise OpikValidationError(
+            "agent_insights_issue needs project_id (a UUID) for now — resolve the "
+            "project name with list('project', name=…) first."
+        )
+    body = await client.get_agent_insights_issue(
+        entity_id, project_id=project_id, from_date=from_date, to_date=to_date
+    )
+    details_raw = body.get("details")
+    details = (
+        [row for row in details_raw if isinstance(row, dict)]
+        if isinstance(details_raw, list)
+        else []
+    )
+    issue = {key: value for key, value in body.items() if key != "details"}
+    return {
+        "issue": issue,
+        "example_trace_ids": _example_trace_ids(details),
+        "details": details,
     }
 
 
@@ -427,6 +492,43 @@ def _compress_thread(data: dict[str, Any], max_tokens: int | None) -> tuple[str,
     return compact_json(skeleton), CompressionTier.SKELETON
 
 
+def _compress_issue(data: dict[str, Any], max_tokens: int | None) -> tuple[str, CompressionTier]:
+    """Issue+details: FULL → MEDIUM (truncated strings) → SKELETON (ids only).
+
+    An all-time read carries one row per report day, each with prose in its
+    metadata. SKELETON drops the rows but keeps every example trace id — the
+    ids are the reason for the read, and the generic pipeline would truncate
+    exactly the field we came for.
+    """
+    full_json = compact_json(data)
+    full_tokens = estimate_tokens(full_json)
+
+    budget = max_tokens if max_tokens is not None else TOKEN_FULL_THRESHOLD
+    if full_tokens <= budget:
+        return full_json, CompressionTier.FULL
+
+    if full_tokens < TOKEN_SKELETON_THRESHOLD:
+        truncated = truncate_strings(data, ".agent_insights_issue")
+        return compact_json(truncated), CompressionTier.MEDIUM
+
+    issue = data.get("issue") or {}
+    skeleton = {
+        "issue": {
+            "id": issue.get("id"),
+            "name": issue.get("name"),
+            "severity": issue.get("severity"),
+            "status": issue.get("status"),
+        },
+        "example_trace_ids": data.get("example_trace_ids") or [],
+        "note": (
+            "SKELETON compression: cause, suggested fix and per-day details "
+            "omitted. Use read('trace', trace_id) on an example, or re-read with "
+            "from_date/to_date to narrow the window."
+        ),
+    }
+    return compact_json(skeleton), CompressionTier.SKELETON
+
+
 # --- registry ------------------------------------------------------------- #
 
 
@@ -530,7 +632,7 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
     ),
     "agent_insights_issue": EntityHandler(
         entity_type="agent_insights_issue",
-        fetch_fn=_unsupported_fetch,
+        fetch_fn=_fetch_agent_insights_issue,
         list_fn=_list_agent_insights_issues,
         list_extra_fields=(
             "severity",
@@ -541,15 +643,22 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         ),
         list_required_kwargs=("project_id",),
         list_optional_kwargs=("status", "from_date", "to_date"),
+        read_optional_kwargs=("from_date", "to_date"),
+        compress_fn=_compress_issue,
         id_only=True,
+        needs_project=True,
         description=(
             "Diagnostics issue (Agent Insights): a recurring failure the "
             "Diagnostics job grouped across a project's traces, with severity, "
             "status, occurrence counts, cause and suggested fix. "
             "list('agent_insights_issue', project_id=… | project_name=…) returns "
             "open issues ranked as the Diagnostics page ranks them (most recently "
-            "seen first); pass status='resolved' or 'closed' for the rest. Counts "
-            "are all-time unless from_date/to_date narrow the window."
+            "seen first); pass status='resolved' or 'closed' for the rest. "
+            "read('agent_insights_issue', id, project_id=…) returns {issue, "
+            "example_trace_ids, details}: the record with cause and suggested fix, "
+            "the deduped ids of traces that exhibit it (open one with "
+            "read('trace', id)), and the per-day breakdown. Counts are all-time "
+            "unless from_date/to_date narrow the window."
         ),
     ),
 }

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -340,6 +340,16 @@ async def _list_threads(client: OpikListClient, **kw: Any) -> dict[str, Any]:
     return await client.list_threads(**kw)
 
 
+async def _list_agent_insights_issues(client: OpikListClient, **kw: Any) -> dict[str, Any]:
+    # "What is broken" means open issues, so that is the default; the caller
+    # asks for resolved/closed explicitly. No name filter exists on the backend.
+    # No ``sorting`` is sent: the backend's default (last seen, then total
+    # occurrences) is the Diagnostics page's ranking.
+    kw.pop("name", None)
+    kw.setdefault("status", "open")
+    return await client.list_agent_insights_issues(**kw)
+
+
 # --- trace skeleton compression ------------------------------------------ #
 
 
@@ -516,6 +526,30 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
             "messagesTruncated}. Requires project scope — pass a thread link/URI "
             "or project_id. list('thread', project_id=…) enumerates a project's "
             "threads."
+        ),
+    ),
+    "agent_insights_issue": EntityHandler(
+        entity_type="agent_insights_issue",
+        fetch_fn=_unsupported_fetch,
+        list_fn=_list_agent_insights_issues,
+        list_extra_fields=(
+            "severity",
+            "status",
+            "total_occurrences",
+            "latest_count",
+            "last_seen",
+        ),
+        list_required_kwargs=("project_id",),
+        list_optional_kwargs=("status", "from_date", "to_date"),
+        id_only=True,
+        description=(
+            "Diagnostics issue (Agent Insights): a recurring failure the "
+            "Diagnostics job grouped across a project's traces, with severity, "
+            "status, occurrence counts, cause and suggested fix. "
+            "list('agent_insights_issue', project_id=… | project_name=…) returns "
+            "open issues ranked as the Diagnostics page ranks them (most recently "
+            "seen first); pass status='resolved' or 'closed' for the rest. Counts "
+            "are all-time unless from_date/to_date narrow the window."
         ),
     ),
 }

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -39,8 +39,7 @@ from opik_mcp.read_list.compression import (
 from opik_mcp.read_list.compression import (
     compress as generic_compress,
 )
-from opik_mcp.read_list.errors import EntityArgValidationError
-from opik_mcp.read_list.project_scope import resolve_project_id
+from opik_mcp.read_list.project_scope import require_project_id
 
 # Inline caps for composite reads — match the previous resources.py
 # constants so cache shapes stay stable for any in-flight integration.
@@ -304,15 +303,15 @@ async def _fetch_agent_insights_issue(
     bodies are deliberately not inlined — that would turn one read into N+1
     calls and blow the default budget on any issue with several examples.
     """
-    if project_id is None:
-        # The agent-insights endpoints take project_id only; resolve the name
-        # here so the read contract stays "project_id or project_name" for
-        # every project-scoped entity. An explicit project_id always wins.
-        if project_name is None:
-            raise EntityArgValidationError(
-                "read('agent_insights_issue') requires project_id or project_name."
-            )
-        project_id = await resolve_project_id(client, project_name)
+    # The agent-insights endpoints take project_id only; resolve the name here
+    # so the read contract stays "project_id or project_name" for every
+    # project-scoped entity. An explicit project_id always wins.
+    project_id = await require_project_id(
+        client,
+        project_id=project_id,
+        project_name=project_name,
+        caller="read('agent_insights_issue')",
+    )
     body = await client.get_agent_insights_issue(
         entity_id, project_id=project_id, from_date=from_date, to_date=to_date
     )
@@ -419,13 +418,12 @@ async def _list_agent_insights_issues(client: OpikListClient, **kw: Any) -> dict
     # The backend takes project_id only. The list tool lets project_name
     # satisfy the project requirement (as for trace/thread), so resolve it
     # here; an explicit project_id wins and skips the lookup.
-    project_name = kw.pop("project_name", None)
-    if kw.get("project_id") is None:
-        if project_name is None:
-            raise EntityArgValidationError(
-                "list('agent_insights_issue') requires project_id or project_name."
-            )
-        kw["project_id"] = await resolve_project_id(client, project_name)
+    kw["project_id"] = await require_project_id(
+        client,
+        project_id=kw.get("project_id"),
+        project_name=kw.pop("project_name", None),
+        caller="list('agent_insights_issue')",
+    )
     return await client.list_agent_insights_issues(**kw)
 
 

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -27,6 +27,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+from opik_mcp.config import Settings
 from opik_mcp.opik_client import OpikListClient, OpikReadClient
 from opik_mcp.read_list.compression import (
     TOKEN_FULL_THRESHOLD,
@@ -40,6 +41,7 @@ from opik_mcp.read_list.compression import (
     compress as generic_compress,
 )
 from opik_mcp.read_list.project_scope import require_project_id
+from opik_mcp.read_list.ui_links import project_page_url
 
 # Inline caps for composite reads — match the previous resources.py
 # constants so cache shapes stay stable for any in-flight integration.
@@ -55,6 +57,7 @@ FetchFn = Callable[..., Awaitable[dict[str, Any]]]
 SearchByNameFn = Callable[[OpikReadClient, str], Awaitable[list[dict[str, Any]]]]
 ListFn = Callable[..., Awaitable[dict[str, Any]]]
 CompressFn = Callable[[dict[str, Any], int | None], tuple[str, CompressionTier]]
+LinkFn = Callable[[Settings, dict[str, Any]], dict[str, str]]
 
 
 @dataclass(frozen=True)
@@ -81,6 +84,15 @@ class EntityHandler:
     read_optional_kwargs: tuple[str, ...] = ()
     """Entity-specific kwargs ``fetch_fn`` accepts beyond the id and project
     scope. Same forwarding rule as ``list_optional_kwargs``, for ``read``."""
+    link_fn: LinkFn | None = None
+    """Optional: UI links to attach to the fetched composite before compression.
+
+    Called by ``read`` with the session's ``Settings`` and the fetched data;
+    returns extra top-level fields (e.g. ``url``). Fetchers cannot do this
+    themselves — they see a client, not settings — and the UI base/workspace
+    are session facts, not entity facts. Return ``{}`` when Opik's URL is
+    unconfigured: no link beats a wrong one.
+    """
     compress_fn: CompressFn | None = None
     id_only: bool = False
     """True if the entity is addressed only by UUID (no name lookup).
@@ -324,9 +336,29 @@ async def _fetch_agent_insights_issue(
     issue = {key: value for key, value in body.items() if key != "details"}
     return {
         "issue": issue,
+        # The link_fn needs the project the issue was read under; the backend
+        # record does not carry it. Kept private so it never reaches the agent.
+        "_project_id": project_id,
         "example_trace_ids": _example_trace_ids(details),
         "details": details,
     }
+
+
+def _issue_links(settings: Settings, data: dict[str, Any]) -> dict[str, str]:
+    """The issue's Diagnostics page (open or resolved view, by status) and a
+    template for deep-linking any of its example traces — the two links the
+    diagnose skill has to hand the user."""
+    project_id = data.pop("_project_id", None)
+    issue = data.get("issue") or {}
+    issue_id = issue.get("id")
+    if not isinstance(project_id, str) or not isinstance(issue_id, str):
+        return {}
+    view = "diagnostics" if issue.get("status") == "open" else "diagnostics/resolved"
+    page = project_page_url(settings, project_id, f"{view}?issue={issue_id}")
+    traces = project_page_url(settings, project_id, "logs?trace={trace_id}")
+    if page is None or traces is None:
+        return {}
+    return {"url": page, "trace_url_template": traces}
 
 
 async def _unsupported_fetch(_client: OpikReadClient, _entity_id: str) -> dict[str, Any]:
@@ -540,7 +572,7 @@ def _compress_issue(data: dict[str, Any], max_tokens: int | None) -> tuple[str, 
         return truncated_json, CompressionTier.MEDIUM
 
     issue = data.get("issue") or {}
-    skeleton = {
+    skeleton: dict[str, Any] = {
         "issue": {
             "id": issue.get("id"),
             "name": issue.get("name"),
@@ -548,12 +580,15 @@ def _compress_issue(data: dict[str, Any], max_tokens: int | None) -> tuple[str, 
             "status": issue.get("status"),
         },
         "example_trace_ids": data.get("example_trace_ids") or [],
-        "note": (
-            "SKELETON compression: cause, suggested fix and per-day details "
-            "omitted. Use read('trace', trace_id) on an example, or re-read with "
-            "from_date/to_date to narrow the window."
-        ),
     }
+    for link_key in ("url", "trace_url_template"):
+        if link_key in data:
+            skeleton[link_key] = data[link_key]
+    skeleton["note"] = (
+        "SKELETON compression: cause, suggested fix and per-day details "
+        "omitted. Use read('trace', trace_id) on an example, or re-read with "
+        "from_date/to_date to narrow the window."
+    )
     return compact_json(skeleton), CompressionTier.SKELETON
 
 
@@ -672,6 +707,7 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         list_required_kwargs=("project_id",),
         list_optional_kwargs=("status", "from_date", "to_date"),
         read_optional_kwargs=("from_date", "to_date"),
+        link_fn=_issue_links,
         compress_fn=_compress_issue,
         id_only=True,
         needs_project=True,
@@ -683,10 +719,11 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
             "open issues ranked as the Diagnostics page ranks them (most recently "
             "seen first); pass status='resolved' or 'closed' for the rest. "
             "read('agent_insights_issue', id, project_id=…) returns {issue, "
-            "example_trace_ids, details}: the record with cause and suggested fix, "
-            "the deduped ids of traces that exhibit it (open one with "
-            "read('trace', id)), and the per-day breakdown. Counts are all-time "
-            "unless from_date/to_date narrow the window."
+            "example_trace_ids, details, url, trace_url_template}: the record with "
+            "cause and suggested fix, the deduped ids of traces that exhibit it "
+            "(open one with read('trace', id)), the per-day breakdown, and UI links "
+            "to hand the user. Counts are all-time unless from_date/to_date narrow "
+            "the window."
         ),
     ),
 }

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -88,10 +88,12 @@ class EntityHandler:
     """Optional: UI links to attach to the fetched composite before compression.
 
     Called by ``read`` with the session's ``Settings`` and the fetched data;
-    returns extra top-level fields (e.g. ``url``). Fetchers cannot do this
-    themselves — they see a client, not settings — and the UI base/workspace
-    are session facts, not entity facts. Return ``{}`` when Opik's URL is
-    unconfigured: no link beats a wrong one.
+    returns extra top-level fields (e.g. ``url``) and must not mutate the
+    data. Fetchers cannot do this themselves — they see a client, not
+    settings — and the UI base/workspace are session facts, not entity
+    facts. A fetcher may stash inputs for the link under underscore-prefixed
+    keys; ``read`` strips those before compression. Return ``{}`` when Opik's
+    URL or the workspace cannot be known: no link beats a wrong one.
     """
     compress_fn: CompressFn | None = None
     id_only: bool = False
@@ -309,11 +311,12 @@ async def _fetch_agent_insights_issue(
 ) -> dict[str, Any]:
     """Diagnostics issue + deduped example trace ids + per-day breakdown.
 
-    One backend call. Returns ``{issue, example_trace_ids, details}``: the
-    issue record without its ``details`` array, the trace ids the agent can
-    open with ``read('trace', id)``, and the per-day rows unchanged. Trace
-    bodies are deliberately not inlined — that would turn one read into N+1
-    calls and blow the default budget on any issue with several examples.
+    One backend call. Returns ``{issue, example_trace_ids, details}`` plus a
+    private ``_project_id`` (see below): the issue record without its
+    ``details`` array, the trace ids the agent can open with
+    ``read('trace', id)``, and the per-day rows unchanged. Trace bodies are
+    deliberately not inlined — that would turn one read into N+1 calls and
+    blow the default budget on any issue with several examples.
     """
     # The agent-insights endpoints take project_id only; resolve the name here
     # so the read contract stays "project_id or project_name" for every
@@ -337,7 +340,8 @@ async def _fetch_agent_insights_issue(
     return {
         "issue": issue,
         # The link_fn needs the project the issue was read under; the backend
-        # record does not carry it. Kept private so it never reaches the agent.
+        # record does not carry it. Underscore-prefixed keys are stripped by
+        # the read tool after links are attached, so it never reaches the agent.
         "_project_id": project_id,
         "example_trace_ids": _example_trace_ids(details),
         "details": details,
@@ -348,7 +352,7 @@ def _issue_links(settings: Settings, data: dict[str, Any]) -> dict[str, str]:
     """The issue's Diagnostics page (open or resolved view, by status) and a
     template for deep-linking any of its example traces — the two links the
     diagnose skill has to hand the user."""
-    project_id = data.pop("_project_id", None)
+    project_id = data.get("_project_id")
     issue = data.get("issue") or {}
     issue_id = issue.get("id")
     if not isinstance(project_id, str) or not isinstance(issue_id, str):

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -726,8 +726,8 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
             "example_trace_ids, details, url, trace_url_template}: the record with "
             "cause and suggested fix, the deduped ids of traces that exhibit it "
             "(open one with read('trace', id)), the per-day breakdown, and UI links "
-            "to hand the user. Counts are all-time unless from_date/to_date narrow "
-            "the window."
+            "to hand the user (omitted when the Opik URL or workspace is unknown). "
+            "Counts are all-time unless from_date/to_date narrow the window."
         ),
     ),
 }

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -505,12 +505,16 @@ def _compress_thread(data: dict[str, Any], max_tokens: int | None) -> tuple[str,
 
 
 def _compress_issue(data: dict[str, Any], max_tokens: int | None) -> tuple[str, CompressionTier]:
-    """Issue+details: FULL → MEDIUM (truncated strings) → SKELETON (ids only).
+    """Issue+details: FULL → MEDIUM (rows without metadata, then truncated
+    strings) → SKELETON (ids only).
 
-    An all-time read carries one row per report day, each with prose in its
-    metadata. SKELETON drops the rows but keeps every example trace id — the
-    ids are the reason for the read, and the generic pipeline would truncate
-    exactly the field we came for.
+    Unlike trace/thread, MEDIUM here is budget-aware. An issue read is mostly
+    per-day rows whose ``metadata`` repeats the example ids (already lifted
+    into ``example_trace_ids``) and carries a confidence justification; that
+    is the bulk of the tokens and none of the reason for the read. So MEDIUM
+    first drops row metadata, then truncates long strings, and returns as
+    soon as the body fits. If it still does not fit, SKELETON — the agent
+    asked for a small answer, so the global 50k threshold is not the bar.
     """
     full_json = compact_json(data)
     full_tokens = estimate_tokens(full_json)
@@ -519,9 +523,21 @@ def _compress_issue(data: dict[str, Any], max_tokens: int | None) -> tuple[str, 
     if full_tokens <= budget:
         return full_json, CompressionTier.FULL
 
-    if full_tokens < TOKEN_SKELETON_THRESHOLD:
-        truncated = truncate_strings(data, ".agent_insights_issue")
-        return compact_json(truncated), CompressionTier.MEDIUM
+    pruned = {
+        **data,
+        "details": [
+            {key: value for key, value in row.items() if key != "metadata"}
+            for row in data.get("details") or []
+            if isinstance(row, dict)
+        ],
+    }
+    pruned_json = compact_json(pruned)
+    if estimate_tokens(pruned_json) <= budget:
+        return pruned_json, CompressionTier.MEDIUM
+
+    truncated_json = compact_json(truncate_strings(pruned, ".agent_insights_issue"))
+    if estimate_tokens(truncated_json) <= budget:
+        return truncated_json, CompressionTier.MEDIUM
 
     issue = data.get("issue") or {}
     skeleton = {

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from opik_mcp.opik_client import OpikListClient, OpikReadClient, OpikValidationError
+from opik_mcp.opik_client import OpikListClient, OpikReadClient
 from opik_mcp.read_list.compression import (
     TOKEN_FULL_THRESHOLD,
     TOKEN_SKELETON_THRESHOLD,
@@ -39,6 +39,8 @@ from opik_mcp.read_list.compression import (
 from opik_mcp.read_list.compression import (
     compress as generic_compress,
 )
+from opik_mcp.read_list.errors import EntityArgValidationError
+from opik_mcp.read_list.project_scope import resolve_project_id
 
 # Inline caps for composite reads — match the previous resources.py
 # constants so cache shapes stay stable for any in-flight integration.
@@ -303,12 +305,14 @@ async def _fetch_agent_insights_issue(
     calls and blow the default budget on any issue with several examples.
     """
     if project_id is None:
-        # The agent-insights endpoints take project_id only. Name resolution
-        # is the next slice; until then say so instead of sending nothing.
-        raise OpikValidationError(
-            "agent_insights_issue needs project_id (a UUID) for now — resolve the "
-            "project name with list('project', name=…) first."
-        )
+        # The agent-insights endpoints take project_id only; resolve the name
+        # here so the read contract stays "project_id or project_name" for
+        # every project-scoped entity. An explicit project_id always wins.
+        if project_name is None:
+            raise EntityArgValidationError(
+                "read('agent_insights_issue') requires project_id or project_name."
+            )
+        project_id = await resolve_project_id(client, project_name)
     body = await client.get_agent_insights_issue(
         entity_id, project_id=project_id, from_date=from_date, to_date=to_date
     )
@@ -412,6 +416,16 @@ async def _list_agent_insights_issues(client: OpikListClient, **kw: Any) -> dict
     # occurrences) is the Diagnostics page's ranking.
     kw.pop("name", None)
     kw.setdefault("status", "open")
+    # The backend takes project_id only. The list tool lets project_name
+    # satisfy the project requirement (as for trace/thread), so resolve it
+    # here; an explicit project_id wins and skips the lookup.
+    project_name = kw.pop("project_name", None)
+    if kw.get("project_id") is None:
+        if project_name is None:
+            raise EntityArgValidationError(
+                "list('agent_insights_issue') requires project_id or project_name."
+            )
+        kw["project_id"] = await resolve_project_id(client, project_name)
     return await client.list_agent_insights_issues(**kw)
 
 

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -65,6 +65,21 @@ class EntityHandler:
     list_fn: ListFn | None = None
     list_extra_fields: tuple[str, ...] = ()
     list_required_kwargs: tuple[str, ...] = ()
+    """Entity-specific kwargs ``list_fn`` cannot run without (a parent id).
+
+    ``project_id`` is special: ``project_name`` satisfies it too, since every
+    project-scoped list accepts either.
+    """
+    list_optional_kwargs: tuple[str, ...] = ()
+    """Entity-specific kwargs ``list_fn`` accepts but does not require.
+
+    The ``list`` tool forwards a kwarg only when the entity declares it here
+    or in ``list_required_kwargs``; anything else the caller passed is dropped
+    so a confused call degrades to a plain list instead of a client TypeError.
+    """
+    read_optional_kwargs: tuple[str, ...] = ()
+    """Entity-specific kwargs ``fetch_fn`` accepts beyond the id and project
+    scope. Same forwarding rule as ``list_optional_kwargs``, for ``read``."""
     compress_fn: CompressFn | None = None
     id_only: bool = False
     """True if the entity is addressed only by UUID (no name lookup).

--- a/src/opik_mcp/read_list/ui_links.py
+++ b/src/opik_mcp/read_list/ui_links.py
@@ -1,0 +1,53 @@
+"""Where the Opik UI lives for this session — base URL and workspace name.
+
+Two consumers must agree on this: the instructions blob, which tells the
+agent the UI address once per session, and the links a ``read`` attaches to
+an entity (a Diagnostics issue's page, a trace deep link) so the agent can
+hand the user something clickable without guessing the URL shape. Keeping
+the derivation here means neither can drift from where REST calls go.
+"""
+
+from __future__ import annotations
+
+from opik_mcp.auth_context import inbound_workspace, resolved_workspace_name
+from opik_mcp.config import DEFAULT_WORKSPACE, Settings
+from opik_mcp.opik_client import opik_rest_base
+
+
+def opik_ui_base(settings: Settings) -> str | None:
+    """Opik **UI** base URL, or ``None`` when Opik's location is unconfigured.
+
+    Derived from :func:`opik_rest_base` — the single source of truth for where
+    Opik lives (``OPIK_URL`` override, else ``COMET_URL_OVERRIDE + "/opik/api"``).
+    That base is the REST **API** base (``…/opik/api``); the UI lives at the
+    same origin without the trailing ``/api`` segment, so we strip it.
+    """
+    base = opik_rest_base(settings)
+    if base is None:
+        return None
+    if base.endswith("/api"):
+        base = base[: -len("/api")]
+    return base
+
+
+def current_workspace(settings: Settings) -> str:
+    """Workspace name for THIS session, most to least authoritative: an explicit
+    inbound ``Comet-Workspace`` header → the OAuth-introspected name → the
+    static ``Settings`` workspace → ``"default"``."""
+    return (
+        inbound_workspace.get()
+        or resolved_workspace_name.get()
+        or settings.comet_workspace
+        or DEFAULT_WORKSPACE
+    )
+
+
+def project_page_url(settings: Settings, project_id: str, page: str) -> str | None:
+    """``<ui>/<workspace>/projects/<project_id>/<page>``, or ``None`` if unconfigured."""
+    base = opik_ui_base(settings)
+    if base is None:
+        return None
+    return f"{base}/{current_workspace(settings)}/projects/{project_id}/{page}"
+
+
+__all__ = ["current_workspace", "opik_ui_base", "project_page_url"]

--- a/src/opik_mcp/read_list/ui_links.py
+++ b/src/opik_mcp/read_list/ui_links.py
@@ -9,7 +9,12 @@ the derivation here means neither can drift from where REST calls go.
 
 from __future__ import annotations
 
-from opik_mcp.auth_context import inbound_workspace, resolved_workspace_name
+from opik_mcp.auth_context import (
+    classify_bearer,
+    inbound_authorization,
+    inbound_workspace,
+    resolved_workspace_name,
+)
 from opik_mcp.config import DEFAULT_WORKSPACE, Settings
 from opik_mcp.opik_client import opik_rest_base
 
@@ -42,12 +47,32 @@ def current_workspace(settings: Settings) -> str:
     )
 
 
-def project_page_url(settings: Settings, project_id: str, page: str) -> str | None:
-    """``<ui>/<workspace>/projects/<project_id>/<page>``, or ``None`` if unconfigured."""
-    base = opik_ui_base(settings)
-    if base is None:
+def link_workspace(settings: Settings) -> str | None:
+    """Workspace to build a **link** with, or ``None`` when it cannot be known.
+
+    Same precedence as :func:`current_workspace`, with one difference: under an
+    OAuth bearer the workspace is derived from the token server-side, so if
+    neither the inbound header nor introspection named it, the static settings
+    fallback would produce a link into the wrong workspace. The instructions
+    blob can afford a best-effort name; a link cannot.
+    """
+    known = inbound_workspace.get() or resolved_workspace_name.get()
+    if known:
+        return known
+    auth = inbound_authorization.get()
+    if auth and classify_bearer(auth)[0] == "oauth":
         return None
-    return f"{base}/{current_workspace(settings)}/projects/{project_id}/{page}"
+    return settings.comet_workspace or DEFAULT_WORKSPACE
 
 
-__all__ = ["current_workspace", "opik_ui_base", "project_page_url"]
+def project_page_url(settings: Settings, project_id: str, page: str) -> str | None:
+    """``<ui>/<workspace>/projects/<project_id>/<page>``, or ``None`` when the
+    UI base or the workspace cannot be known for this session."""
+    base = opik_ui_base(settings)
+    workspace = link_workspace(settings)
+    if base is None or workspace is None:
+        return None
+    return f"{base}/{workspace}/projects/{project_id}/{page}"
+
+
+__all__ = ["current_workspace", "link_workspace", "opik_ui_base", "project_page_url"]

--- a/src/opik_mcp/read_list/uri.py
+++ b/src/opik_mcp/read_list/uri.py
@@ -13,10 +13,13 @@ Recognized shapes (matching the deleted ``resources.py`` URI templates):
 - ``opik://experiments/{id}``               → ("experiment", id)
 - ``opik://prompts/{id}``                   → ("prompt", id)
 - ``opik://projects/{pid}/threads/{tid}``   → ("thread", tid, project_id=pid)
+- ``opik://projects/{pid}/agent-insights-issues/{iid}``
+                                            → ("agent_insights_issue", iid, project_id=pid)
 
-A pasted Opik web thread link (``https://…/projects/{pid}/…?thread={tid}``) is
-also recognized via ``looks_like_thread_url`` + ``parse`` so a user can drop a
-URL straight from the UI.
+Pasted Opik web links are also recognized via ``looks_like_opik_link`` +
+``parse`` so a user can drop a URL straight from the UI: a thread link
+(``https://…/projects/{pid}/…?thread={tid}``) and a Diagnostics link
+(``https://…/projects/{pid}/diagnostics…?issue={iid}``).
 
 List-shaped URIs (``opik://projects``, ``opik://projects/{id}/traces``,
 ``opik://test-suites/{id}/items``) are accepted only as best-effort hints
@@ -46,9 +49,9 @@ class ParsedURI(NamedTuple):
     entity_type: str
     entity_id: str
     project_id: str | None = None
-    """Set only for threads — a thread id is unique only within a project, so
-    the parser extracts the project from the URI/link and the read tool uses it
-    to scope the fetch. ``None`` for every other entity (globally-unique ids)."""
+    """Set for project-scoped entities (thread, agent_insights_issue) — the
+    parser extracts the project from the URI/link and the read tool uses it to
+    scope the fetch. ``None`` for every other entity (globally-unique ids)."""
 
 
 # Canonical singleton URI patterns. test-suites is hyphenated in the URI
@@ -66,13 +69,35 @@ _PATTERNS: list[tuple[re.Pattern[str], str]] = [
 # Threads carry a project id AND a thread id, so they need two capture groups —
 # handled ahead of the single-id ``_PATTERNS`` in ``parse``.
 _THREAD_URI_RE = re.compile(r"^opik://projects/([^/?#]+)/threads/([^/?#]+)$")
-# A pasted Opik web thread link: /projects/<projectId>/... with ?thread=<threadId>.
+# Same for Diagnostics issues: the backend wants project_id on the detail call.
+_ISSUE_URI_RE = re.compile(r"^opik://projects/([^/?#]+)/agent-insights-issues/([^/?#]+)$")
+# A pasted Opik web link: /projects/<projectId>/... with ?thread=<threadId>
+# (thread panel) or ?issue=<issueId> (Diagnostics page, open or resolved view).
 _WEB_PROJECT_RE = re.compile(r"/projects/([^/?#]+)")
 _WEB_THREAD_QS_RE = re.compile(r"[?&]thread=([^&#]+)")
+_WEB_ISSUE_QS_RE = re.compile(r"[?&]issue=([^&#]+)")
 
 
 def looks_like_uri(s: str) -> bool:
     return s.startswith("opik://")
+
+
+def looks_like_issue_url(s: str) -> bool:
+    """A pasted http(s) Diagnostics link — has a project path and an ``issue`` qs.
+
+    Same gate discipline as ``looks_like_thread_url``: the regexes here are the
+    ones ``parse`` extracts with, so passing the gate guarantees extraction.
+    """
+    return (
+        s.startswith(("http://", "https://"))
+        and _WEB_PROJECT_RE.search(s) is not None
+        and _WEB_ISSUE_QS_RE.search(s) is not None
+    )
+
+
+def looks_like_opik_link(s: str) -> bool:
+    """Any pasted Opik web link ``parse`` understands (thread or Diagnostics issue)."""
+    return looks_like_thread_url(s) or looks_like_issue_url(s)
 
 
 def looks_like_thread_url(s: str) -> bool:
@@ -116,12 +141,29 @@ def parse(uri: str) -> ParsedURI:
                 project_id=pm.group(1),
             )
 
+    # Diagnostics issues — canonical URI, then the pasted Diagnostics page link.
+    im = _ISSUE_URI_RE.match(uri)
+    if im is not None:
+        return ParsedURI(
+            entity_type="agent_insights_issue", entity_id=im.group(2), project_id=im.group(1)
+        )
+    if looks_like_issue_url(uri):
+        pm = _WEB_PROJECT_RE.search(uri)
+        qm = _WEB_ISSUE_QS_RE.search(uri)
+        if pm is not None and qm is not None:
+            return ParsedURI(
+                entity_type="agent_insights_issue",
+                entity_id=unquote(qm.group(1)),
+                project_id=pm.group(1),
+            )
+
     for pattern, entity_type in _PATTERNS:
         m = pattern.match(uri)
         if m is not None:
             return ParsedURI(entity_type=entity_type, entity_id=m.group(1))
     raise InvalidURI(
         f"URI {uri!r} starts with opik:// but matches no known entity shape. "
-        "Expected e.g. opik://traces/<uuid>, opik://projects/<uuid>, or "
-        "opik://projects/<projectId>/threads/<threadId>."
+        "Expected e.g. opik://traces/<uuid>, opik://projects/<uuid>, "
+        "opik://projects/<projectId>/threads/<threadId>, or "
+        "opik://projects/<projectId>/agent-insights-issues/<issueId>."
     )

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -3,7 +3,7 @@ import contextlib
 import logging
 import time
 from collections.abc import AsyncIterator
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
 import httpx
@@ -342,14 +342,13 @@ async def list_entities(
         Field(description="Required when listing prompt_versions. UUID of the prompt."),
     ] = None,
     status: Annotated[
-        str | None,
+        Literal["open", "resolved", "closed"] | None,
         Field(
             description=(
                 "agent_insights_issue only: which Diagnostics issues to list. "
                 "Defaults to 'open' (what is broken now); 'resolved' and 'closed' "
                 "show issues already dealt with. Ignored for other entity types."
             ),
-            json_schema_extra={"enum": ["open", "resolved", "closed"]},
         ),
     ] = None,
     from_date: Annotated[

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -51,7 +51,7 @@ from opik_mcp.instructions import render_instructions
 from opik_mcp.oauth_identity import introspect_oauth_token
 from opik_mcp.read_list import run_list, run_read
 from opik_mcp.read_list.registry import LISTABLE_TYPES, READABLE_TYPES
-from opik_mcp.read_list.uri import looks_like_thread_url
+from opik_mcp.read_list.uri import looks_like_opik_link
 from opik_mcp.skills_catalog import (
     SKILLS_URI_PREFIX,
     read_skill_tool_description,
@@ -88,7 +88,7 @@ def _looks_like_uuid(s: str) -> bool:
 
 def _read_props(_result: Any, kwargs: dict[str, Any]) -> dict[str, str]:
     raw_id = str(kwargs.get("id", ""))
-    if raw_id.startswith("opik://") or looks_like_thread_url(raw_id):
+    if raw_id.startswith("opik://") or looks_like_opik_link(raw_id):
         id_kind = "uri"
     elif _looks_like_uuid(raw_id):
         id_kind = "uuid"
@@ -184,9 +184,10 @@ async def read(
         Field(
             description=(
                 "UUID, entity name (for nameable types), full opik:// URI "
-                "(e.g. opik://traces/<uuid>), or a pasted Opik thread link. When "
-                "a URI/link is passed, entity_type (and, for threads, the project) "
-                "is overridden from it."
+                "(e.g. opik://traces/<uuid>), or a pasted Opik link — a thread "
+                "link or a Diagnostics page link (…/projects/<pid>/diagnostics"
+                "?issue=<id>). When a URI/link is passed, entity_type (and, for "
+                "project-scoped entities, the project) is overridden from it."
             ),
             min_length=1,
             max_length=2048,

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -268,7 +268,8 @@ async def read(
       trace_url_template} — the Diagnostics issue with cause and suggested fix,
       the deduped ids of traces that exhibit it (open one with read('trace', id)),
       the per-day breakdown, the issue's Diagnostics page link, and a template
-      for linking any example trace. Needs project scope like thread.
+      for linking any example trace (both links omitted when the Opik URL or
+      the session's workspace is unknown). Needs project scope like thread.
     - All others: the flat record from /v1/private/{entity}/{id}.
 
     Output is a one-line `[read: …]` header (entity_type, id, compression

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -286,8 +286,8 @@ async def list_entities(
         str | None,
         Field(
             description=(
-                "Parent project UUID for project-scoped lists (trace, thread). "
-                "Pass this OR project_name."
+                "Parent project UUID for project-scoped lists (trace, thread, "
+                "agent_insights_issue). Pass this OR project_name."
             )
         ),
     ] = None,
@@ -295,7 +295,7 @@ async def list_entities(
         str | None,
         Field(
             description=(
-                "Parent project name — alternative to project_id for trace/thread "
+                "Parent project name — alternative to project_id for project-scoped "
                 "lists, so you don't need to resolve the UUID first."
             ),
             max_length=200,
@@ -309,6 +309,39 @@ async def list_entities(
         str | None,
         Field(description="Required when listing prompt_versions. UUID of the prompt."),
     ] = None,
+    status: Annotated[
+        str | None,
+        Field(
+            description=(
+                "agent_insights_issue only: which Diagnostics issues to list. "
+                "Defaults to 'open' (what is broken now); 'resolved' and 'closed' "
+                "show issues already dealt with. Ignored for other entity types."
+            ),
+            json_schema_extra={"enum": ["open", "resolved", "closed"]},
+        ),
+    ] = None,
+    from_date: Annotated[
+        str | None,
+        Field(
+            description=(
+                "agent_insights_issue only: start of the aggregation window as an "
+                "ISO date (YYYY-MM-DD). Omit both dates for all-time counts, which "
+                "is what the Diagnostics page shows. Ignored for other entity types."
+            ),
+            pattern=r"^\d{4}-\d{2}-\d{2}$",
+        ),
+    ] = None,
+    to_date: Annotated[
+        str | None,
+        Field(
+            description=(
+                "agent_insights_issue only: end of the aggregation window as an ISO "
+                "date (YYYY-MM-DD), inclusive. Defaults to today. Ignored for other "
+                "entity types."
+            ),
+            pattern=r"^\d{4}-\d{2}-\d{2}$",
+        ),
+    ] = None,
     ctx: Context[ServerSession, None] | None = None,
 ) -> str:
     """List Opik entities with optional name filter and pagination.
@@ -320,6 +353,9 @@ async def list_entities(
     Project-scoped types require their parent:
     - trace: project_id or project_name
     - thread: project_id or project_name
+    - agent_insights_issue: project_id or project_name (Diagnostics issues,
+      open ones by default; columns: severity, status, total_occurrences,
+      latest_count, last_seen)
     - test_suite_item: test_suite_id
     - prompt_version: prompt_id
 
@@ -337,6 +373,9 @@ async def list_entities(
         project_name=project_name,
         test_suite_id=test_suite_id,
         prompt_id=prompt_id,
+        status=status,
+        from_date=from_date,
+        to_date=to_date,
     )
 
 

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -209,17 +209,42 @@ async def read(
         str | None,
         Field(
             description=(
-                "Project UUID. Required for entity_type='thread' unless the id is "
-                "a full thread URL/URI (which carries the project). Ignored for "
-                "globally-unique entities like trace/span."
+                "Project UUID. Required for entity_type='thread' and "
+                "'agent_insights_issue' unless the id is a full Opik URL/URI (which "
+                "carries the project). Ignored for globally-unique entities like "
+                "trace/span."
             ),
         ),
     ] = None,
     project_name: Annotated[
         str | None,
         Field(
-            description="Project name — alternative to project_id for thread reads.",
+            description=(
+                "Project name — alternative to project_id for project-scoped reads "
+                "(thread, agent_insights_issue)."
+            ),
             max_length=200,
+        ),
+    ] = None,
+    from_date: Annotated[
+        str | None,
+        Field(
+            description=(
+                "agent_insights_issue only: start of the window (ISO date, "
+                "YYYY-MM-DD) for the per-day details. Omit both dates for all-time, "
+                "matching the Diagnostics page. Ignored for other entity types."
+            ),
+            pattern=r"^\d{4}-\d{2}-\d{2}$",
+        ),
+    ] = None,
+    to_date: Annotated[
+        str | None,
+        Field(
+            description=(
+                "agent_insights_issue only: end of the window (ISO date, YYYY-MM-DD), "
+                "inclusive. Defaults to today. Ignored for other entity types."
+            ),
+            pattern=r"^\d{4}-\d{2}-\d{2}$",
         ),
     ] = None,
     ctx: Context[ServerSession, None] | None = None,
@@ -238,6 +263,10 @@ async def read(
     - thread: returns {thread, messages, messagesTruncated} — each message is one
       turn's trace input/output + a trace_id to read('trace', id). Needs project
       scope: pass a thread link/URI, or project_id/project_name.
+    - agent_insights_issue: returns {issue, example_trace_ids, details} — the
+      Diagnostics issue with cause and suggested fix, the deduped ids of traces
+      that exhibit it (open one with read('trace', id)), and the per-day
+      breakdown. Needs project scope like thread.
     - All others: the flat record from /v1/private/{entity}/{id}.
 
     Output is a one-line `[read: …]` header (entity_type, id, compression
@@ -251,6 +280,8 @@ async def read(
         max_tokens=max_tokens,
         project_id=project_id,
         project_name=project_name,
+        from_date=from_date,
+        to_date=to_date,
     )
 
 

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -264,10 +264,11 @@ async def read(
     - thread: returns {thread, messages, messagesTruncated} — each message is one
       turn's trace input/output + a trace_id to read('trace', id). Needs project
       scope: pass a thread link/URI, or project_id/project_name.
-    - agent_insights_issue: returns {issue, example_trace_ids, details} — the
-      Diagnostics issue with cause and suggested fix, the deduped ids of traces
-      that exhibit it (open one with read('trace', id)), and the per-day
-      breakdown. Needs project scope like thread.
+    - agent_insights_issue: returns {issue, example_trace_ids, details, url,
+      trace_url_template} — the Diagnostics issue with cause and suggested fix,
+      the deduped ids of traces that exhibit it (open one with read('trace', id)),
+      the per-day breakdown, the issue's Diagnostics page link, and a template
+      for linking any example trace. Needs project scope like thread.
     - All others: the flat record from /v1/private/{entity}/{id}.
 
     Output is a one-line `[read: …]` header (entity_type, id, compression

--- a/src/opik_mcp/skills/opik-diagnose/SKILL.md
+++ b/src/opik_mcp/skills/opik-diagnose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opik-diagnose
-description: Surface the Opik traces worth a developer's attention, ranked by signal — errors, failed tool calls, latency, regressions, and low online-eval scores — plus Diagnostics issues. Reads live/production traces via the SDK (search_traces and agent_insights) and works with no MCP; uses the MCP issue entity when connected. Returns a ranked shortlist, each item ready to hand to the explain skill. Use for "what is broken in production", "which traces need attention", "find failing or slow traces", "which tool calls are failing", "triage my agent". Not for offline experiment results (use evaluate or compare) and not for root-causing one trace (use explain).
+description: Surface the Opik traces worth a developer's attention, ranked by signal — Diagnostics issues first, then errors, failed tool calls, latency, regressions, and low online-eval scores. With the Opik MCP connected it lists the project's agent_insights_issue entities before scanning raw traces; without the MCP it reads the same via the SDK (agent_insights and search_traces). Returns a ranked shortlist, each item ready to hand to the explain skill. Use for "what is broken in production", "which traces need attention", "find failing or slow traces", "which tool calls are failing", "triage my agent". Not for offline experiment results (use evaluate or compare) and not for root-causing one trace (use explain).
 compatibility: Tested with Claude Code; works with any Agent Skills-compatible host (Cursor, VS Code Copilot, Codex). Requires a Python or TypeScript project with Opik configured and a project that has traces. Install the `opik` skill alongside this one — it holds the shared SDK and observability references; without it, this skill falls back to the public docs.
 allowed-tools:
   - Read
@@ -8,7 +8,7 @@ allowed-tools:
   - Glob
   - Bash
 metadata:
-  last_updated: "2026-08-24"
+  last_updated: "2026-09-08"
   source_commit: "2.0.0"
   argument-hint: "[optional: project name, or what to look for]"
 ---
@@ -32,38 +32,49 @@ Ask only at a genuine, non-inferable blocker (see **Blockers**).
 ### 1. Resolve scope
 Project (from config/repo) + a recent window. Confirm Opik is reachable: if `~/.opik.config` exists or `OPIK_API_KEY` is set, use it. Otherwise → **Blocker** ("run `opik configure`, then rerun").
 
-### 2. Pull candidate traces (SDK-first)
-The SDK is the primary path and needs no MCP.
+### 2. Start from Diagnostics issues
+Opik's Diagnostics already groups a project's recurring failures into ranked issues, each with a severity, occurrence counts, a cause, a suggested fix and example traces. Read that list first — it is the answer to "what is broken" the UI already computed, so do not rebuild it from raw traces.
+
+**With the Opik MCP connected**, the `agent_insights_issue` entity is the primary path:
+
+```text
+list('agent_insights_issue', project_name='<project>')        # open issues, ranked as the Diagnostics page ranks them
+read('agent_insights_issue', '<issue id>', project_name='<project>')
+#  → {issue: {name, cause, suggested_fix, severity, status, …}, example_trace_ids: [...], details: [...]}
+```
+
+Each open issue becomes one shortlist item with `signal=diagnostics`: `trace_id` / `trace_url` come from the first `example_trace_ids` entry (read the top few issues to get them), `why` carries the issue name, `latest_count` and the cause. Rank critical/high severity above the rest; within a severity, most recently seen first (that is the list's order). Counts are all-time to match the UI; pass `from_date` to narrow to the window.
+
+**Without the MCP**, the SDK REST client reads the same issues:
 
 ```python
 import opik
 client = opik.Opik()
+# Needs the project_id (a uuid), not the name — read it off any trace from
+# search_traces (trace.project_id), or resolve it from the project name first.
+issues = client.rest_client.agent_insights.find_agent_insights_issues(project_id=project_id)
+```
 
+### 3. Pull candidate traces to fill the gaps (SDK)
+Diagnostics reports what its last run grouped. Anything newer, or below its grouping threshold — a single latency outlier, one low online-eval score, a regression versus the prior window — still needs the raw scan:
+
+```python
 traces = client.search_traces(project_name="<project>", max_results=200)  # recent window
-# Narrow server-side first when the volume is large; otherwise rank client-side (step 3).
+# Narrow server-side first when the volume is large; otherwise rank client-side (step 4).
 # Each trace carries the fields you rank on: error info, duration, feedback_scores.
 ```
 
-### 3. Rank by signal
-Score each candidate and keep the top few. Priority order:
+Skip traces already covered by an issue's `example_trace_ids`; they are on the shortlist under that issue.
+
+### 4. Rank the remaining traces by signal
+Score each remaining candidate and keep the top few. Priority order:
 1. **Errored** — the trace or a span captured an exception.
 2. **Tool-call failures** — a `tool` span errored, returned an error-shaped result, or repeated the same call (a retry loop). Agents fail here often, so surface it as its own signal: use `has_tool_spans` to find candidates, then scan their `tool` spans for a non-empty error, an output that reads like an error/refusal, or duplicate consecutive calls.
 3. **Latency outliers** — duration well above the project's typical (use the p90/p99 as the bar).
 4. **Low online-eval score** — a feedback score below its threshold (Answer Relevance, Hallucination, etc.).
 5. **Regressions** — a signal that worsened versus the prior window.
 
-Give each shortlisted item the one signal that flagged it and a short why. Prefer a short, ranked list over a long one.
-
-### 4. Surface Diagnostics issues
-Opik's Diagnostics groups recurring problems into issues. Read them via the SDK REST client (no MCP required):
-
-```python
-# Needs the project_id (a uuid), not the name — read it off any trace from
-# search_traces (trace.project_id), or resolve it from the project name first.
-issues = client.rest_client.agent_insights.find_agent_insights_issues(project_id=project_id)
-```
-
-When the hosted MCP is connected, the `issue` entity is an equivalent path — a convenience, not a requirement. Merge issues into the shortlist, deduped against the traces you already ranked.
+Merge these under the Diagnostics items: an open critical/high issue outranks a lone errored trace, a lone error outranks a low/medium issue with one occurrence. Give each shortlisted item the one signal that flagged it and a short why. Prefer a short, ranked list over a long one.
 
 ### 5. Stay in scope
 Online/production **trace** signal only. Do **not** surface offline experiment results — those are the output of `/opik-evaluate` and `/opik-compare`, not rediscovered here.
@@ -93,14 +104,16 @@ Invariants: `found` carries a non-empty `shortlist`, each item with a `signal`, 
 
 ## Examples
 
-**Triage a project.** `/opik-diagnose`. `search_traces` on the project; two traces errored, one is 5x the p90 duration, one scored 0.2 on Hallucination. Shortlist = the two errors (rank 1-2), the latency outlier (3), the low-score trace (4), each with its signal; next step = "explain the top trace". → **`found`**.
+**Triage a project, MCP connected.** `/opik-diagnose`. `list('agent_insights_issue', project_name=…)` returns two open issues: a high-severity tool-call loop (12 occurrences yesterday) and a low-severity empty-answer issue. `read` on the first gives the cause and three example trace ids. `search_traces` then finds one trace 5x the p90 that no issue covers. Shortlist = the tool-call loop (rank 1, `diagnostics`, first example trace), the latency outlier (2, `latency`), the empty-answer issue (3, `diagnostics`); next step = "explain the top trace". `source=mcp`. → **`found`**.
+
+**Triage a project, SDK only.** `/opik-diagnose`. `find_agent_insights_issues` returns nothing yet; `search_traces` on the project finds two errored traces, one 5x the p90 duration, one scored 0.2 on Hallucination. Shortlist = the two errors (rank 1-2), the latency outlier (3), the low-score trace (4), each with its signal; next step = "explain the top trace". `source=sdk`. → **`found`**.
 
 **Nothing wrong.** `/opik-diagnose`. Reads fine, but no trace errored, ran slow, or scored low. → **`empty`**: "No traces crossed a threshold in the recent window."
 
 **Blocked — no config.** `/opik-diagnose`. No `~/.opik.config`, no `OPIK_API_KEY`. → **`blocked`**: "run `opik configure`, then rerun `/opik-diagnose`." (No code touched.)
 
 ## Anti-patterns
-Dumping every trace instead of a ranked shortlist; surfacing offline experiment/`evaluate` results (out of scope); requiring the MCP (the SDK `agent_insights` path needs none); root-causing a trace here (hand it to `/opik-explain`); **editing code** (this skill only surfaces); ranking by recency instead of signal.
+Dumping every trace instead of a ranked shortlist; rebuilding the Diagnostics ranking from raw traces when `agent_insights_issue` (or the SDK `agent_insights` client) already lists the issues; surfacing offline experiment/`evaluate` results (out of scope); requiring the MCP (the SDK `agent_insights` path needs none); root-causing a trace here (hand it to `/opik-explain`); **editing code** (this skill only surfaces); ranking by recency instead of signal.
 
 ## References
 

--- a/src/opik_mcp/skills/opik-diagnose/SKILL.md
+++ b/src/opik_mcp/skills/opik-diagnose/SKILL.md
@@ -43,7 +43,7 @@ read('agent_insights_issue', '<issue id>', project_name='<project>')
 #  → {issue: {name, cause, suggested_fix, severity, status, …}, example_trace_ids: [...], details: [...]}
 ```
 
-Each open issue becomes one shortlist item with `signal=diagnostics`: `trace_id` / `trace_url` come from the first `example_trace_ids` entry (read the top few issues to get them), `why` carries the issue name, `latest_count` and the cause. Rank critical/high severity above the rest; within a severity, most recently seen first (that is the list's order). Counts are all-time to match the UI; pass `from_date` to narrow to the window.
+Each open issue becomes one shortlist item with `signal=diagnostics`: `trace_id` / `trace_url` come from the first `example_trace_ids` entry (read the top few issues to get them), `why` carries the issue name, severity, `latest_count` and the cause. Keep the list's order — it is the Diagnostics page's ranking (most recently seen first, then most occurrences). Counts are all-time to match the UI; pass `from_date` to narrow to the window.
 
 **Without the MCP**, the SDK REST client reads the same issues:
 
@@ -74,7 +74,7 @@ Score each remaining candidate and keep the top few. Priority order:
 4. **Low online-eval score** — a feedback score below its threshold (Answer Relevance, Hallucination, etc.).
 5. **Regressions** — a signal that worsened versus the prior window.
 
-Merge these under the Diagnostics items: an open critical/high issue outranks a lone errored trace, a lone error outranks a low/medium issue with one occurrence. Give each shortlisted item the one signal that flagged it and a short why. Prefer a short, ranked list over a long one.
+Append these after the Diagnostics items, in the signal order above. Give each shortlisted item the one signal that flagged it and a short why. Prefer a short, ranked list over a long one.
 
 ### 5. Stay in scope
 Online/production **trace** signal only. Do **not** surface offline experiment results — those are the output of `/opik-evaluate` and `/opik-compare`, not rediscovered here.

--- a/src/opik_mcp/skills/opik-diagnose/SKILL.md
+++ b/src/opik_mcp/skills/opik-diagnose/SKILL.md
@@ -40,10 +40,11 @@ Opik's Diagnostics already groups a project's recurring failures into ranked iss
 ```text
 list('agent_insights_issue', project_name='<project>')        # open issues, ranked as the Diagnostics page ranks them
 read('agent_insights_issue', '<issue id>', project_name='<project>')
-#  → {issue: {name, cause, suggested_fix, severity, status, …}, example_trace_ids: [...], details: [...]}
+#  → {issue: {name, cause, suggested_fix, severity, status, …}, example_trace_ids: [...], details: [...],
+#     url: '<the issue's Diagnostics page>', trace_url_template: '<…/logs?trace={trace_id}>'}
 ```
 
-Each open issue becomes one shortlist item with `signal=diagnostics`: `trace_id` / `trace_url` come from the first `example_trace_ids` entry (read the top few issues to get them), `why` carries the issue name, severity, `latest_count` and the cause. Keep the list's order — it is the Diagnostics page's ranking (most recently seen first, then most occurrences). Counts are all-time to match the UI; pass `from_date` to narrow to the window.
+Each open issue becomes one shortlist item with `signal=diagnostics`: `trace_id` comes from the first `example_trace_ids` entry (read the top few issues to get them) and `trace_url` from `trace_url_template` with that id filled in; mention the issue's `url` so the user can open the Diagnostics page itself. `why` carries the issue name, severity, `latest_count` and the cause. The link fields are absent when the server cannot name the UI base or workspace — fall back to the trace redirect URL then. Keep the list's order — it is the Diagnostics page's ranking (most recently seen first, then most occurrences). Counts are all-time to match the UI; pass `from_date` to narrow to the window.
 
 **Without the MCP**, the SDK REST client reads the same issues:
 

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -103,6 +103,11 @@
     "status": {
       "anyOf": [
         {
+          "enum": [
+            "open",
+            "resolved",
+            "closed"
+          ],
           "type": "string"
         },
         {
@@ -111,11 +116,6 @@
       ],
       "default": null,
       "description": "agent_insights_issue only: which Diagnostics issues to list. Defaults to 'open' (what is broken now); 'resolved' and 'closed' show issues already dealt with. Ignored for other entity types.",
-      "enum": [
-        "open",
-        "resolved",
-        "closed"
-      ],
       "title": "Status"
     },
     "test_suite_id": {

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -1,8 +1,9 @@
 {
   "properties": {
     "entity_type": {
-      "description": "One of: experiment, project, prompt, prompt_version, test_suite, test_suite_item, thread, trace.",
+      "description": "One of: agent_insights_issue, experiment, project, prompt, prompt_version, test_suite, test_suite_item, thread, trace.",
       "enum": [
+        "agent_insights_issue",
         "experiment",
         "project",
         "prompt",
@@ -14,6 +15,20 @@
       ],
       "title": "Entity Type",
       "type": "string"
+    },
+    "from_date": {
+      "anyOf": [
+        {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "agent_insights_issue only: start of the aggregation window as an ISO date (YYYY-MM-DD). Omit both dates for all-time counts, which is what the Diagnostics page shows. Ignored for other entity types.",
+      "title": "From Date"
     },
     "name": {
       "anyOf": [
@@ -47,7 +62,7 @@
         }
       ],
       "default": null,
-      "description": "Parent project UUID for project-scoped lists (trace, thread). Pass this OR project_name.",
+      "description": "Parent project UUID for project-scoped lists (trace, thread, agent_insights_issue). Pass this OR project_name.",
       "title": "Project Id"
     },
     "project_name": {
@@ -61,7 +76,7 @@
         }
       ],
       "default": null,
-      "description": "Parent project name \u2014 alternative to project_id for trace/thread lists, so you don't need to resolve the UUID first.",
+      "description": "Parent project name \u2014 alternative to project_id for project-scoped lists, so you don't need to resolve the UUID first.",
       "title": "Project Name"
     },
     "prompt_id": {
@@ -85,6 +100,24 @@
       "title": "Size",
       "type": "integer"
     },
+    "status": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "agent_insights_issue only: which Diagnostics issues to list. Defaults to 'open' (what is broken now); 'resolved' and 'closed' show issues already dealt with. Ignored for other entity types.",
+      "enum": [
+        "open",
+        "resolved",
+        "closed"
+      ],
+      "title": "Status"
+    },
     "test_suite_id": {
       "anyOf": [
         {
@@ -97,6 +130,20 @@
       "default": null,
       "description": "Required when listing test_suite_items. UUID of the suite.",
       "title": "Test Suite Id"
+    },
+    "to_date": {
+      "anyOf": [
+        {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "agent_insights_issue only: end of the aggregation window as an ISO date (YYYY-MM-DD), inclusive. Defaults to today. Ignored for other entity types.",
+      "title": "To Date"
     }
   },
   "required": [

--- a/tests/conformance/snapshots/read.json
+++ b/tests/conformance/snapshots/read.json
@@ -1,8 +1,9 @@
 {
   "properties": {
     "entity_type": {
-      "description": "One of: experiment, project, prompt, span, test_suite, thread, trace.",
+      "description": "One of: agent_insights_issue, experiment, project, prompt, span, test_suite, thread, trace.",
       "enum": [
+        "agent_insights_issue",
         "experiment",
         "project",
         "prompt",
@@ -13,6 +14,20 @@
       ],
       "title": "Entity Type",
       "type": "string"
+    },
+    "from_date": {
+      "anyOf": [
+        {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "agent_insights_issue only: start of the window (ISO date, YYYY-MM-DD) for the per-day details. Omit both dates for all-time, matching the Diagnostics page. Ignored for other entity types.",
+      "title": "From Date"
     },
     "id": {
       "description": "UUID, entity name (for nameable types), full opik:// URI (e.g. opik://traces/<uuid>), or a pasted Opik thread link. When a URI/link is passed, entity_type (and, for threads, the project) is overridden from it.",
@@ -46,7 +61,7 @@
         }
       ],
       "default": null,
-      "description": "Project UUID. Required for entity_type='thread' unless the id is a full thread URL/URI (which carries the project). Ignored for globally-unique entities like trace/span.",
+      "description": "Project UUID. Required for entity_type='thread' and 'agent_insights_issue' unless the id is a full Opik URL/URI (which carries the project). Ignored for globally-unique entities like trace/span.",
       "title": "Project Id"
     },
     "project_name": {
@@ -60,8 +75,22 @@
         }
       ],
       "default": null,
-      "description": "Project name \u2014 alternative to project_id for thread reads.",
+      "description": "Project name \u2014 alternative to project_id for project-scoped reads (thread, agent_insights_issue).",
       "title": "Project Name"
+    },
+    "to_date": {
+      "anyOf": [
+        {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "agent_insights_issue only: end of the window (ISO date, YYYY-MM-DD), inclusive. Defaults to today. Ignored for other entity types.",
+      "title": "To Date"
     }
   },
   "required": [

--- a/tests/conformance/snapshots/read.json
+++ b/tests/conformance/snapshots/read.json
@@ -30,7 +30,7 @@
       "title": "From Date"
     },
     "id": {
-      "description": "UUID, entity name (for nameable types), full opik:// URI (e.g. opik://traces/<uuid>), or a pasted Opik thread link. When a URI/link is passed, entity_type (and, for threads, the project) is overridden from it.",
+      "description": "UUID, entity name (for nameable types), full opik:// URI (e.g. opik://traces/<uuid>), or a pasted Opik link \u2014 a thread link or a Diagnostics page link (\u2026/projects/<pid>/diagnostics?issue=<id>). When a URI/link is passed, entity_type (and, for project-scoped entities, the project) is overridden from it.",
       "maxLength": 2048,
       "minLength": 1,
       "title": "Id",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     _reset_seen_tools_listed_for_tests()
     transport_probe.reset_for_tests()
     reset_identities_for_tests()
+    reset_project_cache_for_tests()
     os.environ.pop(LIFECYCLE_SENTINEL, None)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
         _reset_seen_tools_listed_for_tests,
     )
     from opik_mcp.credential_identity import reset_identities_for_tests
+    from opik_mcp.read_list.project_scope import reset_project_cache_for_tests
 
     reset_analytics_for_tests()
     _reset_seen_sessions_for_tests()
@@ -62,6 +63,10 @@ def _reset_analytics_wrappers_state() -> Generator[None]:
     transport_probe.reset_for_tests()
     reset_identities_for_tests()
     _reset_detector_caches_for_tests()
+    # The project-name → id cache is process-wide and keyed by client config;
+    # test fakes carry no config, so without a reset one test's resolution
+    # would satisfy the next test's lookup.
+    reset_project_cache_for_tests()
     # main() sets this sentinel so the build_app() lifespan skips its own emit.
     # Clear it between tests or a test that calls main() leaves the build_app()
     # lifespan (e.g. the session http_client fixture) permanently muted.

--- a/tests/test_opik_client_read.py
+++ b/tests/test_opik_client_read.py
@@ -170,6 +170,59 @@ async def test_get_thread_maps_404_to_not_found() -> None:
             await _client().get_thread("th-1", project_id="p-1")
 
 
+# --- agent insights (Diagnostics) issues --------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_list_agent_insights_issues_hits_project_scoped_path() -> None:
+    payload = _page([{"id": "is-1", "name": "Tool loop"}], total=1)
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get("/v1/private/agent-insights/issues").mock(
+            return_value=httpx.Response(200, json=payload),
+        )
+        body = await _client().list_agent_insights_issues(project_id="p-1", page=2, size=25)
+    params = dict(route.calls.last.request.url.params)
+    assert params == {"project_id": "p-1", "page": "2", "size": "25"}
+    assert body == payload
+
+
+@pytest.mark.anyio
+async def test_list_agent_insights_issues_forwards_filters_only_when_set() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get("/v1/private/agent-insights/issues").mock(
+            return_value=httpx.Response(200, json=_page([])),
+        )
+        await _client().list_agent_insights_issues(
+            project_id="p-1",
+            status="resolved",
+            from_date="2026-09-01",
+            to_date="2026-09-08",
+        )
+    params = dict(route.calls.last.request.url.params)
+    assert params == {
+        "project_id": "p-1",
+        "status": "resolved",
+        "from_date": "2026-09-01",
+        "to_date": "2026-09-08",
+        "page": "1",
+        "size": "10",
+    }
+
+
+@pytest.mark.anyio
+async def test_list_agent_insights_issues_maps_400_to_validation_error() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get("/v1/private/agent-insights/issues").mock(
+            return_value=httpx.Response(
+                400, json={"errors": ["Parameter 'from_date' must not be after 'to_date'"]}
+            ),
+        )
+        with pytest.raises(OpikValidationError, match="from_date"):
+            await _client().list_agent_insights_issues(
+                project_id="p-1", from_date="2026-09-09", to_date="2026-09-01"
+            )
+
+
 @pytest.mark.anyio
 async def test_list_spans_requires_project_id_or_name() -> None:
     """opik-backend rejects ``GET /spans`` without a project filter (400)."""

--- a/tests/test_opik_client_read.py
+++ b/tests/test_opik_client_read.py
@@ -210,6 +210,42 @@ async def test_list_agent_insights_issues_forwards_filters_only_when_set() -> No
 
 
 @pytest.mark.anyio
+async def test_get_agent_insights_issue_hits_singleton_path_with_project() -> None:
+    payload = {"id": "is-1", "name": "Tool loop", "details": []}
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get("/v1/private/agent-insights/issues/is-1").mock(
+            return_value=httpx.Response(200, json=payload),
+        )
+        body = await _client().get_agent_insights_issue("is-1", project_id="p-1")
+    params = dict(route.calls.last.request.url.params)
+    assert params == {"project_id": "p-1"}
+    assert body == payload
+
+
+@pytest.mark.anyio
+async def test_get_agent_insights_issue_forwards_window_when_set() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get("/v1/private/agent-insights/issues/is-1").mock(
+            return_value=httpx.Response(200, json={"id": "is-1", "details": []}),
+        )
+        await _client().get_agent_insights_issue(
+            "is-1", project_id="p-1", from_date="2026-09-01", to_date="2026-09-08"
+        )
+    params = dict(route.calls.last.request.url.params)
+    assert params == {"project_id": "p-1", "from_date": "2026-09-01", "to_date": "2026-09-08"}
+
+
+@pytest.mark.anyio
+async def test_get_agent_insights_issue_maps_404_to_not_found() -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        mock.get("/v1/private/agent-insights/issues/is-x").mock(
+            return_value=httpx.Response(404, json={"message": "nope"}),
+        )
+        with pytest.raises(OpikNotFoundError, match="is-x"):
+            await _client().get_agent_insights_issue("is-x", project_id="p-1")
+
+
+@pytest.mark.anyio
 async def test_list_agent_insights_issues_maps_400_to_validation_error() -> None:
     with respx.mock(base_url=OPIK_BASE) as mock:
         mock.get("/v1/private/agent-insights/issues").mock(

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -36,6 +36,11 @@ class FakeOpikClient:
 
     project_lookups: int = 0
     fail_issues_with: Exception | None = None
+    # Credential identity the project-name cache keys on; None mimics a fake
+    # with no config, as every other test here has.
+    _base_url: str | None = None
+    _workspace: str | None = None
+    _api_key: str | None = None
 
     async def list_agent_insights_issues(self, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = kw
@@ -474,6 +479,36 @@ async def test_list_issues_project_name_resolved_once_per_process() -> None:
     await run_list("agent_insights_issue", project_name="demo", status="resolved", client=fake)
     assert fake.project_lookups == 1
     assert fake.last_kwargs.get("project_id") == "p-demo"
+
+
+@pytest.mark.anyio
+async def test_list_issues_project_name_cache_is_per_credential() -> None:
+    """Hosted OAuth passthrough: one process, many bearers, and the client's
+    workspace may be unknown (it lives server-side). Two tenants asking for
+    the same project name must never share a resolved id."""
+    tenant_a = FakeOpikClient(projects={"content": [{"id": "p-a", "name": "demo"}], "total": 1})
+    tenant_a._base_url = "https://opik.test/api"
+    tenant_a._workspace = None
+    tenant_a._api_key = "Bearer opik_mcp_at_aaa"
+    tenant_b = FakeOpikClient(projects={"content": [{"id": "p-b", "name": "demo"}], "total": 1})
+    tenant_b._base_url = "https://opik.test/api"
+    tenant_b._workspace = None
+    tenant_b._api_key = "Bearer opik_mcp_at_bbb"
+
+    await run_list("agent_insights_issue", project_name="demo", client=tenant_a)
+    await run_list("agent_insights_issue", project_name="demo", client=tenant_b)
+    assert tenant_a.last_kwargs.get("project_id") == "p-a"
+    assert tenant_b.last_kwargs.get("project_id") == "p-b"
+    assert tenant_b.project_lookups == 1
+
+    # Same credential again: served from the cache.
+    same_as_a = FakeOpikClient(projects={"content": [], "total": 0})
+    same_as_a._base_url = "https://opik.test/api"
+    same_as_a._workspace = None
+    same_as_a._api_key = "Bearer opik_mcp_at_aaa"
+    await run_list("agent_insights_issue", project_name="demo", client=same_as_a)
+    assert same_as_a.project_lookups == 0
+    assert same_as_a.last_kwargs.get("project_id") == "p-a"
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -462,6 +462,47 @@ async def test_list_issues_resolves_exact_project_name_to_id() -> None:
 
 
 @pytest.mark.anyio
+async def test_list_issues_resolves_project_name_case_insensitively_like_the_backend() -> None:
+    """list('trace', project_name='Support-Agent-Demo') succeeds because the
+    backend matches project names case-insensitively; the same argument on the
+    issue entity must not fail. Exact case still wins when both exist."""
+    fake = FakeOpikClient(
+        projects={"content": [{"id": "p-demo", "name": "support-agent-demo"}], "total": 1},
+        issues={"content": [ISSUE_ROW], "total": 1},
+    )
+    out = await run_list("agent_insights_issue", project_name="Support-Agent-Demo", client=fake)
+    assert "is-1" in out
+    assert fake.last_kwargs.get("project_id") == "p-demo"
+
+
+@pytest.mark.anyio
+async def test_list_issues_exact_case_beats_case_insensitive_match() -> None:
+    fake = FakeOpikClient(
+        projects={
+            "content": [{"id": "p-upper", "name": "Demo"}, {"id": "p-lower", "name": "demo"}],
+            "total": 2,
+        }
+    )
+    await run_list("agent_insights_issue", project_name="demo", client=fake)
+    assert fake.last_kwargs.get("project_id") == "p-lower"
+
+
+@pytest.mark.anyio
+async def test_list_issues_ambiguous_case_insensitive_match_lists_candidates() -> None:
+    fake = FakeOpikClient(
+        projects={
+            "content": [{"id": "p-upper", "name": "Demo"}, {"id": "p-lower", "name": "demo"}],
+            "total": 2,
+        }
+    )
+    with pytest.raises(ToolError) as exc:
+        await run_list("agent_insights_issue", project_name="DEMO", client=fake)
+    msg = str(exc.value)
+    assert "p-upper" in msg and "p-lower" in msg
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
 async def test_list_issues_ambiguous_project_name_lists_candidates() -> None:
     fake = FakeOpikClient(
         projects={

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -29,8 +29,13 @@ class FakeOpikClient:
     test_suite_items: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
     prompt_versions: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
     threads: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
+    issues: dict[str, Any] = field(default_factory=lambda: {"content": [], "total": 0})
 
     last_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    async def list_agent_insights_issues(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.issues
 
     async def list_projects(self, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = kw
@@ -276,6 +281,98 @@ async def test_list_forwards_only_kwargs_the_entity_declares() -> None:
     )
     assert "p-1" in out
     assert set(fake.last_kwargs) == {"page", "size"}
+
+
+# --- agent_insights_issue (Diagnostics) ---------------------------------- #
+
+ISSUE_ROW = {
+    "id": "is-1",
+    "name": "Tool call loop on weather lookup",
+    "severity": "high",
+    "status": "open",
+    "total_occurrences": 300,
+    "latest_count": 12,
+    "last_seen": "2026-09-07",
+    "cause": "The agent retries the same tool call when the API times out.",
+    "suggested_fix": "Cap retries at 2.",
+}
+
+
+@pytest.mark.anyio
+async def test_list_issues_renders_diagnostics_columns_in_backend_order() -> None:
+    second = {**ISSUE_ROW, "id": "is-2", "name": "Empty answer", "severity": "low"}
+    fake = FakeOpikClient(issues={"content": [ISSUE_ROW, second], "total": 2})
+    out = await run_list("agent_insights_issue", project_id="p-1", client=fake)
+    lines = out.splitlines()
+    first = "is-1 | Tool call loop on weather lookup | high | open | 300 | 12 | 2026-09-07"
+    second_row = "is-2 | Empty answer | low | open | 300 | 12 | 2026-09-07"
+    assert "id | name | severity | status | total_occurrences | latest_count | last_seen" in lines
+    assert first in lines
+    assert lines.index(first) < lines.index(second_row)
+    # Long prose stays out of the table — that is what read() is for.
+    assert "Cap retries" not in out
+    assert fake.last_kwargs.get("project_id") == "p-1"
+    assert "sorting" not in fake.last_kwargs
+
+
+@pytest.mark.anyio
+async def test_list_issues_defaults_to_open_status() -> None:
+    fake = FakeOpikClient()
+    await run_list("agent_insights_issue", project_id="p-1", client=fake)
+    assert fake.last_kwargs.get("status") == "open"
+
+
+@pytest.mark.anyio
+async def test_list_issues_forwards_explicit_status() -> None:
+    fake = FakeOpikClient()
+    await run_list("agent_insights_issue", project_id="p-1", status="resolved", client=fake)
+    assert fake.last_kwargs.get("status") == "resolved"
+
+
+@pytest.mark.anyio
+async def test_list_issues_forwards_window_only_when_given() -> None:
+    fake = FakeOpikClient()
+    await run_list("agent_insights_issue", project_id="p-1", client=fake)
+    assert "from_date" not in fake.last_kwargs
+    assert "to_date" not in fake.last_kwargs
+
+    await run_list(
+        "agent_insights_issue",
+        project_id="p-1",
+        from_date="2026-09-01",
+        to_date="2026-09-08",
+        client=fake,
+    )
+    assert fake.last_kwargs.get("from_date") == "2026-09-01"
+    assert fake.last_kwargs.get("to_date") == "2026-09-08"
+
+
+@pytest.mark.anyio
+async def test_list_issues_requires_project_scope() -> None:
+    with pytest.raises(ToolError, match=r"requires project_id \(or project_name\)"):
+        await run_list("agent_insights_issue", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_list_issues_ignores_name_filter() -> None:
+    fake = FakeOpikClient()
+    await run_list("agent_insights_issue", project_id="p-1", name="loop", client=fake)
+    assert "name" not in fake.last_kwargs
+
+
+@pytest.mark.anyio
+async def test_list_issue_filters_not_forwarded_to_other_entities() -> None:
+    fake = FakeOpikClient(projects={"content": [{"id": "p-1", "name": "a"}], "total": 1})
+    await run_list(
+        "project", status="resolved", from_date="2026-09-01", to_date="2026-09-08", client=fake
+    )
+    assert set(fake.last_kwargs) == {"page", "size"}
+
+
+@pytest.mark.anyio
+async def test_list_issues_empty_state() -> None:
+    out = await run_list("agent_insights_issue", project_id="p-1", client=FakeOpikClient())
+    assert "No agent_insights_issues found" in out
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
+from opik_mcp.opik_client import OpikValidationError
 from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.list_tool import run_list
 
@@ -34,9 +35,12 @@ class FakeOpikClient:
     last_kwargs: dict[str, Any] = field(default_factory=dict)
 
     project_lookups: int = 0
+    fail_issues_with: Exception | None = None
 
     async def list_agent_insights_issues(self, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = kw
+        if self.fail_issues_with is not None:
+            raise self.fail_issues_with
         return self.issues
 
     async def list_projects(self, **kw: Any) -> dict[str, Any]:
@@ -370,6 +374,39 @@ async def test_list_issue_filters_not_forwarded_to_other_entities() -> None:
         "project", status="resolved", from_date="2026-09-01", to_date="2026-09-08", client=fake
     )
     assert set(fake.last_kwargs) == {"page", "size"}
+
+
+@pytest.mark.anyio
+async def test_list_issues_bad_window_surfaces_backend_validation_message() -> None:
+    fake = FakeOpikClient(
+        fail_issues_with=OpikValidationError(
+            "Opik rejected the request body (400) for agent insights issues — "
+            "Parameter 'from_date' must not be after 'to_date'"
+        )
+    )
+    with pytest.raises(ToolError) as exc:
+        await run_list(
+            "agent_insights_issue",
+            project_id="p-1",
+            from_date="2026-09-09",
+            to_date="2026-09-01",
+            client=fake,
+        )
+    assert "from_date" in str(exc.value)
+    assert isinstance(exc.value.__cause__, OpikValidationError)
+
+
+@pytest.mark.anyio
+async def test_list_issues_ambiguous_project_name_lists_candidate_names() -> None:
+    fake = FakeOpikClient(
+        projects={
+            "content": [{"id": "p-1", "name": "demo"}, {"id": "p-2", "name": "demo"}],
+            "total": 2,
+        }
+    )
+    with pytest.raises(ToolError) as exc:
+        await run_list("agent_insights_issue", project_name="demo", client=fake)
+    assert "project_id=p-1, name='demo'" in str(exc.value)
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -466,6 +466,39 @@ async def test_list_issues_unknown_project_name_is_a_clear_error() -> None:
 
 
 @pytest.mark.anyio
+async def test_list_issues_project_name_resolved_once_per_process() -> None:
+    """Every call with project_name used to pay a second round trip. The
+    resolved id is cached, so the follow-up call skips the projects lookup."""
+    fake = FakeOpikClient(projects={"content": [{"id": "p-demo", "name": "demo"}], "total": 1})
+    await run_list("agent_insights_issue", project_name="demo", client=fake)
+    await run_list("agent_insights_issue", project_name="demo", status="resolved", client=fake)
+    assert fake.project_lookups == 1
+    assert fake.last_kwargs.get("project_id") == "p-demo"
+
+
+@pytest.mark.anyio
+async def test_list_issues_project_name_cache_is_per_name() -> None:
+    fake = FakeOpikClient(projects={"content": [{"id": "p-demo", "name": "demo"}], "total": 1})
+    await run_list("agent_insights_issue", project_name="demo", client=fake)
+    fake.projects = {"content": [{"id": "p-other", "name": "other"}], "total": 1}
+    await run_list("agent_insights_issue", project_name="other", client=fake)
+    assert fake.project_lookups == 2
+    assert fake.last_kwargs.get("project_id") == "p-other"
+
+
+@pytest.mark.anyio
+async def test_list_issues_unresolved_project_name_is_not_cached() -> None:
+    """A miss must not be remembered: the project may be created a moment later."""
+    fake = FakeOpikClient()
+    with pytest.raises(ToolError):
+        await run_list("agent_insights_issue", project_name="demo", client=fake)
+    fake.projects = {"content": [{"id": "p-demo", "name": "demo"}], "total": 1}
+    await run_list("agent_insights_issue", project_name="demo", client=fake)
+    assert fake.project_lookups == 2
+    assert fake.last_kwargs.get("project_id") == "p-demo"
+
+
+@pytest.mark.anyio
 async def test_list_issues_project_id_wins_over_name_without_lookup() -> None:
     fake = FakeOpikClient()
     await run_list("agent_insights_issue", project_id="p-9", project_name="demo", client=fake)

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -258,3 +258,29 @@ async def test_list_missing_required_kwarg_chains_typed_cause() -> None:
         await run_list("trace")
 
     assert isinstance(ei.value.__cause__, EntityArgValidationError)
+
+
+# --- entity-specific kwargs are registry-gated --------------------------- #
+
+
+@pytest.mark.anyio
+async def test_list_forwards_only_kwargs_the_entity_declares() -> None:
+    """Parent ids meant for other entities never reach a workspace-wide list_fn.
+
+    ``list('project', project_id=…, test_suite_id=…, prompt_id=…)`` is a
+    confused call, but it must degrade to a plain project list rather than
+    blow up the client with unexpected kwargs."""
+    fake = FakeOpikClient(projects={"content": [{"id": "p-1", "name": "a"}], "total": 1})
+    out = await run_list(
+        "project", project_id="p-1", test_suite_id="ts-1", prompt_id="pr-1", client=fake
+    )
+    assert "p-1" in out
+    assert set(fake.last_kwargs) == {"page", "size"}
+
+
+@pytest.mark.anyio
+async def test_list_forwards_declared_parent_id_to_sub_collection() -> None:
+    fake = FakeOpikClient(prompt_versions={"content": [{"id": "v-1"}], "total": 1})
+    await run_list("prompt_version", prompt_id="pr-1", test_suite_id="ts-1", client=fake)
+    assert fake.last_kwargs.get("prompt_id") == "pr-1"
+    assert "test_suite_id" not in fake.last_kwargs

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -33,12 +33,15 @@ class FakeOpikClient:
 
     last_kwargs: dict[str, Any] = field(default_factory=dict)
 
+    project_lookups: int = 0
+
     async def list_agent_insights_issues(self, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = kw
         return self.issues
 
     async def list_projects(self, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = kw
+        self.project_lookups += 1
         return self.projects
 
     async def list_experiments(self, **kw: Any) -> dict[str, Any]:
@@ -373,6 +376,65 @@ async def test_list_issue_filters_not_forwarded_to_other_entities() -> None:
 async def test_list_issues_empty_state() -> None:
     out = await run_list("agent_insights_issue", project_id="p-1", client=FakeOpikClient())
     assert "No agent_insights_issues found" in out
+
+
+# --- project_name resolution (the backend takes project_id only) --------- #
+
+
+@pytest.mark.anyio
+async def test_list_issues_resolves_exact_project_name_to_id() -> None:
+    """The projects endpoint is a substring search; only the exact name counts."""
+    fake = FakeOpikClient(
+        projects={
+            "content": [
+                {"id": "p-demo-2", "name": "demo-2"},
+                {"id": "p-demo", "name": "demo"},
+            ],
+            "total": 2,
+        },
+        issues={"content": [ISSUE_ROW], "total": 1},
+    )
+    out = await run_list("agent_insights_issue", project_name="demo", client=fake)
+    assert "is-1" in out
+    assert fake.last_kwargs.get("project_id") == "p-demo"
+    assert "project_name" not in fake.last_kwargs
+
+
+@pytest.mark.anyio
+async def test_list_issues_ambiguous_project_name_lists_candidates() -> None:
+    fake = FakeOpikClient(
+        projects={
+            "content": [{"id": "p-1", "name": "demo"}, {"id": "p-2", "name": "demo"}],
+            "total": 2,
+        }
+    )
+    with pytest.raises(ToolError) as exc:
+        await run_list("agent_insights_issue", project_name="demo", client=fake)
+    msg = str(exc.value)
+    assert "p-1" in msg
+    assert "p-2" in msg
+    assert "project_id" in msg
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_list_issues_unknown_project_name_is_a_clear_error() -> None:
+    fake = FakeOpikClient(projects={"content": [{"id": "p-1", "name": "demo-2"}], "total": 1})
+    with pytest.raises(ToolError) as exc:
+        await run_list("agent_insights_issue", project_name="demo", client=fake)
+    msg = str(exc.value)
+    assert "No project named 'demo'" in msg
+    assert "list('project'" in msg
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_list_issues_project_id_wins_over_name_without_lookup() -> None:
+    fake = FakeOpikClient()
+    await run_list("agent_insights_issue", project_id="p-9", project_name="demo", client=fake)
+    assert fake.last_kwargs.get("project_id") == "p-9"
+    assert "project_name" not in fake.last_kwargs
+    assert fake.project_lookups == 0
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -520,14 +520,36 @@ async def test_list_issues_ambiguous_project_name_lists_candidates() -> None:
 
 
 @pytest.mark.anyio
-async def test_list_issues_unknown_project_name_is_a_clear_error() -> None:
-    fake = FakeOpikClient(projects={"content": [{"id": "p-1", "name": "demo-2"}], "total": 1})
+async def test_list_issues_unknown_project_name_suggests_the_closest_one() -> None:
+    """Same recovery as a misspelled project_name on a trace list (#185): the
+    message names the closest existing project and lists the rest."""
+    fake = FakeOpikClient(
+        projects={
+            "content": [
+                {"id": "p-1", "name": "support-agent-demo"},
+                {"id": "p-2", "name": "probe"},
+            ],
+            "total": 2,
+        }
+    )
+    with pytest.raises(ToolError) as exc:
+        await run_list("agent_insights_issue", project_name="suport-agent-demo", client=fake)
+    msg = str(exc.value)
+    assert "Project 'suport-agent-demo' not found." in msg
+    assert "Did you mean 'support-agent-demo'?" in msg
+    assert "Projects: support-agent-demo, probe" in msg
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_list_issues_unknown_project_name_without_a_close_match() -> None:
+    fake = FakeOpikClient(projects={"content": [{"id": "p-1", "name": "probe"}], "total": 1})
     with pytest.raises(ToolError) as exc:
         await run_list("agent_insights_issue", project_name="demo", client=fake)
     msg = str(exc.value)
-    assert "No project named 'demo'" in msg
-    assert "list('project'" in msg
-    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+    assert "Project 'demo' not found." in msg
+    assert "Did you mean" not in msg
+    assert "Projects: probe" in msg
 
 
 @pytest.mark.anyio
@@ -587,9 +609,13 @@ async def test_list_issues_unresolved_project_name_is_not_cached() -> None:
     fake = FakeOpikClient()
     with pytest.raises(ToolError):
         await run_list("agent_insights_issue", project_name="demo", client=fake)
+    # A miss costs two calls: the filtered lookup and the unfiltered one that
+    # builds the did-you-mean. Neither result is remembered.
+    lookups_after_miss = fake.project_lookups
+    assert lookups_after_miss == 2
     fake.projects = {"content": [{"id": "p-demo", "name": "demo"}], "total": 1}
     await run_list("agent_insights_issue", project_name="demo", client=fake)
-    assert fake.project_lookups == 2
+    assert fake.project_lookups == lookups_after_miss + 1
     assert fake.last_kwargs.get("project_id") == "p-demo"
 
 

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -39,6 +39,8 @@ class FakeOpikClient:
     prompt_versions: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     threads_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     thread_messages: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    issues_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
+    last_issue_kwargs: dict[str, Any] = field(default_factory=dict)
     fail_list_traces: bool = False
 
     async def get_project(self, project_id: str) -> dict[str, Any]:
@@ -157,6 +159,23 @@ class FakeOpikClient:
 
     async def list_agent_insights_issues(self, **_: Any) -> dict[str, Any]:
         return {"content": [], "page": 1, "size": 0, "total": 0}
+
+    async def get_agent_insights_issue(
+        self,
+        issue_id: str,
+        *,
+        project_id: str,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict[str, Any]:
+        self.last_issue_kwargs = {
+            "project_id": project_id,
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+        if issue_id not in self.issues_by_id:
+            raise OpikNotFoundError(f"agent insights issue {issue_id!r} not found (404).")
+        return self.issues_by_id[issue_id]
 
 
 UUID = "11111111-2222-3333-4444-555555555555"
@@ -368,6 +387,197 @@ async def test_read_surfaces_not_found_with_hint() -> None:
     msg = str(exc.value)
     assert "Not found" in msg
     assert UUID in msg
+
+
+# --- agent_insights_issue (Diagnostics) ---------------------------------- #
+
+ISSUE = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+_ISSUE_DETAIL = {
+    "id": ISSUE,
+    "name": "Tool call loop on weather lookup",
+    "description": "The agent called get_weather 12 times in one turn.",
+    "cause": "Retries on API timeout have no cap.",
+    "suggested_fix": "Cap retries at 2 and surface the timeout.",
+    "status": "open",
+    "severity": "high",
+    "traces_query": "tool_name = 'get_weather'",
+    "details": [
+        {
+            "report_day": "2026-09-06",
+            "count": 7,
+            "total_count": 120,
+            "users_impacted": 3,
+            "total_users": 40,
+            "metadata": {"example_trace_ids": ["tr-a", "tr-b"], "confidence": 0.9},
+        },
+        {
+            "report_day": "2026-09-07",
+            "count": 5,
+            "total_count": 110,
+            "users_impacted": 2,
+            "total_users": 38,
+            "metadata": {"example_trace_ids": ["tr-b", "tr-c"]},
+        },
+    ],
+}
+
+
+def _issue_fake(detail: dict[str, Any] | None = None) -> FakeOpikClient:
+    return FakeOpikClient(issues_by_id={ISSUE: detail if detail is not None else _ISSUE_DETAIL})
+
+
+def _payload(out: str) -> dict[str, Any]:
+    """Strip the ``[read: …]`` header line and parse the JSON body."""
+    body = json.loads(out.split("\n", 1)[1])
+    assert isinstance(body, dict)
+    return body
+
+
+@pytest.mark.anyio
+async def test_read_issue_returns_issue_example_trace_ids_and_details() -> None:
+    out = await run_read("agent_insights_issue", ISSUE, project_id="p-9", client=_issue_fake())
+    assert f"[read: agent_insights_issue {ISSUE}" in out
+    body = _payload(out)
+    assert set(body) == {"issue", "example_trace_ids", "details"}
+    # The issue record is the backend's, minus the per-day rows.
+    assert body["issue"]["name"] == "Tool call loop on weather lookup"
+    assert body["issue"]["suggested_fix"] == "Cap retries at 2 and surface the timeout."
+    assert "details" not in body["issue"]
+    # Deduped across days, first-seen order over ascending report days.
+    assert body["example_trace_ids"] == ["tr-a", "tr-b", "tr-c"]
+    # Per-day rows pass through unchanged.
+    assert body["details"] == _ISSUE_DETAIL["details"]
+    assert _issue_fake().last_issue_kwargs == {}
+
+
+@pytest.mark.anyio
+async def test_read_issue_passes_project_and_window_to_client() -> None:
+    fake = _issue_fake()
+    await run_read(
+        "agent_insights_issue",
+        ISSUE,
+        project_id="p-9",
+        from_date="2026-09-01",
+        to_date="2026-09-08",
+        client=fake,
+    )
+    assert fake.last_issue_kwargs == {
+        "project_id": "p-9",
+        "from_date": "2026-09-01",
+        "to_date": "2026-09-08",
+    }
+
+
+@pytest.mark.anyio
+async def test_read_issue_window_omitted_by_default() -> None:
+    fake = _issue_fake()
+    await run_read("agent_insights_issue", ISSUE, project_id="p-9", client=fake)
+    assert fake.last_issue_kwargs["from_date"] is None
+    assert fake.last_issue_kwargs["to_date"] is None
+
+
+@pytest.mark.anyio
+async def test_read_issue_tolerates_rows_without_example_ids() -> None:
+    detail = {
+        **_ISSUE_DETAIL,
+        "details": [
+            {"report_day": "2026-09-01", "count": 1},  # no metadata at all
+            {"report_day": "2026-09-02", "count": 1, "metadata": "corrupt"},  # not an object
+            {"report_day": "2026-09-03", "count": 1, "metadata": {"confidence": 0.5}},
+            {"report_day": "2026-09-04", "count": 1, "metadata": {"example_trace_ids": ["tr-z"]}},
+        ],
+    }
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", client=_issue_fake(detail)
+    )
+    assert _payload(out)["example_trace_ids"] == ["tr-z"]
+
+
+@pytest.mark.anyio
+async def test_read_issue_with_no_details_has_empty_example_ids() -> None:
+    detail = {**_ISSUE_DETAIL, "details": []}
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", client=_issue_fake(detail)
+    )
+    body = _payload(out)
+    assert body["example_trace_ids"] == []
+    assert body["details"] == []
+
+
+@pytest.mark.anyio
+async def test_read_issue_requires_project_scope() -> None:
+    with pytest.raises(ToolError) as exc:
+        await run_read("agent_insights_issue", ISSUE, client=_issue_fake())
+    msg = str(exc.value)
+    assert "read('agent_insights_issue') requires project scope" in msg
+    assert "project_name" in msg
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_read_issue_not_found_names_entity_and_id() -> None:
+    with pytest.raises(ToolError) as exc:
+        await run_read("agent_insights_issue", "is-missing", project_id="p-9", client=_issue_fake())
+    msg = str(exc.value)
+    assert "agent_insights_issue" in msg
+    assert "is-missing" in msg
+    assert "not found" in msg
+
+
+@pytest.mark.anyio
+async def test_read_issue_skeleton_keeps_every_example_trace_id() -> None:
+    """An all-time read can carry hundreds of per-day rows. When it blows the
+    budget, the trace ids — the reason for the read — must survive; the
+    per-day rows are what gets dropped."""
+    rows = [
+        {
+            "report_day": f"2026-{1 + i // 28:02d}-{1 + i % 28:02d}",
+            "count": i,
+            "metadata": {
+                "example_trace_ids": [f"tr-{i}"],
+                "confidence_justification": "x" * 2_000,
+            },
+        }
+        for i in range(120)
+    ]
+    detail = {**_ISSUE_DETAIL, "details": rows}
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", max_tokens=500, client=_issue_fake(detail)
+    )
+    assert "compression=SKELETON" in out
+    body = _payload(out)
+    assert body["issue"]["id"] == ISSUE
+    assert body["issue"]["name"] == "Tool call loop on weather lookup"
+    assert body["issue"]["severity"] == "high"
+    assert body["issue"]["status"] == "open"
+    assert body["example_trace_ids"] == [f"tr-{i}" for i in range(120)]
+    assert "details" not in body
+    assert "read('trace'" in body["note"]
+
+
+@pytest.mark.anyio
+async def test_read_issue_medium_compression_keeps_trace_ids_too() -> None:
+    """Between FULL and SKELETON the generic string truncation runs; short ids
+    are untouched, so the list stays intact."""
+    rows = [
+        {
+            "report_day": f"2026-01-{1 + i:02d}",
+            "count": i,
+            "metadata": {"example_trace_ids": [f"tr-{i}"], "confidence_justification": "y" * 800},
+        }
+        for i in range(20)
+    ]
+    detail = {**_ISSUE_DETAIL, "details": rows}
+    out = await run_read(
+        "agent_insights_issue",
+        ISSUE,
+        project_id="p-9",
+        max_tokens=1_000,
+        client=_issue_fake(detail),
+    )
+    assert "compression=MEDIUM" in out
+    assert _payload(out)["example_trace_ids"] == [f"tr-{i}" for i in range(20)]
 
 
 # --- compression budget --------------------------------------------------- #

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -624,11 +624,15 @@ async def test_read_issue_ambiguous_project_name_lists_candidates() -> None:
 
 
 @pytest.mark.anyio
-async def test_read_issue_unknown_project_name_is_a_clear_error() -> None:
+async def test_read_issue_unknown_project_name_suggests_the_closest_one() -> None:
     fake = _issue_fake()
+    # The unfiltered lookup (key "") is what the suggestion is built from.
+    fake.projects_by_name = {"": [{"id": "p-1", "name": "ghost-demo"}]}
     with pytest.raises(ToolError) as exc:
-        await run_read("agent_insights_issue", ISSUE, project_name="ghost", client=fake)
-    assert "No project named 'ghost'" in str(exc.value)
+        await run_read("agent_insights_issue", ISSUE, project_name="gost-demo", client=fake)
+    msg = str(exc.value)
+    assert "Project 'gost-demo' not found." in msg
+    assert "Did you mean 'ghost-demo'?" in msg
     assert isinstance(exc.value.__cause__, EntityArgValidationError)
 
 

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -762,6 +762,30 @@ async def test_read_issue_resolved_status_links_to_resolved_view() -> None:
 
 
 @pytest.mark.anyio
+async def test_read_issue_omits_links_under_oauth_bearer_with_unknown_workspace() -> None:
+    """Hosted OAuth: the workspace is token-derived server-side. If this
+    process could not name it, a link built from the static fallback would
+    point at the wrong workspace, so the read carries none."""
+    from opik_mcp.auth_context import OAUTH_ACCESS_TOKEN_PREFIX, inbound_authorization
+
+    tok = inbound_authorization.set(f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}abc")
+    try:
+        out = await run_read(
+            "agent_insights_issue",
+            ISSUE,
+            project_id="p-9",
+            client=_issue_fake(),
+            settings=_UI_SETTINGS,
+        )
+    finally:
+        inbound_authorization.reset(tok)
+    body = _payload(out)
+    assert "url" not in body
+    assert "trace_url_template" not in body
+    assert "_project_id" not in body
+
+
+@pytest.mark.anyio
 async def test_read_issue_omits_links_when_opik_url_unconfigured() -> None:
     """No URL is better than a wrong one."""
     bare = Settings(

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -688,7 +688,11 @@ async def test_read_issue_medium_drops_row_metadata_to_meet_budget() -> None:
     ]
     detail = {**_ISSUE_DETAIL, "details": rows}
     out = await run_read(
-        "agent_insights_issue", ISSUE, project_id="p-9", max_tokens=1_000, client=_issue_fake(detail)
+        "agent_insights_issue",
+        ISSUE,
+        project_id="p-9",
+        max_tokens=1_000,
+        client=_issue_fake(detail),
     )
     header, payload = out.split("\n", 1)
     assert "compression=MEDIUM" in header

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -600,6 +600,37 @@ async def test_read_issue_project_id_wins_over_name_without_lookup() -> None:
 
 
 @pytest.mark.anyio
+async def test_read_issue_via_pasted_diagnostics_link() -> None:
+    """The link carries the project, so no scope argument is needed, and it
+    overrides whatever entity_type the agent guessed."""
+    fake = _issue_fake()
+    url = f"https://www.comet.com/opik/ws/projects/p-link/diagnostics?issue={ISSUE}"
+    out = await run_read("trace", url, client=fake)
+    assert f"[read: agent_insights_issue {ISSUE}" in out
+    assert fake.last_issue_kwargs["project_id"] == "p-link"
+    assert fake.project_lookups == 0
+
+
+@pytest.mark.anyio
+async def test_read_issue_link_project_overrides_explicit_name() -> None:
+    fake = _issue_fake()
+    url = f"https://www.comet.com/opik/ws/projects/p-link/diagnostics?issue={ISSUE}"
+    await run_read("agent_insights_issue", url, project_name="ignored", client=fake)
+    assert fake.last_issue_kwargs["project_id"] == "p-link"
+    assert fake.project_lookups == 0
+
+
+@pytest.mark.anyio
+async def test_read_issue_via_canonical_uri() -> None:
+    fake = _issue_fake()
+    out = await run_read(
+        "agent_insights_issue", f"opik://projects/p-uri/agent-insights-issues/{ISSUE}", client=fake
+    )
+    assert f"[read: agent_insights_issue {ISSUE}" in out
+    assert fake.last_issue_kwargs["project_id"] == "p-uri"
+
+
+@pytest.mark.anyio
 async def test_read_issue_medium_compression_keeps_trace_ids_too() -> None:
     """Between FULL and SKELETON the generic string truncation runs; short ids
     are untouched, so the list stays intact."""

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -41,6 +41,7 @@ class FakeOpikClient:
     thread_messages: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     issues_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     last_issue_kwargs: dict[str, Any] = field(default_factory=dict)
+    project_lookups: int = 0
     fail_list_traces: bool = False
 
     async def get_project(self, project_id: str) -> dict[str, Any]:
@@ -55,6 +56,7 @@ class FakeOpikClient:
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]:
+        self.project_lookups += 1
         content = self.projects_by_name.get(name or "", [])
         return {"content": content, "page": page, "size": len(content), "total": len(content)}
 
@@ -554,6 +556,47 @@ async def test_read_issue_skeleton_keeps_every_example_trace_id() -> None:
     assert body["example_trace_ids"] == [f"tr-{i}" for i in range(120)]
     assert "details" not in body
     assert "read('trace'" in body["note"]
+
+
+@pytest.mark.anyio
+async def test_read_issue_resolves_exact_project_name() -> None:
+    fake = _issue_fake()
+    fake.projects_by_name = {
+        "demo": [{"id": "p-demo-2", "name": "demo-2"}, {"id": "p-demo", "name": "demo"}]
+    }
+    out = await run_read("agent_insights_issue", ISSUE, project_name="demo", client=fake)
+    assert f"[read: agent_insights_issue {ISSUE}" in out
+    assert fake.last_issue_kwargs["project_id"] == "p-demo"
+
+
+@pytest.mark.anyio
+async def test_read_issue_ambiguous_project_name_lists_candidates() -> None:
+    fake = _issue_fake()
+    fake.projects_by_name = {"demo": [{"id": "p-1", "name": "demo"}, {"id": "p-2", "name": "demo"}]}
+    with pytest.raises(ToolError) as exc:
+        await run_read("agent_insights_issue", ISSUE, project_name="demo", client=fake)
+    msg = str(exc.value)
+    assert "p-1" in msg and "p-2" in msg
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_read_issue_unknown_project_name_is_a_clear_error() -> None:
+    fake = _issue_fake()
+    with pytest.raises(ToolError) as exc:
+        await run_read("agent_insights_issue", ISSUE, project_name="ghost", client=fake)
+    assert "No project named 'ghost'" in str(exc.value)
+    assert isinstance(exc.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_read_issue_project_id_wins_over_name_without_lookup() -> None:
+    fake = _issue_fake()
+    await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", project_name="demo", client=fake
+    )
+    assert fake.last_issue_kwargs["project_id"] == "p-9"
+    assert fake.project_lookups == 0
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -155,6 +155,9 @@ class FakeOpikClient:
     async def list_test_suite_items(self, _test_suite_id: str, **_kw: Any) -> dict[str, Any]:
         return {"content": [], "page": 1, "size": 0, "total": 0}
 
+    async def list_agent_insights_issues(self, **_: Any) -> dict[str, Any]:
+        return {"content": [], "page": 1, "size": 0, "total": 0}
+
 
 UUID = "11111111-2222-3333-4444-555555555555"
 

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -399,3 +399,17 @@ async def test_read_invalid_entity_type_chains_typed_cause() -> None:
         await run_read("not_real", "00000000-0000-0000-0000-000000000000")
 
     assert isinstance(ei.value.__cause__, EntityArgValidationError)
+
+
+@pytest.mark.anyio
+async def test_read_missing_project_scope_error_is_entity_neutral() -> None:
+    """The scope error names the entity and every way to supply scope —
+    project_id, project_name, or a pasted link/URI — without assuming the
+    entity is a thread."""
+    with pytest.raises(ToolError) as exc:
+        await run_read("thread", THREAD, client=_thread_fake())
+    msg = str(exc.value)
+    assert "read('thread')" in msg
+    assert "project_id" in msg
+    assert "project_name" in msg
+    assert "link" in msg

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -602,6 +602,17 @@ async def test_read_issue_resolves_exact_project_name() -> None:
 
 
 @pytest.mark.anyio
+async def test_read_issue_resolves_project_name_case_insensitively() -> None:
+    fake = _issue_fake()
+    fake.projects_by_name = {"Support-Agent-Demo": [{"id": "p-demo", "name": "support-agent-demo"}]}
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_name="Support-Agent-Demo", client=fake
+    )
+    assert f"[read: agent_insights_issue {ISSUE}" in out
+    assert fake.last_issue_kwargs["project_id"] == "p-demo"
+
+
+@pytest.mark.anyio
 async def test_read_issue_ambiguous_project_name_lists_candidates() -> None:
     fake = _issue_fake()
     fake.projects_by_name = {"demo": [{"id": "p-1", "name": "demo"}, {"id": "p-2", "name": "demo"}]}

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -592,6 +592,18 @@ async def test_read_issue_unknown_project_name_is_a_clear_error() -> None:
 
 
 @pytest.mark.anyio
+async def test_read_issue_reuses_project_id_resolved_by_an_earlier_call() -> None:
+    """list then read by the same project_name is the agent's normal flow;
+    the second call must not pay the projects lookup again."""
+    fake = _issue_fake()
+    fake.projects_by_name = {"demo": [{"id": "p-demo", "name": "demo"}]}
+    await run_read("agent_insights_issue", ISSUE, project_name="demo", client=fake)
+    await run_read("agent_insights_issue", ISSUE, project_name="demo", client=fake)
+    assert fake.project_lookups == 1
+    assert fake.last_issue_kwargs["project_id"] == "p-demo"
+
+
+@pytest.mark.anyio
 async def test_read_issue_project_id_wins_over_name_without_lookup() -> None:
     fake = _issue_fake()
     await run_read(
@@ -652,6 +664,57 @@ async def test_read_issue_via_canonical_uri() -> None:
     )
     assert f"[read: agent_insights_issue {ISSUE}" in out
     assert fake.last_issue_kwargs["project_id"] == "p-uri"
+
+
+@pytest.mark.anyio
+async def test_read_issue_medium_drops_row_metadata_to_meet_budget() -> None:
+    """The per-row metadata (ids already lifted into example_trace_ids, plus
+    prose) is the bulk of an issue read. When the FULL body is over budget,
+    MEDIUM drops it first — and that alone should bring the seven-row fixture
+    under a 1,000-token budget while keeping every row's counts."""
+    rows = [
+        {
+            "report_day": f"2026-09-0{d}",
+            "count": d,
+            "total_count": 10 * d,
+            "users_impacted": 1,
+            "total_users": 40,
+            "metadata": {
+                "example_trace_ids": [f"tr-{d}-{i}" for i in range(5)],
+                "confidence_justification": "why " * 150,
+            },
+        }
+        for d in range(1, 8)
+    ]
+    detail = {**_ISSUE_DETAIL, "details": rows}
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", max_tokens=1_000, client=_issue_fake(detail)
+    )
+    header, payload = out.split("\n", 1)
+    assert "compression=MEDIUM" in header
+    assert len(payload) // 4 <= 1_000
+    body = json.loads(payload)
+    assert len(body["example_trace_ids"]) == 35
+    assert len(body["details"]) == 7
+    assert body["details"][0]["count"] == 1
+    assert "metadata" not in body["details"][0]
+    # The prose the agent came for is intact at this tier.
+    assert body["issue"]["suggested_fix"] == _ISSUE_DETAIL["suggested_fix"]
+
+
+@pytest.mark.anyio
+async def test_read_issue_falls_to_skeleton_when_still_over_budget() -> None:
+    """A budget too small for even the pruned rows gets SKELETON regardless of
+    the global 50k threshold — the agent asked for a small answer."""
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", max_tokens=150, client=_issue_fake()
+    )
+    header, payload = out.split("\n", 1)
+    assert "compression=SKELETON" in header
+    body = json.loads(payload)
+    assert body["example_trace_ids"] == ["tr-a", "tr-b", "tr-c"]
+    assert body["issue"]["name"] == _ISSUE_DETAIL["name"]
+    assert "details" not in body
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -819,6 +819,21 @@ async def test_read_issue_skeleton_keeps_url() -> None:
 
 
 @pytest.mark.anyio
+async def test_read_window_kwargs_dropped_for_entities_that_do_not_declare_them() -> None:
+    """from_date/to_date belong to the issue read; a thread fetcher takes
+    neither, so the gate must drop them instead of crashing the fetch."""
+    out = await run_read(
+        "thread",
+        THREAD,
+        project_id="p-9",
+        from_date="2026-09-01",
+        to_date="2026-09-08",
+        client=_thread_fake(),
+    )
+    assert f"[read: thread {THREAD}" in out
+
+
+@pytest.mark.anyio
 async def test_read_thread_has_no_link_fields() -> None:
     """Links are an issue-read affordance; other composites are unchanged."""
     out = await run_read(

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
-from opik_mcp.opik_client import OpikNotFoundError, OpikServerError
+from opik_mcp.opik_client import OpikNotFoundError, OpikServerError, OpikValidationError
 from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.read_tool import run_read
 
@@ -41,6 +41,7 @@ class FakeOpikClient:
     thread_messages: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     issues_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     last_issue_kwargs: dict[str, Any] = field(default_factory=dict)
+    fail_issue_with: Exception | None = None
     project_lookups: int = 0
     fail_list_traces: bool = False
 
@@ -175,6 +176,8 @@ class FakeOpikClient:
             "from_date": from_date,
             "to_date": to_date,
         }
+        if self.fail_issue_with is not None:
+            raise self.fail_issue_with
         if issue_id not in self.issues_by_id:
             raise OpikNotFoundError(f"agent insights issue {issue_id!r} not found (404).")
         return self.issues_by_id[issue_id]
@@ -450,7 +453,6 @@ async def test_read_issue_returns_issue_example_trace_ids_and_details() -> None:
     assert body["example_trace_ids"] == ["tr-a", "tr-b", "tr-c"]
     # Per-day rows pass through unchanged.
     assert body["details"] == _ISSUE_DETAIL["details"]
-    assert _issue_fake().last_issue_kwargs == {}
 
 
 @pytest.mark.anyio
@@ -597,6 +599,28 @@ async def test_read_issue_project_id_wins_over_name_without_lookup() -> None:
     )
     assert fake.last_issue_kwargs["project_id"] == "p-9"
     assert fake.project_lookups == 0
+
+
+@pytest.mark.anyio
+async def test_read_issue_bad_window_surfaces_backend_validation_message() -> None:
+    """The backend rejects from_date > to_date with a 400; the agent must see
+    that reason, not a generic failure."""
+    fake = _issue_fake()
+    fake.fail_issue_with = OpikValidationError(
+        "Opik rejected the request body (400) for agent insights issue — "
+        "Parameter 'from_date' must not be after 'to_date'"
+    )
+    with pytest.raises(ToolError) as exc:
+        await run_read(
+            "agent_insights_issue",
+            ISSUE,
+            project_id="p-9",
+            from_date="2026-09-09",
+            to_date="2026-09-01",
+            client=fake,
+        )
+    assert "from_date" in str(exc.value)
+    assert isinstance(exc.value.__cause__, OpikValidationError)
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
+from opik_mcp.config import Settings
 from opik_mcp.opik_client import OpikNotFoundError, OpikServerError, OpikValidationError
 from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.read_tool import run_read
@@ -444,7 +445,9 @@ async def test_read_issue_returns_issue_example_trace_ids_and_details() -> None:
     out = await run_read("agent_insights_issue", ISSUE, project_id="p-9", client=_issue_fake())
     assert f"[read: agent_insights_issue {ISSUE}" in out
     body = _payload(out)
-    assert set(body) == {"issue", "example_trace_ids", "details"}
+    assert {"issue", "example_trace_ids", "details"} <= set(body)
+    # The project the issue was read under feeds the UI links and never leaks.
+    assert "_project_id" not in body
     # The issue record is the backend's, minus the per-day rows.
     assert body["issue"]["name"] == "Tool call loop on weather lookup"
     assert body["issue"]["suggested_fix"] == "Cap retries at 2 and surface the timeout."
@@ -719,6 +722,85 @@ async def test_read_issue_falls_to_skeleton_when_still_over_budget() -> None:
     assert body["example_trace_ids"] == ["tr-a", "tr-b", "tr-c"]
     assert body["issue"]["name"] == _ISSUE_DETAIL["name"]
     assert "details" not in body
+
+
+# --- UI links on the issue read ------------------------------------------ #
+
+_UI_SETTINGS = Settings(
+    opik_api_key="k", comet_workspace="demo-ws", opik_url="https://opik.test/api"
+)
+
+
+@pytest.mark.anyio
+async def test_read_issue_carries_diagnostics_page_url_and_trace_url_template() -> None:
+    """The diagnose skill must hand back clickable links; the server knows
+    the UI base and workspace, so the read supplies them instead of making
+    the agent guess the URL shape."""
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", client=_issue_fake(), settings=_UI_SETTINGS
+    )
+    body = _payload(out)
+    assert body["url"] == f"https://opik.test/demo-ws/projects/p-9/diagnostics?issue={ISSUE}"
+    assert (
+        body["trace_url_template"] == "https://opik.test/demo-ws/projects/p-9/logs?trace={trace_id}"
+    )
+
+
+@pytest.mark.anyio
+async def test_read_issue_resolved_status_links_to_resolved_view() -> None:
+    detail = {**_ISSUE_DETAIL, "status": "resolved"}
+    out = await run_read(
+        "agent_insights_issue",
+        ISSUE,
+        project_id="p-9",
+        client=_issue_fake(detail),
+        settings=_UI_SETTINGS,
+    )
+    assert _payload(out)["url"] == (
+        f"https://opik.test/demo-ws/projects/p-9/diagnostics/resolved?issue={ISSUE}"
+    )
+
+
+@pytest.mark.anyio
+async def test_read_issue_omits_links_when_opik_url_unconfigured() -> None:
+    """No URL is better than a wrong one."""
+    bare = Settings(
+        opik_api_key="k", comet_workspace="demo-ws", opik_url=None, comet_url_override=""
+    )
+    out = await run_read(
+        "agent_insights_issue", ISSUE, project_id="p-9", client=_issue_fake(), settings=bare
+    )
+    body = _payload(out)
+    assert "url" not in body
+    assert "trace_url_template" not in body
+
+
+@pytest.mark.anyio
+async def test_read_issue_skeleton_keeps_url() -> None:
+    out = await run_read(
+        "agent_insights_issue",
+        ISSUE,
+        project_id="p-9",
+        max_tokens=150,
+        client=_issue_fake(),
+        settings=_UI_SETTINGS,
+    )
+    header, payload = out.split("\n", 1)
+    assert "compression=SKELETON" in header
+    body = json.loads(payload)
+    assert body["url"].endswith(f"diagnostics?issue={ISSUE}")
+    # The skeleton keeps the example ids; the template is what makes them
+    # clickable, so it stays too.
+    assert body["trace_url_template"].endswith("/logs?trace={trace_id}")
+
+
+@pytest.mark.anyio
+async def test_read_thread_has_no_link_fields() -> None:
+    """Links are an issue-read affordance; other composites are unchanged."""
+    out = await run_read(
+        "thread", THREAD, project_id="p-9", client=_thread_fake(), settings=_UI_SETTINGS
+    )
+    assert "url" not in _payload(out)
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_registry.py
+++ b/tests/test_read_list/test_registry.py
@@ -63,3 +63,19 @@ def test_needs_project_is_thread_only() -> None:
     """Only thread declares needs_project — every other fetcher is (client, id)."""
     for entity_type, handler in ENTITY_REGISTRY.items():
         assert handler.needs_project is (entity_type == "thread")
+
+
+def test_optional_kwargs_never_overlap_required_ones() -> None:
+    """A kwarg is either required or optional for an entity, never both — the
+    list tool's forwarding gate unions the two, so an overlap would hide a
+    missing-parent error."""
+    for handler in ENTITY_REGISTRY.values():
+        assert not set(handler.list_required_kwargs) & set(handler.list_optional_kwargs)
+
+
+def test_optional_kwargs_default_empty() -> None:
+    """No entity declares optional kwargs yet; the gate must drop everything
+    the caller passes beyond the required parent id."""
+    for handler in ENTITY_REGISTRY.values():
+        assert handler.list_optional_kwargs == ()
+        assert handler.read_optional_kwargs == ()

--- a/tests/test_read_list/test_registry.py
+++ b/tests/test_read_list/test_registry.py
@@ -59,10 +59,11 @@ def test_thread_needs_project_and_is_id_only() -> None:
     assert handler.search_by_name_fn is None
 
 
-def test_needs_project_is_thread_only() -> None:
-    """Only thread declares needs_project — every other fetcher is (client, id)."""
+def test_needs_project_is_declared_by_project_scoped_reads_only() -> None:
+    """thread and agent_insights_issue need project scope on read — every other
+    fetcher is (client, id)."""
     for entity_type, handler in ENTITY_REGISTRY.items():
-        assert handler.needs_project is (entity_type == "thread")
+        assert handler.needs_project is (entity_type in {"thread", "agent_insights_issue"})
 
 
 def test_optional_kwargs_never_overlap_required_ones() -> None:
@@ -86,7 +87,11 @@ def test_only_agent_insights_issue_declares_optional_kwargs() -> None:
 def test_agent_insights_issue_is_project_scoped_and_listable() -> None:
     handler = ENTITY_REGISTRY["agent_insights_issue"]
     assert "agent_insights_issue" in LISTABLE_TYPES
+    assert "agent_insights_issue" in READABLE_TYPES
     assert handler.list_required_kwargs == ("project_id",)
     assert set(handler.list_optional_kwargs) == {"status", "from_date", "to_date"}
+    assert set(handler.read_optional_kwargs) == {"from_date", "to_date"}
+    assert handler.needs_project is True
     assert handler.id_only is True
     assert handler.search_by_name_fn is None
+    assert handler.compress_fn is not None

--- a/tests/test_read_list/test_registry.py
+++ b/tests/test_read_list/test_registry.py
@@ -73,9 +73,20 @@ def test_optional_kwargs_never_overlap_required_ones() -> None:
         assert not set(handler.list_required_kwargs) & set(handler.list_optional_kwargs)
 
 
-def test_optional_kwargs_default_empty() -> None:
-    """No entity declares optional kwargs yet; the gate must drop everything
-    the caller passes beyond the required parent id."""
-    for handler in ENTITY_REGISTRY.values():
+def test_only_agent_insights_issue_declares_optional_kwargs() -> None:
+    """Every other entity takes nothing beyond its parent id, so the gate
+    must drop whatever else the caller passes."""
+    for entity_type, handler in ENTITY_REGISTRY.items():
+        if entity_type == "agent_insights_issue":
+            continue
         assert handler.list_optional_kwargs == ()
         assert handler.read_optional_kwargs == ()
+
+
+def test_agent_insights_issue_is_project_scoped_and_listable() -> None:
+    handler = ENTITY_REGISTRY["agent_insights_issue"]
+    assert "agent_insights_issue" in LISTABLE_TYPES
+    assert handler.list_required_kwargs == ("project_id",)
+    assert set(handler.list_optional_kwargs) == {"status", "from_date", "to_date"}
+    assert handler.id_only is True
+    assert handler.search_by_name_fn is None

--- a/tests/test_read_list/test_ui_links.py
+++ b/tests/test_read_list/test_ui_links.py
@@ -62,6 +62,18 @@ def test_link_workspace_is_none_for_oauth_bearer_with_unknown_workspace() -> Non
         inbound_authorization.reset(tok)
 
 
+def test_link_workspace_trusts_inbound_header_under_oauth() -> None:
+    """An explicit Comet-Workspace header is cross-checked against the token
+    server-side, so it is a safe name to link with even under OAuth."""
+    tok_auth = inbound_authorization.set(f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}abc")
+    tok_ws = inbound_workspace.set("header-ws")
+    try:
+        assert link_workspace(_settings()) == "header-ws"
+    finally:
+        inbound_workspace.reset(tok_ws)
+        inbound_authorization.reset(tok_auth)
+
+
 def test_link_workspace_uses_settings_for_api_key_sessions() -> None:
     tok = inbound_authorization.set("plain-api-key")
     try:

--- a/tests/test_read_list/test_ui_links.py
+++ b/tests/test_read_list/test_ui_links.py
@@ -1,0 +1,52 @@
+"""UI link helpers — the Opik UI base and the session's workspace name.
+
+These feed both the instructions blob and the links a read attaches, so the
+two can never disagree about where the UI lives.
+"""
+
+from __future__ import annotations
+
+from opik_mcp.auth_context import inbound_workspace, resolved_workspace_name
+from opik_mcp.config import Settings
+from opik_mcp.read_list.ui_links import current_workspace, opik_ui_base
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "opik_api_key": "k",
+        "comet_workspace": "demo-ws",
+        "opik_url": "https://opik.test/api/",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_ui_base_strips_api_suffix_and_trailing_slash() -> None:
+    assert opik_ui_base(_settings()) == "https://opik.test"
+
+
+def test_ui_base_derives_from_comet_url_override() -> None:
+    s = _settings(opik_url=None, comet_url_override="https://demo.comet.com/")
+    assert opik_ui_base(s) == "https://demo.comet.com/opik"
+
+
+def test_ui_base_none_when_unconfigured() -> None:
+    assert opik_ui_base(_settings(opik_url=None, comet_url_override="")) is None
+
+
+def test_workspace_falls_back_to_settings_then_default() -> None:
+    assert current_workspace(_settings()) == "demo-ws"
+    assert current_workspace(_settings(comet_workspace=None)) == "default"
+
+
+def test_workspace_prefers_inbound_header_then_resolved_name() -> None:
+    tok_resolved = resolved_workspace_name.set("oauth-ws")
+    try:
+        assert current_workspace(_settings()) == "oauth-ws"
+        tok_inbound = inbound_workspace.set("header-ws")
+        try:
+            assert current_workspace(_settings()) == "header-ws"
+        finally:
+            inbound_workspace.reset(tok_inbound)
+    finally:
+        resolved_workspace_name.reset(tok_resolved)

--- a/tests/test_read_list/test_ui_links.py
+++ b/tests/test_read_list/test_ui_links.py
@@ -6,9 +6,14 @@ two can never disagree about where the UI lives.
 
 from __future__ import annotations
 
-from opik_mcp.auth_context import inbound_workspace, resolved_workspace_name
+from opik_mcp.auth_context import (
+    OAUTH_ACCESS_TOKEN_PREFIX,
+    inbound_authorization,
+    inbound_workspace,
+    resolved_workspace_name,
+)
 from opik_mcp.config import Settings
-from opik_mcp.read_list.ui_links import current_workspace, opik_ui_base
+from opik_mcp.read_list.ui_links import current_workspace, link_workspace, opik_ui_base
 
 
 def _settings(**overrides: object) -> Settings:
@@ -37,6 +42,33 @@ def test_ui_base_none_when_unconfigured() -> None:
 def test_workspace_falls_back_to_settings_then_default() -> None:
     assert current_workspace(_settings()) == "demo-ws"
     assert current_workspace(_settings(comet_workspace=None)) == "default"
+
+
+def test_link_workspace_is_none_for_oauth_bearer_with_unknown_workspace() -> None:
+    """Under an OAuth bearer the workspace lives server-side. If neither the
+    header nor introspection named it, a link built from the static settings
+    fallback would point at the wrong workspace — so no link at all."""
+    tok = inbound_authorization.set(f"Bearer {OAUTH_ACCESS_TOKEN_PREFIX}abc")
+    try:
+        assert link_workspace(_settings()) is None
+        # ...but the instructions blob keeps its best-effort name.
+        assert current_workspace(_settings()) == "demo-ws"
+        tok_res = resolved_workspace_name.set("oauth-ws")
+        try:
+            assert link_workspace(_settings()) == "oauth-ws"
+        finally:
+            resolved_workspace_name.reset(tok_res)
+    finally:
+        inbound_authorization.reset(tok)
+
+
+def test_link_workspace_uses_settings_for_api_key_sessions() -> None:
+    tok = inbound_authorization.set("plain-api-key")
+    try:
+        assert link_workspace(_settings()) == "demo-ws"
+    finally:
+        inbound_authorization.reset(tok)
+    assert link_workspace(_settings()) == "demo-ws"
 
 
 def test_workspace_prefers_inbound_header_then_resolved_name() -> None:

--- a/tests/test_read_list/test_uri.py
+++ b/tests/test_read_list/test_uri.py
@@ -7,6 +7,7 @@ import pytest
 from opik_mcp.read_list.uri import (
     InvalidURI,
     ParsedURI,
+    looks_like_opik_link,
     looks_like_thread_url,
     looks_like_uri,
     parse,
@@ -85,3 +86,51 @@ def test_looks_like_thread_url() -> None:
 def test_thread_uri_not_confused_with_project_singleton() -> None:
     # A plain project singleton must still parse as project, not thread.
     assert parse("opik://projects/p-1") == ParsedURI("project", "p-1")
+
+
+# --- Diagnostics (agent insights) issues ---------------------------------- #
+
+
+def test_parse_canonical_issue_uri_carries_project() -> None:
+    assert parse("opik://projects/p-9/agent-insights-issues/is-1") == ParsedURI(
+        "agent_insights_issue", "is-1", project_id="p-9"
+    )
+
+
+def test_parse_web_diagnostics_link_extracts_project_and_issue() -> None:
+    url = "https://www.comet.com/opik/my-ws/projects/p-9/diagnostics?issue=is-1&tab=open"
+    assert parse(url) == ParsedURI("agent_insights_issue", "is-1", project_id="p-9")
+
+
+def test_parse_web_diagnostics_resolved_link_too() -> None:
+    url = "https://www.comet.com/opik/my-ws/projects/p-9/diagnostics/resolved?issue=is-2"
+    assert parse(url) == ParsedURI("agent_insights_issue", "is-2", project_id="p-9")
+
+
+def test_parse_web_issue_link_url_decodes_issue_id() -> None:
+    url = "https://x.test/ws/projects/p-9/diagnostics?issue=is%2F42"
+    assert parse(url) == ParsedURI("agent_insights_issue", "is/42", project_id="p-9")
+
+
+def test_looks_like_opik_link_covers_thread_and_issue_links() -> None:
+    assert looks_like_opik_link("https://x.test/ws/projects/p/traces?thread=t")
+    assert looks_like_opik_link("https://x.test/ws/projects/p/diagnostics?issue=i")
+    assert not looks_like_opik_link("https://x.test/ws/projects/p/diagnostics")  # no issue=
+    assert not looks_like_opik_link("https://x.test/ws/diagnostics?issue=i")  # no /projects/
+    assert not looks_like_opik_link("opik://projects/p/agent-insights-issues/i")  # not http
+    # 'issue=' inside another key is not an issue link.
+    assert not looks_like_opik_link("https://x.test/ws/projects/p/diagnostics?other_issue=i")
+
+
+def test_thread_query_wins_when_both_present() -> None:
+    """A URL carrying both keys is a thread link with an unrelated issue param;
+    the thread rule is checked first so existing behaviour is unchanged."""
+    url = "https://x.test/ws/projects/p-9/traces?thread=th-1&issue=is-1"
+    assert parse(url) == ParsedURI("thread", "th-1", project_id="p-9")
+
+
+def test_issue_uri_not_confused_with_thread_or_project() -> None:
+    assert parse("opik://projects/p-9/threads/th-1").entity_type == "thread"
+    assert parse("opik://projects/p-9").entity_type == "project"
+    with pytest.raises(InvalidURI):
+        parse("opik://projects/p-9/agent-insights-issues")  # collection, not a singleton


### PR DESCRIPTION
## Details

The UI's Diagnostics page already groups a project's recurring failures into ranked issues with example traces. The MCP had none of it, so the `opik-diagnose` skill rebuilt the same ranking from raw traces inside the context window. This PR exposes those reports through `read` and `list` as a new project-scoped entity, `agent_insights_issue`, and reorders the skill to consult it first.

### list

`list('agent_insights_issue', project_id=… | project_name=…)` returns the Diagnostics issue list in the order the UI shows it: most recently seen first, then most occurrences. Columns are `severity`, `status`, `total_occurrences`, `latest_count` and `last_seen`. Open issues come back by default; the new `status` parameter takes `open`, `resolved` or `closed`. Counts are all-time so they match the page. The `since` / `until` window that #185 added for traces works here too, truncated to UTC report days because Diagnostics aggregates per day, so `list` has one date vocabulary and `read` takes the same two parameters for this entity.

### read

`read('agent_insights_issue', id, project_id=… | project_name=…)` makes one backend call and returns `{issue, example_trace_ids, details, url, trace_url_template}`. That is the record with cause and suggested fix, the deduplicated ids of traces that exhibit the issue (the page's affected-traces sample is the prefix of this list), the per-day breakdown, the issue's Diagnostics page link, and a deep-link template for any example trace. Trace bodies stay out. When the read exceeds its token budget, MEDIUM drops per-row metadata first and then long strings, and SKELETON keeps every trace id and both links.

### Project scope and links

`project_name` resolves to a UUID by whole-name match, case-insensitive like the backend's own `project_name` handling on the trace and thread endpoints, because the agent-insights endpoints take `project_id` only. Exact case wins when both exist. Ambiguous names list the candidates. An unknown name gets the same "Did you mean …?" and project list that #185 gives a trace list. Substring hits are never used, and an explicit id wins over a name.

Resolutions are cached for five minutes, keyed by REST base, workspace, a hash of the credential, and the name, so list-then-read pays the lookup once. The credential is in the key because under OAuth passthrough the workspace lives server-side and this process may not know it. For the same reason the UI links are left out when an OAuth session's workspace has not been named by the header or by introspection; a wrong link would be worse than none.

`read` also accepts a pasted Diagnostics page link (`…/projects/<pid>/diagnostics?issue=<id>`, open or resolved view) and `opik://projects/<pid>/agent-insights-issues/<id>`, taking the entity type and project from the link the way thread links already work.

### Prefactor

Entity-specific kwargs are declared on the registry entry and forwarded only to the entity that declares them. `list('project', project_id=…)` now degrades to a plain project list instead of a client `TypeError`, and the "requires project scope" error no longer assumes the entity is a thread.

### Skill

With the MCP connected, `opik-diagnose` lists Diagnostics issues as its first step, keeps their order, and scans raw traces only for what Diagnostics has not grouped. The SDK path for hosts without the MCP is unchanged. The eval grader scores which traces are on the shortlist and ignores their order, so it needed no change.

Left for follow-up: issue status updates and job triggering (the UI gates them behind `canConfigure`, and the MCP has no equivalent yet), a severity filter and sorting, and an `issue` alias.

## Change checklist
- [x] User facing
- [x] Documentation updated (if needed): README `read` / `list` sections, server instructions blob, tool descriptions
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any): none. `read` and `list` gain optional parameters only.

## Issues
- OPIK-8285

## Testing

- `make check` after merging `main` (#185): 1458 tests, mypy --strict, ruff. The frozen `inputSchema` snapshots for `read` and `list` were regenerated on purpose. New optional parameters; `status` is a `Literal`, so the enum sits inside the string branch and `null` validates; `read` gains `since`/`until` for the issue entity only and rejects them for other entities.
- Live after the merge: `list('agent_insights_issue', since="3d")` maps to report days, `read(…, since="2d")` returns the 3 matching per-day rows, and #185's `list('trace', since="7d", filters=…, sort=…)` works in the same session.
- Live against dev, workspace `yaroslav-boiko`, project `support-agent-demo`, side by side with the Diagnostics page: the same 4 open issues in the same order with the same `total_occurrences` and `latest_count`; the resolved view matches; the page's 5-trace sample is the prefix of the read's 21 deduplicated ids; each id opens with `read('trace', id)`; the pasted page link resolves; a one-day window makes total equal latest; `url` opens the issue and `trace_url_template` opens the trace panel.
- Driven as an agent host over stdio and then through Claude Code's own MCP connection: initialize, tools/list, the full triage flow, and the usual agent mistakes (missing scope, wrong-case name, misspelled name, uppercase status, inverted window, natural-language date, guessed entity name, link with the wrong entity type). The cache cut a repeated read from 1,063 ms to 359 ms, and a 600-token budget now returns 341 tokens.
- Not run: the `opik-diagnose` eval harness, which seeds a live project and needs an agent run. Reading the grader confirmed it scores shortlist contents and ignores order.

## Documentation

README (`read`, `list`, Diagnostics issues paragraph), the `InitializeResult.instructions` blob, and the `read` / `list` tool descriptions. No docs-site change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
