### PR TITLE
[OPIK-8283] Search across traces, spans, threads and experiments through list

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,19 @@ with a timezone, so "the last hour" needs no clock arithmetic. The window is by
 record creation time, which is cheap for the backend and agrees with
 `start_time` within seconds for live traffic; use `start_time` in `filters`
 for an exact bound. The same three types take `search`, free text matched
-anywhere in id, name, input, output, metadata, tags and thread id.
+anywhere in id, name, input, output, metadata, tags and thread id. Search is a
+full scan on the backend and can take tens of seconds on a large project the
+first time; those calls get a 60-second timeout, and narrowing with `since`
+first keeps them quick.
+
+**Reading the table.** Durations are labelled `duration_ms` / `ttft_ms` and
+shown as whole milliseconds; the field stays `duration` in `filters` and
+`sort`. Timestamps are shown to the second and costs as plain decimals.
+Project rows carry `last_updated_trace_at` so you can see which project has
+live traffic; thread rows carry the first message. An empty page under a time
+window says when the project's last trace landed, and an empty page under the
+default `source = "sdk"` says how to see the other sources. A misspelled
+`project_name` comes back with the closest existing name.
 
 ```python
 list(entity_type="trace", project_name="demo", since="1h",

--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ list(entity_type="trace", project_name="demo",
      filters='error_info is_not_empty AND duration > 5000')
 list(entity_type="span", project_name="demo",          # spans across the whole project
      filters='type = "llm" AND usage.total_tokens > 10000')
+list(entity_type="thread", project_name="demo",
+     filters='number_of_messages > 20 AND feedback_scores.helpfulness < 0.5')
+list(entity_type="experiment",
+     filters='dataset_id = "<dataset-uuid>" AND tags contains "baseline"')
 ```
 
 **Filters.** `trace`, `span`, `thread` and `experiment` take an OQL string, the

--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ the position of a syntax error, the closest field name, the valid operators for
 the field's type, or the expected value format. Ask `schema("list.trace")` (or
 `list.span`, `list.thread`, `list.experiment`) for the full field reference.
 
+**Sort.** The same four types take `sort="<field> [asc|desc]"`, `desc` by
+default and one field only: `sort="duration desc"`, `sort="total_estimated_cost"`,
+`sort="feedback_scores.accuracy asc"`, `sort="usage.total_tokens"`. The field is
+checked against the entity's sortable list before the call, because the backend
+silently ignores fields it cannot sort by. On very large workspaces the backend
+drops sorting altogether; the header says so when that happens.
+
 ### `write`
 
 Universal write dispatcher. Pass `operation` + `data` and the dispatcher

--- a/README.md
+++ b/README.md
@@ -346,6 +346,15 @@ schema(operation="score.create")
 schema(operation="prompt_version.save")
 ```
 
+The same tool answers `list.trace`, `list.span`, `list.thread` and
+`list.experiment` with the `list` tool's reference for that entity: every
+filterable field with its type and valid operators, the sortable fields, whether
+a time window and free-text search apply, and two example filters.
+
+```python
+schema(operation="list.trace")
+```
+
 ---
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ read(entity_type="trace", id="opik://traces/7f2e3c8a-…")
 ### `list`
 
 Browse or search a collection with pagination. Project-scoped types (`trace`,
-`thread`, `test_suite_item`, `prompt_version`) require their parent — a project
-UUID or name, a suite UUID, a prompt UUID.
+`span`, `thread`, `test_suite_item`, `prompt_version`) require their parent — a
+project UUID or name, a suite UUID, a prompt UUID.
 
 ```python
 list(entity_type="experiment", page=1, size=25)
@@ -252,6 +252,8 @@ list(entity_type="experiment", name="rerank")          # name substring filter
 list(entity_type="trace", project_name="demo")         # latest traces of one project
 list(entity_type="trace", project_name="demo",
      filters='error_info is_not_empty AND duration > 5000')
+list(entity_type="span", project_name="demo",          # spans across the whole project
+     filters='type = "llm" AND usage.total_tokens > 10000')
 ```
 
 **Filters.** `trace`, `span`, `thread` and `experiment` take an OQL string, the

--- a/README.md
+++ b/README.md
@@ -242,14 +242,39 @@ read(entity_type="trace", id="opik://traces/7f2e3c8a-…")
 
 ### `list`
 
-Browse a collection with optional name filter and pagination. Project-scoped
-types (`trace`, `test_suite_item`, `prompt_version`) require their parent UUID.
+Browse or search a collection with pagination. Project-scoped types (`trace`,
+`thread`, `test_suite_item`, `prompt_version`) require their parent — a project
+UUID or name, a suite UUID, a prompt UUID.
 
 ```python
 list(entity_type="experiment", page=1, size=25)
 list(entity_type="experiment", name="rerank")          # name substring filter
-list(entity_type="trace", project_id="<project-uuid>") # traces of one project
+list(entity_type="trace", project_name="demo")         # latest traces of one project
+list(entity_type="trace", project_name="demo",
+     filters='error_info is_not_empty AND duration > 5000')
 ```
+
+**Filters.** `trace`, `span`, `thread` and `experiment` take an OQL string, the
+same grammar as the SDK's `search_traces(filter_string=…)`:
+
+```
+<field>[.<key>] <op> <value> [AND ...]
+ops: = != > >= < <= contains not_contains starts_with ends_with is_empty is_not_empty in not_in
+```
+
+Strings go in double quotes, numbers are bare, `duration` is in milliseconds,
+dates are ISO-8601 instants with a timezone (`"2026-09-08T10:00:00Z"`).
+Scores and dictionaries take a key: `feedback_scores.accuracy < 0.5`,
+`metadata.environment = "prod"`. `AND` is the only connector.
+
+Like the UI's Logs page, trace, span and thread lists add `source = "sdk"` so
+evaluator, playground and experiment traces stay out of the way; name `source`
+yourself to see them. The first output line echoes the filter that was applied.
+
+A bad filter fails before reaching the backend with what is needed to fix it:
+the position of a syntax error, the closest field name, the valid operators for
+the field's type, or the expected value format. Ask `schema("list.trace")` (or
+`list.span`, `list.thread`, `list.experiment`) for the full field reference.
 
 ### `write`
 

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ read(entity_type="trace", id="opik://traces/7f2e3c8a-…")
 ### `list`
 
 Browse or search a collection with pagination. Project-scoped types (`trace`,
-`span`, `thread`, `test_suite_item`, `prompt_version`) require their parent — a
-project UUID or name, a suite UUID, a prompt UUID.
+`span`, `thread`, `test_suite_item`, `prompt_version`) need their parent: a
+project UUID or name, a suite UUID, or a prompt UUID.
 
 ```python
 list(entity_type="experiment", page=1, size=25)
@@ -293,12 +293,12 @@ drops sorting altogether; the header says so when that happens.
 `until`, each a relative span (`"30m"`, `"1h"`, `"7d"`) or an ISO-8601 instant
 with a timezone, so "the last hour" needs no clock arithmetic. The window is by
 record creation time, which is cheap for the backend and agrees with
-`start_time` within seconds for live traffic; use `start_time` in `filters`
-for an exact bound. The same three types take `search`, free text matched
-anywhere in id, name, input, output, metadata, tags and thread id. Search is a
-full scan on the backend and can take tens of seconds on a large project the
-first time; those calls get a 60-second timeout, and narrowing with `since`
-first keeps them quick.
+`start_time` within seconds for live traffic. For an exact bound, put
+`start_time` in `filters`. The same three types take `search`, free text matched
+anywhere in id, name, input, output, metadata, tags and thread id. Search scans
+the whole project on the backend, so the first call on a large project can take
+tens of seconds. Those calls get a 60-second timeout. Adding `since` makes them
+fast again.
 
 **Reading the table.** Durations are labelled `duration_ms` / `ttft_ms` and
 shown as whole milliseconds; the field stays `duration` in `filters` and

--- a/README.md
+++ b/README.md
@@ -289,6 +289,20 @@ checked against the entity's sortable list before the call, because the backend
 silently ignores fields it cannot sort by. On very large workspaces the backend
 drops sorting altogether; the header says so when that happens.
 
+**Time window and search.** `trace`, `span` and `thread` take `since` and
+`until`, each a relative span (`"30m"`, `"1h"`, `"7d"`) or an ISO-8601 instant
+with a timezone, so "the last hour" needs no clock arithmetic. The window is by
+record creation time, which is cheap for the backend and agrees with
+`start_time` within seconds for live traffic; use `start_time` in `filters`
+for an exact bound. The same three types take `search`, free text matched
+anywhere in id, name, input, output, metadata, tags and thread id.
+
+```python
+list(entity_type="trace", project_name="demo", since="1h",
+     filters="error_info is_not_empty", sort="duration desc")
+list(entity_type="trace", project_name="demo", search="order-42")
+```
+
 ### `write`
 
 Universal write dispatcher. Pass `operation` + `data` and the dispatcher

--- a/src/opik_mcp/instructions.py
+++ b/src/opik_mcp/instructions.py
@@ -41,12 +41,17 @@ in workspace "{workspace}". The Opik UI is at {opik_url}.
 Tool selection:
 - read / list: use for any "show me X" or "what is Y" — these are the cheapest \
 reads. read takes (entity_type, id_or_name_or_uri); list takes (entity_type, \
-optional name filter, page, size). Readable entity types include trace, span, \
-project, experiment, prompt, test_suite, thread. Composite reads (trace, prompt, \
-thread) inline their child collections so one call usually gets the full picture. \
-For a thread, pass the thread link/URI or a project_id — read('thread', …) \
-returns the messages list, and list('thread', project_id=…) enumerates a \
-project's threads.
+page, size, and a name substring for workspace-wide types). For trace, span, \
+thread and experiment, list \
+also takes filters (OQL, the same language as search_traces(filter_string=…)), \
+sort, since/until and search, so one call answers most questions: \
+list('trace', project_name=…, since="1h", filters="error_info is_not_empty", \
+sort="duration desc"). Field reference: schema("list.trace"). Readable entity \
+types include trace, span, project, experiment, prompt, test_suite, thread. \
+Composite reads (trace, prompt, thread) inline their child collections so one \
+call usually gets the full picture. For a thread, pass the thread link/URI or a \
+project_id — read('thread', …) returns the messages list, and \
+list('thread', project_id=…) enumerates a project's threads.
 - Direct writes — use when the user's intent is concrete and well-defined \
 ("score this trace 0.8 on helpfulness", "comment 'retry with temperature=0' \
 on span X"). The full write surface is two tools: write (takes \

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -954,10 +954,17 @@ def opik_rest_base(settings: Settings) -> str | None:
     return None
 
 
-def make_opik_client(settings: Settings) -> OpikClient:
-    """Construct an ``OpikClient`` bound to the configured workspace."""
+def make_opik_client(settings: Settings, *, timeout: float | None = None) -> OpikClient:
+    """Construct an ``OpikClient`` bound to the configured workspace.
+
+    ``timeout`` overrides the default per-request timeout; the ``list`` tool
+    passes a longer one for free-text ``search``, which the backend can take
+    over 30 s to answer on a cold cache.
+    """
     base_url, api_key, workspace = resolve_opik_config(settings)
-    return OpikClient(base_url=base_url, api_key=api_key, workspace=workspace)
+    if timeout is None:
+        return OpikClient(base_url=base_url, api_key=api_key, workspace=workspace)
+    return OpikClient(base_url=base_url, api_key=api_key, workspace=workspace, timeout=timeout)
 
 
 def _score_body(score: FeedbackScore) -> dict[str, Any]:

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -962,9 +962,12 @@ def make_opik_client(settings: Settings, *, timeout: float | None = None) -> Opi
     over 30 s to answer on a cold cache.
     """
     base_url, api_key, workspace = resolve_opik_config(settings)
-    if timeout is None:
-        return OpikClient(base_url=base_url, api_key=api_key, workspace=workspace)
-    return OpikClient(base_url=base_url, api_key=api_key, workspace=workspace, timeout=timeout)
+    return OpikClient(
+        base_url=base_url,
+        api_key=api_key,
+        workspace=workspace,
+        timeout=_DEFAULT_TIMEOUT if timeout is None else timeout,
+    )
 
 
 def _score_body(score: FeedbackScore) -> dict[str, Any]:

--- a/src/opik_mcp/opik_client.py
+++ b/src/opik_mcp/opik_client.py
@@ -127,6 +127,11 @@ class OpikListClient(Protocol):
         project_id: str | None = None,
         project_name: str | None = None,
         filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]: ...
@@ -136,6 +141,12 @@ class OpikListClient(Protocol):
         *,
         project_id: str | None = None,
         project_name: str | None = None,
+        filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]: ...
@@ -143,9 +154,15 @@ class OpikListClient(Protocol):
     async def list_spans(
         self,
         *,
-        trace_id: str,
+        trace_id: str | None = None,
         project_id: str | None = None,
         project_name: str | None = None,
+        filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
         page: int = 1,
         size: int = 100,
     ) -> dict[str, Any]: ...
@@ -159,7 +176,17 @@ class OpikListClient(Protocol):
     ) -> dict[str, Any]: ...
 
     async def list_experiments(
-        self, *, name: str | None = None, page: int = 1, size: int = 10
+        self,
+        *,
+        name: str | None = None,
+        filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
+        page: int = 1,
+        size: int = 10,
     ) -> dict[str, Any]: ...
 
     async def list_prompts(
@@ -209,6 +236,35 @@ _DEFAULT_TIMEOUT: Final = 30.0
 
 def _drop_none(d: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in d.items() if v is not None}
+
+
+def _search_params(
+    *,
+    filters: str | None,
+    sorting: str | None,
+    search: str | None,
+    from_time: str | None,
+    to_time: str | None,
+    truncate: bool | None,
+) -> dict[str, Any]:
+    """Query params shared by the searchable list endpoints (traces, spans,
+    threads, experiments). Only set values are sent: the backend treats an
+    empty ``filters=`` as malformed JSON and answers 400.
+
+    ``truncate`` is rendered as the lowercase literal the backend's boolean
+    query param parser expects (httpx would otherwise send ``True``)."""
+    params = _drop_none(
+        {
+            "filters": filters,
+            "sorting": sorting,
+            "search": search,
+            "from_time": from_time,
+            "to_time": to_time,
+        }
+    )
+    if truncate is not None:
+        params["truncate"] = "true" if truncate else "false"
+    return params
 
 
 class OpikClient:
@@ -349,15 +405,22 @@ class OpikClient:
         project_id: str | None = None,
         project_name: str | None = None,
         filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]:
         """``GET /v1/private/traces`` — requires ``project_id`` or ``project_name``.
 
         ``filters`` is the backend's JSON-encoded filter array (query param),
-        e.g. ``[{"field":"thread_id","operator":"=","value":"<id>"}]`` — used
-        by the thread read to pull a thread's messages. Forwarded only when set;
-        the ``list`` tool never passes it.
+        e.g. ``[{"field":"thread_id","operator":"=","value":"<id>"}]``; the
+        ``list`` tool compiles OQL into it and the thread read uses it to pull a
+        thread's messages. ``sorting`` is the JSON-encoded ``[{field,direction}]``
+        array, ``search`` a free-text term, ``from_time``/``to_time`` ISO-8601
+        instants. Each is forwarded only when set.
         """
         if project_id is None and project_name is None:
             raise ValueError("list_traces requires project_id or project_name")
@@ -366,8 +429,16 @@ class OpikClient:
             params["project_id"] = project_id
         if project_name is not None:
             params["project_name"] = project_name
-        if filters is not None:
-            params["filters"] = filters
+        params.update(
+            _search_params(
+                filters=filters,
+                sorting=sorting,
+                search=search,
+                from_time=from_time,
+                to_time=to_time,
+                truncate=truncate,
+            )
+        )
         return await self._get_json("/v1/private/traces", params=params, entity_hint="traces")
 
     async def get_trace(self, trace_id: str) -> dict[str, Any]:
@@ -383,6 +454,12 @@ class OpikClient:
         *,
         project_id: str | None = None,
         project_name: str | None = None,
+        filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]:
@@ -390,7 +467,8 @@ class OpikClient:
 
         A thread groups traces by ``thread_id`` within one project, so listing
         requires ``project_id`` or ``project_name`` (like ``list_traces``).
-        Returns a Spring Page envelope ``{content, page, size, total}``.
+        Returns a Spring Page envelope ``{content, page, size, total}``. Search
+        params are the same as ``list_traces`` and forwarded only when set.
         """
         if project_id is None and project_name is None:
             raise ValueError("list_threads requires project_id or project_name")
@@ -399,6 +477,16 @@ class OpikClient:
             params["project_id"] = project_id
         if project_name is not None:
             params["project_name"] = project_name
+        params.update(
+            _search_params(
+                filters=filters,
+                sorting=sorting,
+                search=search,
+                from_time=from_time,
+                to_time=to_time,
+                truncate=truncate,
+            )
+        )
         return await self._get_json(
             "/v1/private/traces/threads",
             params=params,
@@ -437,31 +525,47 @@ class OpikClient:
     async def list_spans(
         self,
         *,
-        trace_id: str,
+        trace_id: str | None = None,
         project_id: str | None = None,
         project_name: str | None = None,
+        filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
         page: int = 1,
         size: int = 100,
     ) -> dict[str, Any]:
-        """``GET /v1/private/spans?trace_id=...&project_id=...`` — spans on one trace.
+        """``GET /v1/private/spans`` — spans of one trace, or across a project.
 
         opik-backend rejects ``GET /v1/private/spans`` with 400 if neither
         ``project_id`` nor ``project_name`` is supplied (the spans index is
-        sharded by project). Callers must thread one through; the resource
-        layer extracts ``project_id`` from the trace record it just fetched.
+        sharded by project). ``trace_id`` is optional: the trace read passes it
+        to inline one trace's spans, the ``list`` tool omits it to search spans
+        project-wide. Search params are the same as ``list_traces``.
         """
         if project_id is None and project_name is None:
             raise ValueError("list_spans requires project_id or project_name")
-        params: dict[str, Any] = {"trace_id": trace_id, "page": page, "size": size}
+        params: dict[str, Any] = {"page": page, "size": size}
+        if trace_id is not None:
+            params["trace_id"] = trace_id
         if project_id is not None:
             params["project_id"] = project_id
         if project_name is not None:
             params["project_name"] = project_name
-        return await self._get_json(
-            "/v1/private/spans",
-            params=params,
-            entity_hint=f"spans for trace {trace_id!r}",
+        params.update(
+            _search_params(
+                filters=filters,
+                sorting=sorting,
+                search=search,
+                from_time=from_time,
+                to_time=to_time,
+                truncate=truncate,
+            )
         )
+        hint = f"spans for trace {trace_id!r}" if trace_id is not None else "spans"
+        return await self._get_json("/v1/private/spans", params=params, entity_hint=hint)
 
     async def get_span(self, span_id: str) -> dict[str, Any]:
         """``GET /v1/private/spans/{id}`` — single span."""
@@ -522,13 +626,35 @@ class OpikClient:
         self,
         *,
         name: str | None = None,
+        filters: str | None = None,
+        sorting: str | None = None,
+        search: str | None = None,
+        from_time: str | None = None,
+        to_time: str | None = None,
+        truncate: bool | None = None,
         page: int = 1,
         size: int = 10,
     ) -> dict[str, Any]:
-        """``GET /v1/private/experiments`` — Spring Page envelope."""
+        """``GET /v1/private/experiments`` — Spring Page envelope.
+
+        ``name`` is the backend's case-insensitive partial match. The search
+        params are accepted for signature parity with the other searchable
+        lists and forwarded only when set; the ``list`` tool never sends a time
+        window or free-text search for experiments (the backend has neither).
+        """
         params: dict[str, Any] = {"page": page, "size": size}
         if name is not None:
             params["name"] = name
+        params.update(
+            _search_params(
+                filters=filters,
+                sorting=sorting,
+                search=search,
+                from_time=from_time,
+                to_time=to_time,
+                truncate=truncate,
+            )
+        )
         return await self._get_json(
             "/v1/private/experiments",
             params=params,

--- a/src/opik_mcp/read_list/errors.py
+++ b/src/opik_mcp/read_list/errors.py
@@ -10,12 +10,13 @@ now chains through (``raise ToolError(str(err)) from err``). It owns the
 ``"validation"`` / 400 ClassVars so ``analytics/errors.bucket_exception``
 can route the bucket via ``getattr(type(real), "error_kind")``.
 
-We deliberately keep this as a single coarse class rather than per-failure-
-mode subclasses: the validation surface is small and stable, every case
-answers the same dashboard question ("the caller passed something the tool
-can't handle"), and BI's ``cause_type`` already carries the wrapper class
-for triage. Future divergence (e.g. a distinct ``entity_not_listable``
-bucket) can split the class then; YAGNI today.
+The entity-argument cases (unknown entity_type, missing parent id) stay on
+this one coarse class. The ``list`` search surface (OPIK-8283) subclasses it
+per failure kind — ``OQLSyntaxError`` … ``OQLBadValueError`` in ``oql.py``,
+``SortError`` in ``sorting.py``, ``WindowError`` in ``window.py`` — because
+the analytics wrapper records only exception class names on failure, and
+"which kind of filter mistake do agents make" is a question the dashboards
+need answered without ever seeing the string that failed.
 """
 
 from __future__ import annotations

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -43,6 +43,7 @@ from opik_mcp.read_list.oql import (
     render_filters,
 )
 from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, EntityHandler
+from opik_mcp.read_list.sorting import SortError, compile_sort
 
 logger = logging.getLogger("opik_mcp.read_list.list")
 
@@ -60,6 +61,7 @@ async def run_list(
     *,
     name: str | None = None,
     filters: str | None = None,
+    sort: str | None = None,
     page: int = 1,
     size: int = 25,
     project_id: str | None = None,
@@ -122,6 +124,17 @@ async def run_list(
         # Bodies never reach the table, so let the backend trim them.
         kw["truncate"] = True
 
+    sort_label: str | None = None
+    if sort is not None:
+        try:
+            sort_field, direction = compile_sort(entity_type, sort)
+        except SortError as err:
+            raise ToolError(str(err)) from err
+        kw["sorting"] = json.dumps(
+            [{"field": sort_field, "direction": direction}], separators=(",", ":")
+        )
+        sort_label = f"sort: {sort_field} {direction.lower()}"
+
     opik = client if client is not None else make_opik_client(settings or get_settings())
 
     try:
@@ -133,6 +146,13 @@ async def run_list(
     content: list[dict[str, Any]] = [it for it in content_raw if isinstance(it, dict)]
     total_raw = page_body.get("total")
     total = total_raw if isinstance(total_raw, int) and total_raw >= 0 else len(content)
+
+    if sort_label is not None:
+        # The backend blanks ``sortable_by`` when it dropped sorting for a large
+        # workspace — the only signal that the page is not actually ordered.
+        if page_body.get("sortable_by") == []:
+            sort_label += " (dropped by the backend for this workspace size; page is unsorted)"
+        applied.append(sort_label)
 
     header = f"[list: {entity_type} | {' | '.join(applied)}]" if applied else None
     if not content:

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -20,8 +20,11 @@ traffic. Whatever was applied is echoed on the first output line.
 
 from __future__ import annotations
 
+import difflib
 import json
 import logging
+import re
+from decimal import Decimal
 from typing import Any
 
 import httpx
@@ -47,12 +50,22 @@ from opik_mcp.read_list.oql import (
 )
 from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, EntityHandler
 from opik_mcp.read_list.sorting import SortError, compile_sort
-from opik_mcp.read_list.window import WindowError, resolve_window
+from opik_mcp.read_list.window import (
+    WindowError,
+    format_instant,
+    is_relative,
+    parse_instant,
+    resolve_window,
+    to_minute,
+)
 
 logger = logging.getLogger("opik_mcp.read_list.list")
 
 _MAX_SIZE = 100
 _TRUNCATE_AT = 60
+# Free-text search is an ilike across several columns; on a cold cache the
+# backend took 32 s live. Everything else keeps the client's 30 s default.
+_SEARCH_TIMEOUT_S = 60.0
 
 _SDK_SOURCE_CLAUSE = {"field": "source", "operator": "=", "key": "", "value": "sdk"}
 
@@ -152,10 +165,10 @@ async def run_list(
             raise ToolError(str(err)) from err
         if from_time is not None:
             kw["from_time"] = from_time
-            applied.append(f"since: {from_time}")
+            applied.append(f"since: {_window_echo(since, from_time)}")
         if to_time is not None:
             kw["to_time"] = to_time
-            applied.append(f"until: {to_time}")
+            applied.append(f"until: {_window_echo(until, to_time)}")
 
     if search is not None and search.strip():
         if entity_type in WINDOWED_ENTITIES:
@@ -176,11 +189,21 @@ async def run_list(
         )
         sort_label = f"sort: {sort_field} {direction.lower()}"
 
-    opik = client if client is not None else make_opik_client(settings or get_settings())
+    if client is not None:
+        opik = client
+    else:
+        # Free-text search can take the backend >30 s on a cold cache (seen
+        # live: 32 s); give only those calls a longer leash.
+        timeout = _SEARCH_TIMEOUT_S if "search" in kw else None
+        opik = make_opik_client(settings or get_settings(), timeout=timeout)
 
     try:
         page_body = await handler.list_fn(opik, **kw)
-    except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as e:
+    except OpikNotFoundError as e:
+        if kw.get("project_name"):
+            raise ToolError(await _unknown_project_message(opik, kw["project_name"])) from e
+        raise ToolError(f"Failed to list {entity_type}s: {e}") from e
+    except (OpikAuthError, OpikValidationError, OpikServerError) as e:
         raise ToolError(f"Failed to list {entity_type}s: {e}") from e
     except httpx.TimeoutException as e:
         # ``str(httpx.ReadTimeout)`` is often empty, so without this the agent
@@ -219,11 +242,67 @@ async def run_list(
                 ' Only source = "sdk" rows are listed by default; add source = "experiment", '
                 '"evaluator" or "playground" to filters to see the others.'
             )
+        elif "from_time" in kw:
+            # Seen live: since="30d" on a project whose traffic ended weeks
+            # earlier looks like a project with no traffic. One project read
+            # tells the agent which it is, and how far to widen the window.
+            last_trace = await _last_trace_hint(opik, kw, kw["from_time"])
+            if last_trace:
+                empty += " " + last_trace
         return f"{header}\n{empty}" if header else empty
 
     extra = _requested_columns(sort_field, clauses)
     table = _format_table(entity_type, handler, content, total, page, size, name, extra)
     return f"{header}\n{table}" if header else table
+
+
+def _window_echo(raw: str | None, resolved: str) -> str:
+    """``30d (2026-08-09T11:03Z)`` for shorthand, the bound to the minute for ISO."""
+    minute = to_minute(resolved)
+    if raw is not None and is_relative(raw):
+        return f"{raw.strip()} ({minute})"
+    return minute
+
+
+async def _unknown_project_message(opik: OpikListClient, project_name: str) -> str:
+    """One extra call on a project-name 404: the names that do exist, and the
+    closest one. The backend matches names exactly, so a typo is the common case."""
+    try:
+        body = await opik.list_projects(size=100)
+        names = [
+            p["name"] for p in body.get("content") or [] if isinstance(p, dict) and "name" in p
+        ]
+    except Exception:  # recovery must never mask the 404 itself
+        names = []
+    message = f"Project {project_name!r} not found."
+    close = difflib.get_close_matches(project_name, names, n=1, cutoff=0.6)
+    if close:
+        message += f" Did you mean {close[0]!r}?"
+    if names:
+        message += f" Projects: {', '.join(names)}."
+    return message
+
+
+async def _last_trace_hint(opik: OpikListClient, kw: dict[str, Any], from_time: str) -> str | None:
+    """For an empty windowed page: when the project's last trace landed."""
+    try:
+        if kw.get("project_name"):
+            body = await opik.list_projects(name=kw["project_name"], size=5)
+            rows = [p for p in body.get("content") or [] if p.get("name") == kw["project_name"]]
+        else:
+            body = await opik.list_projects(size=100)
+            rows = [p for p in body.get("content") or [] if p.get("id") == kw.get("project_id")]
+    except Exception:  # a hint must never turn an empty page into an error
+        return None
+    if not rows:
+        return None
+    last = rows[0].get("last_updated_trace_at")
+    if not last:
+        return "This project has no traces yet."
+    last_dt, start_dt = parse_instant(str(last)), parse_instant(from_time)
+    if last_dt is None or start_dt is None or last_dt >= start_dt:
+        return None
+    return f"Last trace in this project: {to_minute(format_instant(last_dt))}, before your window."
 
 
 # Filter fields that make no sense as a table column: bodies (never shown in a
@@ -275,13 +354,12 @@ def _format_table(
     else:
         header = f"Found {total} {entity_type}s (page {page}, showing {count} of {total}):"
 
-    col_header = " | ".join(columns)
+    col_header = " | ".join(_COLUMN_LABELS.get(c, c) for c in columns)
     rows: list[str] = []
     for item in content:
         values: list[str] = []
         for col in columns:
-            val = _cell(item, col)
-            s = "" if val is None else str(val)
+            s = _render(col, _cell(item, col))
             if len(s) > _TRUNCATE_AT:
                 s = s[: _TRUNCATE_AT - 3] + "..."
             values.append(s)
@@ -327,6 +405,33 @@ def _cell(item: dict[str, Any], col: str) -> Any:
 
 def _score_summary(scores: list[dict[str, Any]]) -> str:
     return ", ".join(f"{s.get('name')}={s.get('value')}" for s in scores if "name" in s)
+
+
+# Header labels that carry the unit the backend leaves implicit. The field
+# keeps its backend name in filters/sort (``duration > 5000``); only the
+# column heading says ``_ms`` so the agent never mistakes 82.461 for seconds.
+_COLUMN_LABELS = {"duration": "duration_ms", "ttft": "ttft_ms"}
+_ISO_WITH_FRACTION = re.compile(r"^(\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d)(?:\.\d+)?(Z|[+-]\d\d:\d\d)$")
+
+
+def _render(col: str, val: Any) -> str:
+    """One cell, compact: whole milliseconds, seconds-precision timestamps,
+    plain decimals. Every page pays for every character here."""
+    if val is None:
+        return ""
+    if col in _COLUMN_LABELS and isinstance(val, int | float) and not isinstance(val, bool):
+        return str(round(val))
+    if isinstance(val, float):
+        text = repr(val)
+        if "e" in text or "E" in text:
+            return format(Decimal(text), "f")
+        return text
+    if isinstance(val, str):
+        m = _ISO_WITH_FRACTION.match(val)
+        if m:
+            tz = "Z" if m.group(2) in ("Z", "+00:00") else m.group(2)
+            return m.group(1) + tz
+    return str(val)
 
 
 __all__ = ["run_list"]

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 import difflib
 import json
 import logging
+import math
 import re
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
 import httpx
@@ -52,7 +53,6 @@ from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, EntityH
 from opik_mcp.read_list.sorting import SortError, compile_sort
 from opik_mcp.read_list.window import (
     WindowError,
-    format_instant,
     is_relative,
     parse_instant,
     resolve_window,
@@ -163,10 +163,10 @@ async def run_list(
             from_time, to_time = resolve_window(since, until)
         except WindowError as err:
             raise ToolError(str(err)) from err
-        if from_time is not None:
+        if since is not None and from_time is not None:
             kw["from_time"] = from_time
             applied.append(f"since: {_window_echo(since, from_time)}")
-        if to_time is not None:
+        if until is not None and to_time is not None:
             kw["to_time"] = to_time
             applied.append(f"until: {_window_echo(until, to_time)}")
 
@@ -200,7 +200,9 @@ async def run_list(
     try:
         page_body = await handler.list_fn(opik, **kw)
     except OpikNotFoundError as e:
-        if kw.get("project_name"):
+        # The backend's 404 for a misspelled project names it ("Project name: X
+        # not found"); only that case gets the did-you-mean recovery.
+        if kw.get("project_name") and kw["project_name"] in str(e):
             raise ToolError(await _unknown_project_message(opik, kw["project_name"])) from e
         raise ToolError(f"Failed to list {entity_type}s: {e}") from e
     except (OpikAuthError, OpikValidationError, OpikServerError) as e:
@@ -230,25 +232,18 @@ async def run_list(
 
     header = f"[list: {entity_type} | {' | '.join(applied)}]" if applied else None
     if not content:
-        empty = (
-            f"No {entity_type}s matching {name!r} found." if name else f"No {entity_type}s found."
+        # "No agent constraints" = nothing but the default source clause, no
+        # window, no search. A sort does not change what matches.
+        unconstrained = source_defaulted and len(clauses) == 1 and "search" not in kw
+        empty = await _empty_message(
+            opik,
+            entity_type,
+            name=name,
+            project_name=kw.get("project_name"),
+            project_id=kw.get("project_id"),
+            from_time=kw.get("from_time"),
+            unconstrained=unconstrained,
         )
-        if source_defaulted and len(clauses) == 1 and len(applied) == 1:
-            # Seen live: a project holding only experiment traces looks empty
-            # under the sdk default. Say so here, where the agent is looking —
-            # but only when the default is the sole constraint; with a window
-            # or filters of the agent's own, those are the likelier reason.
-            empty += (
-                ' Only source = "sdk" rows are listed by default; add source = "experiment", '
-                '"evaluator" or "playground" to filters to see the others.'
-            )
-        elif "from_time" in kw:
-            # Seen live: since="30d" on a project whose traffic ended weeks
-            # earlier looks like a project with no traffic. One project read
-            # tells the agent which it is, and how far to widen the window.
-            last_trace = await _last_trace_hint(opik, kw, kw["from_time"])
-            if last_trace:
-                empty += " " + last_trace
         return f"{header}\n{empty}" if header else empty
 
     extra = _requested_columns(sort_field, clauses)
@@ -256,24 +251,91 @@ async def run_list(
     return f"{header}\n{table}" if header else table
 
 
-def _window_echo(raw: str | None, resolved: str) -> str:
+_SOURCE_HINT = (
+    'Only source = "sdk" rows are listed by default; add source = "experiment", '
+    '"evaluator" or "playground" to filters to see the others.'
+)
+
+
+async def _empty_message(
+    opik: OpikListClient,
+    entity_type: str,
+    *,
+    name: str | None,
+    project_name: str | None,
+    project_id: str | None,
+    from_time: str | None,
+    unconstrained: bool,
+) -> str:
+    """The empty-page reply, with the one hint that explains it when we can.
+
+    Two cases seen live look identical without help: a project holding only
+    experiment traces under the ``source = "sdk"`` default, and a window that
+    starts after the project's last trace. The first costs nothing to explain;
+    the second costs one project read, spent only on an empty windowed page.
+    """
+    empty = f"No {entity_type}s matching {name!r} found." if name else f"No {entity_type}s found."
+    if from_time is None:
+        return f"{empty} {_SOURCE_HINT}" if unconstrained else empty
+
+    rows = await _project_rows(opik, name=project_name)
+    match = [
+        p
+        for p in rows
+        if (p.get("name") == project_name if project_name else p.get("id") == project_id)
+    ]
+    if not match:
+        return empty
+    last = match[0].get("last_updated_trace_at")
+    if not last:
+        return f"{empty} This project has no traces yet."
+    last_dt, start_dt = parse_instant(str(last)), parse_instant(from_time)
+    if last_dt is None or start_dt is None:
+        return empty
+    if last_dt < start_dt:
+        return f"{empty} Last trace in this project: {to_minute(last_dt)}, before your window."
+    # Traffic exists inside the window, so the default source is what hid it.
+    return f"{empty} {_SOURCE_HINT}" if unconstrained else empty
+
+
+def _window_echo(raw: str, resolved: str) -> str:
     """``30d (2026-08-09T11:03Z)`` for shorthand, the bound to the minute for ISO."""
-    minute = to_minute(resolved)
-    if raw is not None and is_relative(raw):
+    resolved_dt = parse_instant(resolved)
+    minute = to_minute(resolved_dt) if resolved_dt is not None else resolved
+    if is_relative(raw):
         return f"{raw.strip()} ({minute})"
     return minute
+
+
+async def _project_rows(opik: OpikListClient, *, name: str | None = None) -> list[dict[str, Any]]:
+    """One page of projects for the side lookups (did-you-mean, last-trace hint).
+
+    ``name`` is the backend's substring filter, so the caller still matches
+    exactly. Failures are logged and yield ``[]``: these lookups decorate an
+    answer the agent already has and must never replace it with an error.
+    """
+    try:
+        body = (
+            await opik.list_projects(name=name, size=100)
+            if name
+            else await opik.list_projects(size=100)
+        )
+    except (
+        OpikAuthError,
+        OpikNotFoundError,
+        OpikValidationError,
+        OpikServerError,
+        httpx.HTTPError,
+    ):
+        logger.debug("project lookup for a list hint failed; skipping the hint", exc_info=True)
+        return []
+    return [p for p in body.get("content") or [] if isinstance(p, dict)]
 
 
 async def _unknown_project_message(opik: OpikListClient, project_name: str) -> str:
     """One extra call on a project-name 404: the names that do exist, and the
     closest one. The backend matches names exactly, so a typo is the common case."""
-    try:
-        body = await opik.list_projects(size=100)
-        names = [
-            p["name"] for p in body.get("content") or [] if isinstance(p, dict) and "name" in p
-        ]
-    except Exception:  # recovery must never mask the 404 itself
-        names = []
+    names = [p["name"] for p in await _project_rows(opik) if isinstance(p.get("name"), str)]
     message = f"Project {project_name!r} not found."
     close = difflib.get_close_matches(project_name, names, n=1, cutoff=0.6)
     if close:
@@ -281,28 +343,6 @@ async def _unknown_project_message(opik: OpikListClient, project_name: str) -> s
     if names:
         message += f" Projects: {', '.join(names)}."
     return message
-
-
-async def _last_trace_hint(opik: OpikListClient, kw: dict[str, Any], from_time: str) -> str | None:
-    """For an empty windowed page: when the project's last trace landed."""
-    try:
-        if kw.get("project_name"):
-            body = await opik.list_projects(name=kw["project_name"], size=5)
-            rows = [p for p in body.get("content") or [] if p.get("name") == kw["project_name"]]
-        else:
-            body = await opik.list_projects(size=100)
-            rows = [p for p in body.get("content") or [] if p.get("id") == kw.get("project_id")]
-    except Exception:  # a hint must never turn an empty page into an error
-        return None
-    if not rows:
-        return None
-    last = rows[0].get("last_updated_trace_at")
-    if not last:
-        return "This project has no traces yet."
-    last_dt, start_dt = parse_instant(str(last)), parse_instant(from_time)
-    if last_dt is None or start_dt is None or last_dt >= start_dt:
-        return None
-    return f"Last trace in this project: {to_minute(format_instant(last_dt))}, before your window."
 
 
 # Filter fields that make no sense as a table column: bodies (never shown in a
@@ -419,8 +459,11 @@ def _render(col: str, val: Any) -> str:
     plain decimals. Every page pays for every character here."""
     if val is None:
         return ""
+    if isinstance(val, float) and not math.isfinite(val):
+        return ""
     if col in _COLUMN_LABELS and isinstance(val, int | float) and not isinstance(val, bool):
-        return str(round(val))
+        # Half-up, not banker's: 82.5 ms reads as 83, the way a person rounds.
+        return str(Decimal(repr(val)).quantize(Decimal(1), rounding=ROUND_HALF_UP))
     if isinstance(val, float):
         text = repr(val)
         if "e" in text or "E" in text:

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -44,6 +44,7 @@ from opik_mcp.read_list.oql import (
 )
 from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, EntityHandler
 from opik_mcp.read_list.sorting import SortError, compile_sort
+from opik_mcp.read_list.window import WindowError, resolve_window
 
 logger = logging.getLogger("opik_mcp.read_list.list")
 
@@ -54,6 +55,10 @@ _TRUNCATE_AT = 60
 # defaults to the SDK source. Experiments are one source by definition.
 _SOURCE_DEFAULTED = frozenset({"trace", "span", "thread"})
 _SDK_SOURCE_CLAUSE = {"field": "source", "operator": "=", "key": "", "value": "sdk"}
+# Entities whose backend list takes from_time/to_time and free-text search.
+# Experiments have neither.
+_WINDOWED = ("trace", "span", "thread")
+_SEARCHABLE_TEXT = ("trace", "span", "thread")
 
 
 async def run_list(
@@ -62,6 +67,9 @@ async def run_list(
     name: str | None = None,
     filters: str | None = None,
     sort: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    search: str | None = None,
     page: int = 1,
     size: int = 25,
     project_id: str | None = None,
@@ -123,6 +131,33 @@ async def run_list(
             applied.append(f"filters: {render_filters(entity_type, clauses)}")
         # Bodies never reach the table, so let the backend trim them.
         kw["truncate"] = True
+
+    if since is not None or until is not None:
+        if entity_type not in _WINDOWED:
+            why = (
+                "experiments have no time window on the backend."
+                if entity_type == "experiment"
+                else f"only {', '.join(_WINDOWED)} take a time window."
+            )
+            unsupported = WindowError(f"since/until are not supported for {entity_type!r}: {why}")
+            raise ToolError(str(unsupported)) from unsupported
+        try:
+            from_time, to_time = resolve_window(since, until)
+        except WindowError as err:
+            raise ToolError(str(err)) from err
+        if from_time is not None:
+            kw["from_time"] = from_time
+            applied.append(f"since: {from_time}")
+        if to_time is not None:
+            kw["to_time"] = to_time
+            applied.append(f"until: {to_time}")
+
+    if search is not None and search.strip():
+        if entity_type in _SEARCHABLE_TEXT:
+            kw["search"] = search
+            applied.append(f'search: "{search}"')
+        else:
+            applied.append(f"search ignored (only {', '.join(_SEARCHABLE_TEXT)})")
 
     sort_label: str | None = None
     if sort is not None:

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -24,6 +24,7 @@ import json
 import logging
 from typing import Any
 
+import httpx
 from mcp.server.fastmcp.exceptions import ToolError
 
 from opik_mcp.config import Settings, get_settings
@@ -115,6 +116,7 @@ async def run_list(
 
     applied: list[str] = []
     clauses: list[dict[str, str]] = []
+    source_defaulted = False
     if entity_type in SUPPORTED_ENTITIES or filters:
         try:
             clauses = compile_filters(entity_type, filters or "")
@@ -124,6 +126,7 @@ async def run_list(
             c["field"] == "source" for c in clauses
         ):
             clauses.append(dict(_SDK_SOURCE_CLAUSE))
+            source_defaulted = True
         if clauses:
             kw["filters"] = json.dumps(clauses, separators=(",", ":"))
             applied.append(f"filters: {render_filters(entity_type, clauses)}")
@@ -179,6 +182,16 @@ async def run_list(
         page_body = await handler.list_fn(opik, **kw)
     except (OpikAuthError, OpikNotFoundError, OpikValidationError, OpikServerError) as e:
         raise ToolError(f"Failed to list {entity_type}s: {e}") from e
+    except httpx.TimeoutException as e:
+        # ``str(httpx.ReadTimeout)`` is often empty, so without this the agent
+        # sees an error with no text. Seen live: a free-text search that the
+        # backend took >30s to answer on a cold cache.
+        raise ToolError(
+            f"Opik did not answer in time for list({entity_type}, …). Narrow the query — "
+            "a shorter since window, fewer filters, a smaller size, or drop search — and retry."
+        ) from e
+    except httpx.HTTPError as e:
+        raise ToolError(f"Could not reach Opik for list({entity_type}, …): {e}") from e
 
     content_raw = page_body.get("content") or []
     content: list[dict[str, Any]] = [it for it in content_raw if isinstance(it, dict)]
@@ -197,6 +210,15 @@ async def run_list(
         empty = (
             f"No {entity_type}s matching {name!r} found." if name else f"No {entity_type}s found."
         )
+        if source_defaulted and len(clauses) == 1 and len(applied) == 1:
+            # Seen live: a project holding only experiment traces looks empty
+            # under the sdk default. Say so here, where the agent is looking —
+            # but only when the default is the sole constraint; with a window
+            # or filters of the agent's own, those are the likelier reason.
+            empty += (
+                ' Only source = "sdk" rows are listed by default; add source = "experiment", '
+                '"evaluator" or "playground" to filters to see the others.'
+            )
         return f"{header}\n{empty}" if header else empty
 
     extra = _requested_columns(sort_field, clauses)

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -155,7 +155,8 @@ def _format_table(
     name: str | None,
 ) -> str:
     """Pipe-delimited table — mirrors ollie's ``_format_table``."""
-    columns: tuple[str, ...] = ("id", "name", *handler.list_extra_fields)
+    base = ("id", "name") if handler.list_has_name else ("id",)
+    columns: tuple[str, ...] = (*base, *handler.list_extra_fields)
     count = len(content)
     if name:
         header = (
@@ -189,14 +190,22 @@ def _cell(item: dict[str, Any], col: str) -> Any:
 
     ``error_type`` is derived from the error container when the record does
     not carry it flat: the backend's list payload has ``error_info.exception_type``.
+    A feedback-score list (``[{name, value}, …]``) renders as ``name=value`` pairs.
     """
     if col in item:
-        return item[col]
+        val = item[col]
+        if isinstance(val, list) and val and all(isinstance(s, dict) for s in val):
+            return _score_summary(val)
+        return val
     if col == "error_type":
         info = item.get("error_info")
         if isinstance(info, dict):
             return info.get("exception_type")
     return None
+
+
+def _score_summary(scores: list[dict[str, Any]]) -> str:
+    return ", ".join(f"{s.get('name')}={s.get('value')}" for s in scores if "name" in s)
 
 
 __all__ = ["run_list"]

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -37,7 +37,9 @@ from opik_mcp.opik_client import (
 )
 from opik_mcp.read_list.errors import EntityArgValidationError
 from opik_mcp.read_list.oql import (
+    SOURCE_DEFAULTED_ENTITIES,
     SUPPORTED_ENTITIES,
+    WINDOWED_ENTITIES,
     OQLError,
     compile_filters,
     render_filters,
@@ -51,14 +53,7 @@ logger = logging.getLogger("opik_mcp.read_list.list")
 _MAX_SIZE = 100
 _TRUNCATE_AT = 60
 
-# Entities whose backend list endpoint stores a ``source`` and whose UI list
-# defaults to the SDK source. Experiments are one source by definition.
-_SOURCE_DEFAULTED = frozenset({"trace", "span", "thread"})
 _SDK_SOURCE_CLAUSE = {"field": "source", "operator": "=", "key": "", "value": "sdk"}
-# Entities whose backend list takes from_time/to_time and free-text search.
-# Experiments have neither.
-_WINDOWED = ("trace", "span", "thread")
-_SEARCHABLE_TEXT = ("trace", "span", "thread")
 
 
 async def run_list(
@@ -120,25 +115,31 @@ async def run_list(
 
     applied: list[str] = []
     clauses: list[dict[str, str]] = []
-    if entity_type in SUPPORTED_ENTITIES or filters is not None:
+    if entity_type in SUPPORTED_ENTITIES or filters:
         try:
             clauses = compile_filters(entity_type, filters or "")
         except OQLError as err:
             raise ToolError(str(err)) from err
-        if entity_type in _SOURCE_DEFAULTED and not any(c["field"] == "source" for c in clauses):
+        if entity_type in SOURCE_DEFAULTED_ENTITIES and not any(
+            c["field"] == "source" for c in clauses
+        ):
             clauses.append(dict(_SDK_SOURCE_CLAUSE))
         if clauses:
             kw["filters"] = json.dumps(clauses, separators=(",", ":"))
             applied.append(f"filters: {render_filters(entity_type, clauses)}")
+    if entity_type in WINDOWED_ENTITIES:
         # Bodies never reach the table, so let the backend trim them.
         kw["truncate"] = True
+    # The sort label is filled in after the response (the backend may have
+    # dropped the sort), but it belongs right after the filters in the header.
+    sort_slot = len(applied)
 
     if since is not None or until is not None:
-        if entity_type not in _WINDOWED:
+        if entity_type not in WINDOWED_ENTITIES:
             why = (
                 "experiments have no time window on the backend."
                 if entity_type == "experiment"
-                else f"only {', '.join(_WINDOWED)} take a time window."
+                else f"only {', '.join(WINDOWED_ENTITIES)} take a time window."
             )
             unsupported = WindowError(f"since/until are not supported for {entity_type!r}: {why}")
             raise ToolError(str(unsupported)) from unsupported
@@ -154,11 +155,11 @@ async def run_list(
             applied.append(f"until: {to_time}")
 
     if search is not None and search.strip():
-        if entity_type in _SEARCHABLE_TEXT:
+        if entity_type in WINDOWED_ENTITIES:
             kw["search"] = search
             applied.append(f'search: "{search}"')
         else:
-            applied.append(f"search ignored (only {', '.join(_SEARCHABLE_TEXT)})")
+            applied.append(f"search ignored (only {', '.join(WINDOWED_ENTITIES)})")
 
     sort_label: str | None = None
     sort_field: str | None = None
@@ -189,7 +190,7 @@ async def run_list(
         # workspace — the only signal that the page is not actually ordered.
         if page_body.get("sortable_by") == []:
             sort_label += " (dropped by the backend for this workspace size; page is unsorted)"
-        applied.append(sort_label)
+        applied.insert(sort_slot, sort_label)
 
     header = f"[list: {entity_type} | {' | '.join(applied)}]" if applied else None
     if not content:

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -119,6 +119,7 @@ async def run_list(
             raise ToolError(str(err)) from err
 
     applied: list[str] = []
+    clauses: list[dict[str, str]] = []
     if entity_type in SUPPORTED_ENTITIES or filters is not None:
         try:
             clauses = compile_filters(entity_type, filters or "")
@@ -160,6 +161,7 @@ async def run_list(
             applied.append(f"search ignored (only {', '.join(_SEARCHABLE_TEXT)})")
 
     sort_label: str | None = None
+    sort_field: str | None = None
     if sort is not None:
         try:
             sort_field, direction = compile_sort(entity_type, sort)
@@ -196,8 +198,28 @@ async def run_list(
         )
         return f"{header}\n{empty}" if header else empty
 
-    table = _format_table(entity_type, handler, content, total, page, size, name)
+    extra = _requested_columns(sort_field, clauses)
+    table = _format_table(entity_type, handler, content, total, page, size, name, extra)
     return f"{header}\n{table}" if header else table
+
+
+# Filter fields that make no sense as a table column: bodies (never shown in a
+# list), the error container (error_type carries the useful part) and source
+# (it is a scope, not a per-row fact).
+_NEVER_COLUMNS = frozenset({"input", "output", "input_json", "output_json", "error_info", "source"})
+
+
+def _requested_columns(sort_field: str | None, clauses: list[dict[str, str]]) -> list[str]:
+    """Columns the request names — the sort field first, then filter fields in
+    order of first mention. Nested references keep their ``field.key`` form."""
+    out: list[str] = []
+    if sort_field is not None:
+        out.append(sort_field)
+    for c in clauses:
+        col = f"{c['field']}.{c['key']}" if c.get("key") else c["field"]
+        if c["field"] not in _NEVER_COLUMNS and col not in out:
+            out.append(col)
+    return out
 
 
 def _format_table(
@@ -208,10 +230,19 @@ def _format_table(
     page: int,
     size: int,
     name: str | None,
+    extra_columns: list[str] | None = None,
 ) -> str:
-    """Pipe-delimited table — mirrors ollie's ``_format_table``."""
+    """Pipe-delimited table — mirrors ollie's ``_format_table``.
+
+    ``extra_columns`` are the fields the request sorted or filtered on; they
+    are appended after the entity's default columns (deduplicated) so the
+    table shows why each row is present and in what order.
+    """
     base = ("id", "name") if handler.list_has_name else ("id",)
     columns: tuple[str, ...] = (*base, *handler.list_extra_fields)
+    for col in extra_columns or ():
+        if col not in columns:
+            columns = (*columns, col)
     count = len(content)
     if name:
         header = (
@@ -246,6 +277,9 @@ def _cell(item: dict[str, Any], col: str) -> Any:
     ``error_type`` is derived from the error container when the record does
     not carry it flat: the backend's list payload has ``error_info.exception_type``.
     A feedback-score list (``[{name, value}, …]``) renders as ``name=value`` pairs.
+    A dotted column (``feedback_scores.accuracy``, ``usage.total_tokens``,
+    ``metadata.environment``) resolves into the nested value: a dict by key, a
+    list of named entries by ``name``. Anything missing renders empty.
     """
     if col in item:
         val = item[col]
@@ -256,6 +290,15 @@ def _cell(item: dict[str, Any], col: str) -> Any:
         info = item.get("error_info")
         if isinstance(info, dict):
             return info.get("exception_type")
+    if "." in col:
+        top, _, key = col.partition(".")
+        container = item.get(top)
+        if isinstance(container, dict):
+            return container.get(key)
+        if isinstance(container, list):
+            for entry in container:
+                if isinstance(entry, dict) and entry.get("name") == key:
+                    return entry.get("value")
     return None
 
 

--- a/src/opik_mcp/read_list/list_tool.py
+++ b/src/opik_mcp/read_list/list_tool.py
@@ -1,17 +1,26 @@
-"""``list`` tool — paginated discovery of Opik entities.
+"""``list`` tool — paginated discovery and search of Opik entities.
 
 Ported from ollie-assist's ``tools/list.py``. Output is a pipe-delimited
 table (mirrors ollie's format) — easier for the LLM to scan than nested
 JSON and lossless for the columns we care about (id, name, plus a few
 entity-specific fields like ``created_at`` / ``dataset_name``).
 
-Project-scoped lists (``trace``, ``test_suite_item``, ``prompt_version``)
-require their parent id via ``project_id`` / ``test_suite_id`` /
-``prompt_id`` — enforced via the registry's ``list_required_kwargs``.
+Project-scoped lists (``trace``, ``span``, ``thread``, ``test_suite_item``,
+``prompt_version``) require their parent id via ``project_id`` /
+``test_suite_id`` / ``prompt_id`` — enforced via the registry's
+``list_required_kwargs``.
+
+The searchable types (``trace``, ``span``, ``thread``, ``experiment``) also
+take ``filters`` — an OQL string compiled by ``oql.py`` into the backend's
+filter array. Like the UI's Logs page, trace/span/thread lists add
+``source = "sdk"`` unless the caller names ``source`` themselves, so
+evaluator / playground / experiment traces don't crowd out application
+traffic. Whatever was applied is echoed on the first output line.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -27,6 +36,12 @@ from opik_mcp.opik_client import (
     make_opik_client,
 )
 from opik_mcp.read_list.errors import EntityArgValidationError
+from opik_mcp.read_list.oql import (
+    SUPPORTED_ENTITIES,
+    OQLError,
+    compile_filters,
+    render_filters,
+)
 from opik_mcp.read_list.registry import ENTITY_REGISTRY, LISTABLE_TYPES, EntityHandler
 
 logger = logging.getLogger("opik_mcp.read_list.list")
@@ -34,11 +49,17 @@ logger = logging.getLogger("opik_mcp.read_list.list")
 _MAX_SIZE = 100
 _TRUNCATE_AT = 60
 
+# Entities whose backend list endpoint stores a ``source`` and whose UI list
+# defaults to the SDK source. Experiments are one source by definition.
+_SOURCE_DEFAULTED = frozenset({"trace", "span", "thread"})
+_SDK_SOURCE_CLAUSE = {"field": "source", "operator": "=", "key": "", "value": "sdk"}
+
 
 async def run_list(
     entity_type: str,
     *,
     name: str | None = None,
+    filters: str | None = None,
     page: int = 1,
     size: int = 25,
     project_id: str | None = None,
@@ -63,9 +84,9 @@ async def run_list(
         kw["name"] = name
     if project_id is not None:
         kw["project_id"] = project_id
-    # Only project-scoped lists (trace, thread) take project_name; forwarding it
-    # to a workspace-wide list_fn (projects/experiments/…) would be an unexpected
-    # kwarg. Gate on the same signal the required-check uses.
+    # Only project-scoped lists (trace, span, thread) take project_name;
+    # forwarding it to a workspace-wide list_fn (projects/experiments/…) would
+    # be an unexpected kwarg. Gate on the same signal the required-check uses.
     if project_name is not None and "project_id" in handler.list_required_kwargs:
         kw["project_name"] = project_name
     if test_suite_id is not None:
@@ -76,8 +97,8 @@ async def run_list(
     for required in handler.list_required_kwargs:
         if kw.get(required) is None:
             # project_name is an accepted alternative to project_id for the
-            # project-scoped lists (trace, thread) — the client methods take
-            # either, so don't force the UUID when a name was given.
+            # project-scoped lists (trace, span, thread) — the client methods
+            # take either, so don't force the UUID when a name was given.
             if required == "project_id" and kw.get("project_name"):
                 continue
             hint = f"{required} (or project_name)" if required == "project_id" else required
@@ -86,6 +107,20 @@ async def run_list(
                 f"E.g. list({entity_type!r}, {required}='<uuid>', …)."
             )
             raise ToolError(str(err)) from err
+
+    applied: list[str] = []
+    if entity_type in SUPPORTED_ENTITIES or filters is not None:
+        try:
+            clauses = compile_filters(entity_type, filters or "")
+        except OQLError as err:
+            raise ToolError(str(err)) from err
+        if entity_type in _SOURCE_DEFAULTED and not any(c["field"] == "source" for c in clauses):
+            clauses.append(dict(_SDK_SOURCE_CLAUSE))
+        if clauses:
+            kw["filters"] = json.dumps(clauses, separators=(",", ":"))
+            applied.append(f"filters: {render_filters(entity_type, clauses)}")
+        # Bodies never reach the table, so let the backend trim them.
+        kw["truncate"] = True
 
     opik = client if client is not None else make_opik_client(settings or get_settings())
 
@@ -99,12 +134,15 @@ async def run_list(
     total_raw = page_body.get("total")
     total = total_raw if isinstance(total_raw, int) and total_raw >= 0 else len(content)
 
+    header = f"[list: {entity_type} | {' | '.join(applied)}]" if applied else None
     if not content:
-        if name:
-            return f"No {entity_type}s matching {name!r} found."
-        return f"No {entity_type}s found."
+        empty = (
+            f"No {entity_type}s matching {name!r} found." if name else f"No {entity_type}s found."
+        )
+        return f"{header}\n{empty}" if header else empty
 
-    return _format_table(entity_type, handler, content, total, page, size, name)
+    table = _format_table(entity_type, handler, content, total, page, size, name)
+    return f"{header}\n{table}" if header else table
 
 
 def _format_table(
@@ -132,7 +170,7 @@ def _format_table(
     for item in content:
         values: list[str] = []
         for col in columns:
-            val = item.get(col)
+            val = _cell(item, col)
             s = "" if val is None else str(val)
             if len(s) > _TRUNCATE_AT:
                 s = s[: _TRUNCATE_AT - 3] + "..."
@@ -144,6 +182,21 @@ def _format_table(
         lines.append("")
         lines.append(f"Use page={page + 1} for next {size} results.")
     return "\n".join(lines)
+
+
+def _cell(item: dict[str, Any], col: str) -> Any:
+    """Resolve one column of one record.
+
+    ``error_type`` is derived from the error container when the record does
+    not carry it flat: the backend's list payload has ``error_info.exception_type``.
+    """
+    if col in item:
+        return item[col]
+    if col == "error_type":
+        info = item.get("error_info")
+        if isinstance(info, dict):
+            return info.get("exception_type")
+    return None
 
 
 __all__ = ["run_list"]

--- a/src/opik_mcp/read_list/oql.py
+++ b/src/opik_mcp/read_list/oql.py
@@ -33,10 +33,10 @@ from __future__ import annotations
 
 import difflib
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Final, Literal
 
 from opik_mcp.read_list.errors import EntityArgValidationError
+from opik_mcp.read_list.window import parse_instant
 
 FieldType = Literal[
     "string",
@@ -163,6 +163,16 @@ FILTERABLE_FIELDS: Final[dict[str, dict[str, FieldType]]] = {
     },
 }
 SUPPORTED_ENTITIES: Final[tuple[str, ...]] = tuple(FILTERABLE_FIELDS)
+# The per-entity search surface beyond filters, in one place so the list tool
+# and the schema reference cannot disagree. Experiments have no ``source``
+# (they are one source by definition), no time window and no free-text search.
+SOURCE_DEFAULTED_ENTITIES: Final[tuple[str, ...]] = ("trace", "span", "thread")
+"""Lists that add ``source = "sdk"`` unless the caller names ``source`` — the
+UI's Logs page default, so evaluator / playground / experiment traces don't
+crowd out application traffic."""
+WINDOWED_ENTITIES: Final[tuple[str, ...]] = ("trace", "span", "thread")
+"""Lists whose backend endpoint takes ``from_time``/``to_time`` and free-text
+``search`` (the two capabilities ship together on the backend)."""
 
 GRAMMAR_LINE: Final = (
     "<field>[.<key>] <op> <value> [AND ...] — strings in double quotes, numbers bare, "
@@ -453,7 +463,7 @@ def _validate(entity_type: str, raw: _RawClause) -> tuple[dict[str, str] | None,
 
     # usage.<x> is a flat composite field name, not a dictionary key.
     if field == "usage":
-        composite = f"usage.{key}"
+        composite = f"usage.{key}" if key is not None else "usage"
         if composite not in fields:
             return None, OQLIssue(
                 "unknown_field",
@@ -505,11 +515,7 @@ def _validate_value(field: str, ftype: str, key: str | None, raw: _RawClause) ->
     if raw.operator in NO_VALUE_OPERATORS:
         return None
     if ftype == "date_time":
-        try:
-            parsed = datetime.fromisoformat(raw.value)
-        except ValueError:
-            parsed = None
-        if parsed is None or parsed.tzinfo is None:
+        if parse_instant(raw.value) is None:
             return OQLIssue(
                 "bad_value",
                 f"Invalid value \"{raw.value}\" for '{field}': expected an ISO-8601 instant "
@@ -562,7 +568,7 @@ def compile_filters(entity_type: str, query: str) -> list[dict[str, str]]:
         # Clauses parsed before the syntax error still get validated so the
         # agent sees every problem in one round.
         raw_clauses = []
-        for raw in _partial(parser):
+        for raw in _clauses_before_error(parser):
             clause, issue = _validate(entity_type, raw)
             if issue is not None:
                 issues.append(issue)
@@ -582,7 +588,7 @@ def compile_filters(entity_type: str, query: str) -> list[dict[str, str]]:
     return compiled
 
 
-def _partial(parser: _Parser) -> list[_RawClause]:
+def _clauses_before_error(parser: _Parser) -> list[_RawClause]:
     """Clauses fully parsed before a syntax error — re-run the parser on the
     prefix up to the failing clause. Cheap (queries are short) and keeps the
     parser itself free of error-recovery state."""
@@ -656,8 +662,10 @@ __all__ = [
     "KEYED_TYPES",
     "MILLISECOND_FIELDS",
     "OPERATORS_BY_TYPE",
+    "SOURCE_DEFAULTED_ENTITIES",
     "SUPPORTED_ENTITIES",
     "USAGE_FIELDS",
+    "WINDOWED_ENTITIES",
     "FieldType",
     "IssueKind",
     "OQLBadOperatorError",

--- a/src/opik_mcp/read_list/oql.py
+++ b/src/opik_mcp/read_list/oql.py
@@ -1,0 +1,614 @@
+"""OQL — the Opik Query Language behind the ``list`` tool's ``filters`` string.
+
+Grammar (the same one the Opik Python SDK's ``search_traces(filter_string=…)``
+accepts, so agents learn one query form)::
+
+    <field>[.<key>] <op> <value> [AND <field> <op> <value>]*
+
+- Connector is ``AND`` only. ``OR`` is rejected with an explicit message.
+- Values are double-quoted strings (``""`` escapes a quote) or bare numbers.
+- ``is_empty`` / ``is_not_empty`` take no value.
+- ``in`` / ``not_in`` take a parenthesised list of quoted strings.
+- ``usage.total_tokens`` / ``usage.prompt_tokens`` / ``usage.completion_tokens``
+  are flat field names, not dictionary keys.
+
+The parser is ported from the SDK (``opik/api_objects/opik_query_language.py``)
+with two deliberate departures. First, the field and operator tables come
+from opik-backend's ``TraceField`` / ``SpanField`` / ``TraceThreadField`` /
+``ExperimentField`` enums and its ``FilterQueryBuilder`` operator map, not the
+SDK's copies — the SDK lists ``>=`` / ``<=`` for dictionaries (the backend
+400s) and misses ``is_empty`` on enums, ``source``, ``error_type``, ``ttft``
+and the whole experiment surface. Second, unknown fields are rejected here
+instead of being defaulted to ``string`` and left for the backend to refuse.
+
+Every problem in a string is collected and reported together so the agent
+repairs the call in one retry: syntax errors carry the position and a caret,
+unknown fields carry the closest name and the entity's field list, invalid
+operators carry the field's type and the valid set, invalid values carry the
+expected format. The full type/operator reference lives behind
+``schema("list.<entity>")``, keeping the tool description short.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Final, Literal
+
+from opik_mcp.read_list.errors import EntityArgValidationError
+
+FieldType = Literal[
+    "string",
+    "date_time",
+    "number",
+    "feedback_scores",
+    "dictionary",
+    "list",
+    "enum",
+    "enum_legacy",
+    "error_container",
+    "string_list",
+]
+
+# Operator → FieldType entries of opik-backend's ANALYTICS_DB_OPERATOR_MAP
+# (FilterQueryBuilder.java). A pair missing there is a 400 server-side.
+OPERATORS_BY_TYPE: Final[dict[str, tuple[str, ...]]] = {
+    "string": ("=", "!=", "contains", "not_contains", "starts_with", "ends_with", ">", "<"),
+    "date_time": ("=", "!=", ">", ">=", "<", "<="),
+    "number": ("=", "!=", ">", ">=", "<", "<="),
+    "feedback_scores": ("=", "!=", ">", ">=", "<", "<=", "is_empty", "is_not_empty"),
+    "dictionary": (
+        "=",
+        "!=",
+        "contains",
+        "not_contains",
+        "starts_with",
+        "ends_with",
+        ">",
+        "<",
+        "is_empty",
+        "is_not_empty",
+    ),
+    "list": ("=", "!=", "contains", "not_contains", "is_empty", "is_not_empty"),
+    "enum": ("=", "!=", "in", "not_in", "is_empty", "is_not_empty"),
+    "enum_legacy": ("=", "!="),
+    "error_container": ("is_empty", "is_not_empty"),
+    "string_list": ("in", "not_in"),
+}
+
+NO_VALUE_OPERATORS: Final = frozenset({"is_empty", "is_not_empty"})
+LIST_VALUE_OPERATORS: Final = frozenset({"in", "not_in"})
+# Types whose filters need a ``.key`` (the backend rejects a blank key).
+KEYED_TYPES: Final = frozenset({"feedback_scores", "dictionary"})
+USAGE_FIELDS: Final = ("usage.total_tokens", "usage.prompt_tokens", "usage.completion_tokens")
+# Number fields the backend stores in milliseconds — named in value errors so
+# an agent writing ``duration > 5`` learns it asked for five milliseconds.
+MILLISECOND_FIELDS: Final = frozenset({"duration", "ttft"})
+
+_SHARED_TIMING: dict[str, FieldType] = {
+    "start_time": "date_time",
+    "end_time": "date_time",
+    "created_at": "date_time",
+    "last_updated_at": "date_time",
+}
+_SHARED_PAYLOAD: dict[str, FieldType] = {
+    "input": "string",
+    "output": "string",
+    "input_json": "dictionary",
+    "output_json": "dictionary",
+    "metadata": "dictionary",
+    "tags": "list",
+    "usage.total_tokens": "number",
+    "usage.prompt_tokens": "number",
+    "usage.completion_tokens": "number",
+    "total_estimated_cost": "number",
+    "duration": "number",
+    "ttft": "number",
+    "feedback_scores": "feedback_scores",
+    "error_info": "error_container",
+    "error_type": "string",
+    "source": "enum_legacy",
+    "environment": "enum",
+}
+
+# Filterable fields per entity — mirrors the backend's field enums.
+FILTERABLE_FIELDS: Final[dict[str, dict[str, FieldType]]] = {
+    "trace": {
+        "id": "string",
+        "name": "string",
+        **_SHARED_TIMING,
+        **_SHARED_PAYLOAD,
+        "llm_span_count": "number",
+        "span_feedback_scores": "feedback_scores",
+        "thread_id": "string",
+        "guardrails": "string",
+        "visibility_mode": "enum",
+        "annotation_queue_ids": "list",
+        "experiment_id": "string",
+        "experiment_ids": "string_list",
+    },
+    "span": {
+        "id": "string",
+        "name": "string",
+        "type": "enum",
+        "trace_id": "string",
+        **_SHARED_TIMING,
+        **_SHARED_PAYLOAD,
+        "model": "string",
+        "provider": "string",
+    },
+    "thread": {
+        "id": "string",
+        "first_message": "string",
+        "last_message": "string",
+        "number_of_messages": "number",
+        "duration": "number",
+        **_SHARED_TIMING,
+        "feedback_scores": "feedback_scores",
+        "status": "enum",
+        "tags": "list",
+        "annotation_queue_ids": "list",
+        "source": "enum_legacy",
+        "environment": "enum",
+    },
+    "experiment": {
+        "metadata": "dictionary",
+        "dataset_id": "string",
+        "project_id": "string",
+        "prompt_ids": "list",
+        "tags": "list",
+        "feedback_scores": "feedback_scores",
+        "experiment_scores": "feedback_scores",
+    },
+}
+SUPPORTED_ENTITIES: Final[tuple[str, ...]] = tuple(FILTERABLE_FIELDS)
+
+GRAMMAR_LINE: Final = (
+    "<field>[.<key>] <op> <value> [AND ...] — strings in double quotes, numbers bare, "
+    'is_empty/is_not_empty take no value, in/not_in take ("a", "b").'
+)
+
+IssueKind = Literal["syntax", "unknown_field", "bad_operator", "bad_value", "unsupported_entity"]
+
+
+@dataclass(frozen=True)
+class OQLIssue:
+    kind: IssueKind
+    message: str
+    position: int | None = None
+    """Cursor offset into the query for syntax errors; None for semantic ones."""
+
+
+class OQLError(EntityArgValidationError):
+    """The ``filters`` string does not validate. Carries every issue found.
+
+    Subclasses ``EntityArgValidationError`` so the analytics wrapper buckets
+    it as validation/400 like the other list-argument failures.
+    """
+
+    def __init__(self, entity_type: str, query: str, issues: list[OQLIssue]) -> None:
+        self.entity_type = entity_type
+        self.query = query
+        self.issues: tuple[OQLIssue, ...] = tuple(issues)
+        super().__init__(self._render())
+
+    @property
+    def kinds(self) -> tuple[IssueKind, ...]:
+        return tuple(i.kind for i in self.issues)
+
+    def _render(self) -> str:
+        lines = [f"Invalid filters for {self.entity_type}:"]
+        for n, issue in enumerate(self.issues, start=1):
+            lines.append(f"  {n}. {issue.message}")
+            if issue.position is not None:
+                lines.append(self.query)
+                lines.append(" " * issue.position + "^")
+        lines.append(f"Grammar: {GRAMMAR_LINE}")
+        if self.entity_type in FILTERABLE_FIELDS:
+            lines.append(f'Field reference: schema("list.{self.entity_type}").')
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class _RawClause:
+    field: str
+    key: str | None
+    operator: str
+    value: str
+    """Comma-joined for in/not_in, "" for is_empty/is_not_empty."""
+    quoted: bool
+    """True when the value was written in double quotes (vs a bare number)."""
+    field_position: int
+
+
+class _SyntaxError(Exception):
+    def __init__(self, message: str, position: int) -> None:
+        super().__init__(message)
+        self.message = message
+        self.position = position
+
+
+class _Parser:
+    """Character-cursor parser ported from the SDK, minus the semantic checks.
+
+    Produces raw clauses; ``_validate`` applies the field/operator/value
+    tables afterwards so semantic problems in several clauses can all be
+    reported at once. Syntax problems stop the parse (there is no reliable
+    way to resynchronise) and are reported with the cursor position.
+    """
+
+    def __init__(self, query: str) -> None:
+        self.q = query
+        self.i = 0
+
+    # -- helpers --
+
+    def _at_end(self) -> bool:
+        return self.i >= len(self.q)
+
+    def _skip_ws(self) -> None:
+        while not self._at_end() and self.q[self.i].isspace():
+            self.i += 1
+
+    def _read_word(self) -> str:
+        start = self.i
+        while not self._at_end() and (self.q[self.i].isalnum() or self.q[self.i] == "_"):
+            self.i += 1
+        return self.q[start : self.i]
+
+    def _read_quoted(self, *, what: str) -> str:
+        """Cursor is on the opening quote. Returns the unescaped content."""
+        open_pos = self.i
+        self.i += 1
+        out: list[str] = []
+        while not self._at_end():
+            ch = self.q[self.i]
+            if ch == '"':
+                if self.i + 1 < len(self.q) and self.q[self.i + 1] == '"':
+                    out.append('"')
+                    self.i += 2
+                    continue
+                self.i += 1
+                return "".join(out)
+            out.append(ch)
+            self.i += 1
+        raise _SyntaxError(f"missing closing quote for {what} {self.q[open_pos:]}", open_pos)
+
+    def _read_number(self) -> str:
+        start = self.i
+        if not self._at_end() and self.q[self.i] == "-":
+            self.i += 1
+        digits_start = self.i
+        while not self._at_end() and self.q[self.i].isdigit():
+            self.i += 1
+        if self.i == digits_start:
+            msg = "expected a number after '-'" if self.q[start] == "-" else "expected a number"
+            raise _SyntaxError(msg, start)
+        if not self._at_end() and self.q[self.i] == ".":
+            self.i += 1
+            frac_start = self.i
+            while not self._at_end() and self.q[self.i].isdigit():
+                self.i += 1
+            if self.i == frac_start:
+                raise _SyntaxError("expected digits after decimal point", frac_start)
+        return self.q[start : self.i]
+
+    # -- grammar --
+
+    def _parse_field(self) -> tuple[str, str | None, int]:
+        self._skip_ws()
+        pos = self.i
+        if self._at_end():
+            raise _SyntaxError("unexpected end of input, expected a field name", pos)
+        field = self._read_word()
+        if not field:
+            raise _SyntaxError(f"expected a field name, got {self.q[pos : pos + 12]!r}", pos)
+        key: str | None = None
+        if not self._at_end() and self.q[self.i] == ".":
+            self.i += 1
+            if not self._at_end() and self.q[self.i] == '"':
+                key = self._read_quoted(what="key")
+            else:
+                key_pos = self.i
+                key = self._read_word()
+                if not key:
+                    raise _SyntaxError("expected a key after '.'", key_pos)
+        return field, key, pos
+
+    def _parse_operator(self) -> str:
+        self._skip_ws()
+        pos = self.i
+        if self._at_end():
+            raise _SyntaxError("unexpected end of input, expected an operator", pos)
+        ch = self.q[self.i]
+        if ch == "=":
+            self.i += 1
+            return "="
+        if ch in "<>!":
+            if self.i + 1 < len(self.q) and self.q[self.i + 1] == "=":
+                self.i += 2
+                return ch + "="
+            if ch == "!":
+                raise _SyntaxError("expected '!=' ", pos)
+            self.i += 1
+            return ch
+        op = self._read_word()
+        if not op:
+            raise _SyntaxError(f"expected an operator, got {self.q[pos : pos + 12]!r}", pos)
+        return op
+
+    def _parse_value(self) -> tuple[str, bool]:
+        self._skip_ws()
+        pos = self.i
+        if self._at_end():
+            raise _SyntaxError("unexpected end of input, expected a value", pos)
+        ch = self.q[self.i]
+        if ch == '"':
+            return self._read_quoted(what="value"), True
+        if ch.isdigit() or ch == "-":
+            return self._read_number(), False
+        raise _SyntaxError('expected a value in double quotes ("…") or a number', pos)
+
+    def _parse_list_value(self) -> str:
+        self._skip_ws()
+        pos = self.i
+        if self._at_end() or self.q[self.i] != "(":
+            raise _SyntaxError(
+                'expected a list in parentheses after in/not_in, e.g. in ("a", "b"); '
+                "the list must start with '('",
+                pos,
+            )
+        self.i += 1
+        items: list[str] = []
+        while True:
+            self._skip_ws()
+            if self._at_end():
+                raise _SyntaxError("unterminated list, missing ')'", pos)
+            if self.q[self.i] == ")":
+                if not items:
+                    raise _SyntaxError("expected at least one item inside (...)", pos)
+                self.i += 1
+                return ",".join(items)
+            if items:
+                if self.q[self.i] != ",":
+                    raise _SyntaxError("expected ',' between list items", self.i)
+                self.i += 1
+                self._skip_ws()
+            if self._at_end() or self.q[self.i] != '"':
+                raise _SyntaxError("list items must be quoted strings", self.i)
+            items.append(self._read_quoted(what="list item"))
+
+    def parse(self) -> list[_RawClause]:
+        clauses: list[_RawClause] = []
+        self._skip_ws()
+        if self._at_end():
+            return clauses
+        while True:
+            field, key, field_pos = self._parse_field()
+            operator = self._parse_operator()
+            if operator in NO_VALUE_OPERATORS:
+                value, quoted = "", False
+            elif operator in LIST_VALUE_OPERATORS:
+                value, quoted = self._parse_list_value(), True
+            else:
+                value, quoted = self._parse_value()
+            clauses.append(_RawClause(field, key, operator, value, quoted, field_pos))
+
+            self._skip_ws()
+            if self._at_end():
+                return clauses
+            pos = self.i
+            connector = self._read_word()
+            if connector.lower() == "and":
+                continue
+            if connector.lower() == "or":
+                raise _SyntaxError(
+                    "OR is not supported; use AND, or run one query per alternative", pos
+                )
+            raise _SyntaxError(f"trailing characters {self.q[pos:]!r}", pos)
+
+
+def _validate(entity_type: str, raw: _RawClause) -> tuple[dict[str, str] | None, OQLIssue | None]:
+    fields = FILTERABLE_FIELDS[entity_type]
+    field, key = raw.field, raw.key
+
+    # usage.<x> is a flat composite field name, not a dictionary key.
+    if field == "usage":
+        composite = f"usage.{key}"
+        if composite not in fields:
+            return None, OQLIssue(
+                "unknown_field",
+                f"Unknown field '{composite}'. Usage fields: {', '.join(USAGE_FIELDS)}.",
+            )
+        field, key = composite, None
+
+    if field not in fields:
+        names = sorted(fields)
+        close = difflib.get_close_matches(field, names, n=1, cutoff=0.6)
+        hint = f" Did you mean '{close[0]}'?" if close else ""
+        return None, OQLIssue(
+            "unknown_field", f"Unknown field '{field}'.{hint} Fields: {', '.join(names)}."
+        )
+
+    ftype = fields[field]
+    if key is not None and ftype not in KEYED_TYPES:
+        keyed = ", ".join(sorted(f for f, t in fields.items() if t in KEYED_TYPES))
+        return None, OQLIssue(
+            "unknown_field",
+            f"Field '{field}' does not take a key ('{field}.{key}'). Keyed fields: {keyed}.",
+        )
+
+    valid_ops = OPERATORS_BY_TYPE[ftype]
+    if raw.operator not in valid_ops:
+        return None, OQLIssue(
+            "bad_operator",
+            f"Operator '{raw.operator}' is not valid for '{field}' ({ftype}). "
+            f"Valid: {', '.join(valid_ops)}.",
+        )
+
+    issue = _validate_value(field, ftype, key, raw)
+    if issue is not None:
+        return None, issue
+    return {"field": field, "operator": raw.operator, "key": key or "", "value": raw.value}, None
+
+
+def _validate_value(field: str, ftype: str, key: str | None, raw: _RawClause) -> OQLIssue | None:
+    if ftype in KEYED_TYPES and not key:
+        if ftype == "feedback_scores":
+            return OQLIssue(
+                "bad_value",
+                f"'{field}' needs a score name: write {field}.<name>, e.g. {field}.accuracy < 0.5.",
+            )
+        return OQLIssue(
+            "bad_value",
+            f"'{field}' needs a key: write {field}.<key>, e.g. {field}.environment = \"prod\".",
+        )
+    if raw.operator in NO_VALUE_OPERATORS:
+        return None
+    if ftype == "date_time":
+        try:
+            parsed = datetime.fromisoformat(raw.value)
+        except ValueError:
+            parsed = None
+        if parsed is None or parsed.tzinfo is None:
+            return OQLIssue(
+                "bad_value",
+                f"Invalid value \"{raw.value}\" for '{field}': expected an ISO-8601 instant "
+                'with a timezone, e.g. "2026-09-08T10:00:00Z".',
+            )
+        return None
+    if ftype in ("number", "feedback_scores"):
+        try:
+            float(raw.value)
+        except ValueError:
+            unit = " (value is in milliseconds)" if field in MILLISECOND_FIELDS else ""
+            return OQLIssue(
+                "bad_value",
+                f"Invalid value \"{raw.value}\" for '{field}': expected a number{unit}.",
+            )
+        return None
+    if raw.value.strip() == "":
+        return OQLIssue(
+            "bad_value", f"Empty value for '{field}': the backend rejects blank filter values."
+        )
+    return None
+
+
+def compile_filters(entity_type: str, query: str) -> list[dict[str, str]]:
+    """Compile an OQL string into the backend's filter array.
+
+    Returns ``[{field, operator, key, value}, …]`` ready to be JSON-encoded into
+    the ``filters`` query parameter. An empty or blank query compiles to ``[]``.
+    Raises :class:`OQLError` carrying every problem found.
+    """
+    if entity_type not in FILTERABLE_FIELDS:
+        raise OQLError(
+            entity_type,
+            query,
+            [
+                OQLIssue(
+                    "unsupported_entity",
+                    f"filters are not supported for {entity_type!r}. "
+                    f"Filterable types: {', '.join(SUPPORTED_ENTITIES)}.",
+                )
+            ],
+        )
+
+    parser = _Parser(query)
+    issues: list[OQLIssue] = []
+    compiled: list[dict[str, str]] = []
+    try:
+        raw_clauses = parser.parse()
+    except _SyntaxError as e:
+        # Clauses parsed before the syntax error still get validated so the
+        # agent sees every problem in one round.
+        raw_clauses = []
+        for raw in _partial(parser):
+            clause, issue = _validate(entity_type, raw)
+            if issue is not None:
+                issues.append(issue)
+        issues.append(
+            OQLIssue("syntax", f"Syntax error at position {e.position}: {e.message}", e.position)
+        )
+        raise OQLError(entity_type, query, issues) from None
+
+    for raw in raw_clauses:
+        clause, issue = _validate(entity_type, raw)
+        if issue is not None:
+            issues.append(issue)
+        elif clause is not None:
+            compiled.append(clause)
+    if issues:
+        raise OQLError(entity_type, query, issues)
+    return compiled
+
+
+def _partial(parser: _Parser) -> list[_RawClause]:
+    """Clauses fully parsed before a syntax error — re-run the parser on the
+    prefix up to the failing clause. Cheap (queries are short) and keeps the
+    parser itself free of error-recovery state."""
+    prefix = parser.q[: parser.i]
+    # Walk back to the last complete AND boundary and parse that prefix.
+    lowered = prefix.lower()
+    cut = lowered.rfind(" and ")
+    if cut < 0:
+        return []
+    try:
+        return _Parser(prefix[:cut]).parse()
+    except _SyntaxError:
+        return []
+
+
+def filter_fields(entity_type: str) -> dict[str, FieldType]:
+    """Filterable fields and their types for one entity (schema tool, columns)."""
+    return dict(FILTERABLE_FIELDS[entity_type])
+
+
+def render_filters(entity_type: str, clauses: list[dict[str, str]]) -> str:
+    """Render a compiled filter array back to OQL, for the applied-filters header.
+
+    Numbers on numeric fields render bare, everything else double-quoted, so
+    the echoed string is itself valid input for the next call.
+    """
+    fields = FILTERABLE_FIELDS.get(entity_type, {})
+    parts: list[str] = []
+    for c in clauses:
+        field, op, key, value = c["field"], c["operator"], c.get("key", ""), c.get("value", "")
+        name = f"{field}.{_quote_key(key)}" if key else field
+        if op in NO_VALUE_OPERATORS:
+            parts.append(f"{name} {op}")
+        elif op in LIST_VALUE_OPERATORS:
+            items = ", ".join(_quote(v) for v in value.split(","))
+            parts.append(f"{name} {op} ({items})")
+        elif fields.get(field) in ("number", "feedback_scores"):
+            parts.append(f"{name} {op} {value}")
+        else:
+            parts.append(f"{name} {op} {_quote(value)}")
+    return " AND ".join(parts)
+
+
+def _quote(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _quote_key(key: str) -> str:
+    return key if all(ch.isalnum() or ch == "_" for ch in key) else _quote(key)
+
+
+__all__ = [
+    "FILTERABLE_FIELDS",
+    "GRAMMAR_LINE",
+    "KEYED_TYPES",
+    "MILLISECOND_FIELDS",
+    "OPERATORS_BY_TYPE",
+    "SUPPORTED_ENTITIES",
+    "USAGE_FIELDS",
+    "FieldType",
+    "IssueKind",
+    "OQLError",
+    "OQLIssue",
+    "compile_filters",
+    "filter_fields",
+    "render_filters",
+]

--- a/src/opik_mcp/read_list/oql.py
+++ b/src/opik_mcp/read_list/oql.py
@@ -184,8 +184,17 @@ class OQLError(EntityArgValidationError):
     """The ``filters`` string does not validate. Carries every issue found.
 
     Subclasses ``EntityArgValidationError`` so the analytics wrapper buckets
-    it as validation/400 like the other list-argument failures.
+    it as validation/400 like the other list-argument failures. Instantiating
+    ``OQLError`` yields the per-kind subclass of the first issue (``OQLSyntaxError``
+    etc.): analytics records only exception class names, so the class is how
+    "which kind of mistake do agents make" reaches a dashboard without the
+    string itself ever leaving the process.
     """
+
+    def __new__(cls, entity_type: str, query: str, issues: list[OQLIssue]) -> OQLError:
+        if cls is OQLError and issues:
+            cls = _KIND_CLASSES[issues[0].kind]
+        return super().__new__(cls)
 
     def __init__(self, entity_type: str, query: str, issues: list[OQLIssue]) -> None:
         self.entity_type = entity_type
@@ -208,6 +217,35 @@ class OQLError(EntityArgValidationError):
         if self.entity_type in FILTERABLE_FIELDS:
             lines.append(f'Field reference: schema("list.{self.entity_type}").')
         return "\n".join(lines)
+
+
+class OQLSyntaxError(OQLError):
+    """Grammar problem: quoting, operator shape, trailing text, OR."""
+
+
+class OQLUnknownFieldError(OQLError):
+    """A field the entity does not have."""
+
+
+class OQLBadOperatorError(OQLError):
+    """An operator the field's type does not support."""
+
+
+class OQLBadValueError(OQLError):
+    """A value in the wrong format, or a missing key on a keyed field."""
+
+
+class OQLUnsupportedEntityError(OQLError):
+    """``filters`` on an entity type that has none."""
+
+
+_KIND_CLASSES: Final[dict[IssueKind, type[OQLError]]] = {
+    "syntax": OQLSyntaxError,
+    "unknown_field": OQLUnknownFieldError,
+    "bad_operator": OQLBadOperatorError,
+    "bad_value": OQLBadValueError,
+    "unsupported_entity": OQLUnsupportedEntityError,
+}
 
 
 @dataclass(frozen=True)
@@ -565,6 +603,22 @@ def filter_fields(entity_type: str) -> dict[str, FieldType]:
     return dict(FILTERABLE_FIELDS[entity_type])
 
 
+def filter_field_names(entity_type: str, query: str | None) -> list[str]:
+    """Sorted, de-duplicated field names a query uses — keys stripped.
+
+    For analytics: says *which fields* agents filter on without carrying the
+    values or the user-named keys. Returns ``[]`` for anything that does not
+    parse; the failure itself is recorded by exception class elsewhere.
+    """
+    if not query:
+        return []
+    try:
+        clauses = compile_filters(entity_type, query)
+    except OQLError:
+        return []
+    return sorted({c["field"] for c in clauses})
+
+
 def render_filters(entity_type: str, clauses: list[dict[str, str]]) -> str:
     """Render a compiled filter array back to OQL, for the applied-filters header.
 
@@ -606,9 +660,15 @@ __all__ = [
     "USAGE_FIELDS",
     "FieldType",
     "IssueKind",
+    "OQLBadOperatorError",
+    "OQLBadValueError",
     "OQLError",
     "OQLIssue",
+    "OQLSyntaxError",
+    "OQLUnknownFieldError",
+    "OQLUnsupportedEntityError",
     "compile_filters",
+    "filter_field_names",
     "filter_fields",
     "render_filters",
 ]

--- a/src/opik_mcp/read_list/reference.py
+++ b/src/opik_mcp/read_list/reference.py
@@ -1,0 +1,84 @@
+"""``schema("list.<entity>")`` — the filter / sort reference for one entity.
+
+The ``list`` tool's description carries two lines of grammar and two
+examples so it stays cheap on every turn. This is the long form an agent
+asks for on purpose: every filterable field with its type and valid
+operators, the sortable fields, whether a time window and free-text search
+exist, and the same two examples. It is generated from the tables the
+validator uses (``oql.py``, ``sorting.py``), so it cannot say one thing
+while ``list`` accepts another.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from opik_mcp.read_list.oql import (
+    FILTERABLE_FIELDS,
+    GRAMMAR_LINE,
+    KEYED_TYPES,
+    MILLISECOND_FIELDS,
+    OPERATORS_BY_TYPE,
+    SUPPORTED_ENTITIES,
+)
+from opik_mcp.read_list.sorting import SORT_FORM, sortable_names
+
+LIST_SCHEMA_KEYS: Final[tuple[str, ...]] = tuple(f"list.{e}" for e in SUPPORTED_ENTITIES)
+
+# Kept in step with list_tool: which entities take from_time/to_time + search,
+# and which get the UI's ``source = "sdk"`` default.
+_WINDOWED_OR_SEARCHABLE: Final = frozenset({"trace", "span", "thread"})
+_SOURCE_DEFAULTED: Final = frozenset({"trace", "span", "thread"})
+
+FILTER_EXAMPLES: Final[dict[str, tuple[str, str]]] = {
+    "trace": (
+        "error_info is_not_empty AND duration > 5000",
+        'feedback_scores.accuracy < 0.5 AND start_time >= "2026-09-08T00:00:00Z"',
+    ),
+    "span": (
+        'type = "llm" AND usage.total_tokens > 10000',
+        'name = "search_docs" AND error_info is_not_empty',
+    ),
+    "thread": (
+        'status = "active" AND number_of_messages > 20',
+        "feedback_scores.helpfulness < 0.5 AND duration > 60000",
+    ),
+    "experiment": (
+        'dataset_id = "<dataset-uuid>" AND tags contains "baseline"',
+        'metadata.model = "gpt-4o" AND feedback_scores.accuracy >= 0.8',
+    ),
+}
+
+
+def list_reference(entity_type: str) -> dict[str, Any]:
+    """The ``schema("list.<entity>")`` payload. ``entity_type`` must be supported."""
+    fields: dict[str, dict[str, Any]] = {}
+    for name, ftype in FILTERABLE_FIELDS[entity_type].items():
+        spec: dict[str, Any] = {"type": ftype, "operators": list(OPERATORS_BY_TYPE[ftype])}
+        if ftype in KEYED_TYPES:
+            spec["key"] = "required"
+        if name in MILLISECOND_FIELDS:
+            spec["unit"] = "milliseconds"
+        if ftype == "date_time":
+            spec["format"] = 'ISO-8601 instant with timezone, e.g. "2026-09-08T10:00:00Z"'
+        fields[name] = spec
+
+    filters: dict[str, Any] = {
+        "grammar": GRAMMAR_LINE,
+        "fields": fields,
+        "examples": list(FILTER_EXAMPLES[entity_type]),
+    }
+    if entity_type in _SOURCE_DEFAULTED:
+        filters["default"] = 'source = "sdk" unless you name source'
+
+    return {
+        "operation": f"list.{entity_type}",
+        "entity_type": entity_type,
+        "filters": filters,
+        "sort": {"form": SORT_FORM, "fields": sortable_names(entity_type)},
+        "window": entity_type in _WINDOWED_OR_SEARCHABLE,
+        "search": entity_type in _WINDOWED_OR_SEARCHABLE,
+    }
+
+
+__all__ = ["FILTER_EXAMPLES", "LIST_SCHEMA_KEYS", "list_reference"]

--- a/src/opik_mcp/read_list/reference.py
+++ b/src/opik_mcp/read_list/reference.py
@@ -19,16 +19,13 @@ from opik_mcp.read_list.oql import (
     KEYED_TYPES,
     MILLISECOND_FIELDS,
     OPERATORS_BY_TYPE,
+    SOURCE_DEFAULTED_ENTITIES,
     SUPPORTED_ENTITIES,
+    WINDOWED_ENTITIES,
 )
 from opik_mcp.read_list.sorting import SORT_FORM, sortable_names
 
 LIST_SCHEMA_KEYS: Final[tuple[str, ...]] = tuple(f"list.{e}" for e in SUPPORTED_ENTITIES)
-
-# Kept in step with list_tool: which entities take from_time/to_time + search,
-# and which get the UI's ``source = "sdk"`` default.
-_WINDOWED_OR_SEARCHABLE: Final = frozenset({"trace", "span", "thread"})
-_SOURCE_DEFAULTED: Final = frozenset({"trace", "span", "thread"})
 
 FILTER_EXAMPLES: Final[dict[str, tuple[str, str]]] = {
     "trace": (
@@ -68,7 +65,7 @@ def list_reference(entity_type: str) -> dict[str, Any]:
         "fields": fields,
         "examples": list(FILTER_EXAMPLES[entity_type]),
     }
-    if entity_type in _SOURCE_DEFAULTED:
+    if entity_type in SOURCE_DEFAULTED_ENTITIES:
         filters["default"] = 'source = "sdk" unless you name source'
 
     return {
@@ -76,8 +73,8 @@ def list_reference(entity_type: str) -> dict[str, Any]:
         "entity_type": entity_type,
         "filters": filters,
         "sort": {"form": SORT_FORM, "fields": sortable_names(entity_type)},
-        "window": entity_type in _WINDOWED_OR_SEARCHABLE,
-        "search": entity_type in _WINDOWED_OR_SEARCHABLE,
+        "window": entity_type in WINDOWED_ENTITIES,
+        "search": entity_type in WINDOWED_ENTITIES,
     }
 
 

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -418,7 +418,9 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         entity_type="trace",
         fetch_fn=_fetch_trace,
         list_fn=_list_traces,
-        list_extra_fields=("start_time", "end_time"),
+        # Triage columns: what a "which traces need attention" list needs
+        # without a read() per row. error_type is derived from error_info.
+        list_extra_fields=("start_time", "duration", "error_type", "total_estimated_cost"),
         list_required_kwargs=("project_id",),
         compress_fn=_compress_trace,
         id_only=True,

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -325,6 +325,14 @@ async def _list_threads(client: OpikListClient, **kw: Any) -> dict[str, Any]:
     return await client.list_threads(**kw)
 
 
+async def _list_spans(client: OpikListClient, **kw: Any) -> dict[str, Any]:
+    # Project-wide span search: no ``trace_id`` — that scoping (and ``type``)
+    # is expressed in OQL (``trace_id = "…"``, ``type = "llm"``). ``name``
+    # filtering isn't supported by opik-backend; drop it if passed.
+    kw.pop("name", None)
+    return await client.list_spans(**kw)
+
+
 # --- trace skeleton compression ------------------------------------------ #
 
 
@@ -432,8 +440,14 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
     "span": EntityHandler(
         entity_type="span",
         fetch_fn=_fetch_span,
+        list_fn=_list_spans,
+        list_extra_fields=("type", "trace_id", "duration", "model", "error_type"),
+        list_required_kwargs=("project_id",),
         id_only=True,
-        description="Single span: inputs, outputs, metadata, timing, feedback_scores.",
+        description=(
+            "Single span: inputs, outputs, metadata, timing, feedback_scores. "
+            "list('span', project_id=…, filters=…) searches spans across a project."
+        ),
     ),
     "test_suite": EntityHandler(
         entity_type="test_suite",

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -422,7 +422,9 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         fetch_fn=_fetch_project,
         search_by_name_fn=_search_project,
         list_fn=_list_projects,
-        list_extra_fields=("created_at",),
+        # last_updated_trace_at lets the agent pick the project with live
+        # traffic in one call instead of probing each one.
+        list_extra_fields=("created_at", "last_updated_trace_at"),
         description="Project metadata + stats (trace_count, last activity).",
     ),
     "trace": EntityHandler(
@@ -511,7 +513,15 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         entity_type="thread",
         fetch_fn=_fetch_thread,
         list_fn=_list_threads,
-        list_extra_fields=("status", "number_of_messages", "duration", "last_updated_at"),
+        # first_message stands in for the name a thread doesn't have: the
+        # agent can pick the conversation without a read() per row.
+        list_extra_fields=(
+            "first_message",
+            "status",
+            "number_of_messages",
+            "duration",
+            "last_updated_at",
+        ),
         list_required_kwargs=("project_id",),
         list_has_name=False,
         compress_fn=_compress_thread,

--- a/src/opik_mcp/read_list/registry.py
+++ b/src/opik_mcp/read_list/registry.py
@@ -65,6 +65,9 @@ class EntityHandler:
     list_fn: ListFn | None = None
     list_extra_fields: tuple[str, ...] = ()
     list_required_kwargs: tuple[str, ...] = ()
+    list_has_name: bool = True
+    """False for entities whose records carry no ``name`` (thread) — the table
+    then starts at ``id`` instead of rendering an always-empty name column."""
     compress_fn: CompressFn | None = None
     id_only: bool = False
     """True if the entity is addressed only by UUID (no name lookup).
@@ -465,7 +468,9 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         fetch_fn=_fetch_experiment,
         search_by_name_fn=_search_experiment,
         list_fn=_list_experiments,
-        list_extra_fields=("dataset_name", "created_at"),
+        # feedback_scores is the experiment's per-metric averages, rendered as
+        # ``name=value`` pairs so a comparison list reads without a read() per row.
+        list_extra_fields=("dataset_name", "created_at", "feedback_scores"),
         description="Experiment status + summary scores.",
     ),
     "prompt": EntityHandler(
@@ -506,8 +511,9 @@ ENTITY_REGISTRY: dict[str, EntityHandler] = {
         entity_type="thread",
         fetch_fn=_fetch_thread,
         list_fn=_list_threads,
-        list_extra_fields=("status", "number_of_messages", "last_updated_at"),
+        list_extra_fields=("status", "number_of_messages", "duration", "last_updated_at"),
         list_required_kwargs=("project_id",),
+        list_has_name=False,
         compress_fn=_compress_thread,
         id_only=True,
         needs_project=True,

--- a/src/opik_mcp/read_list/sorting.py
+++ b/src/opik_mcp/read_list/sorting.py
@@ -156,6 +156,22 @@ def is_sortable(entity_type: str, field: str) -> bool:
     return False
 
 
+def sort_field_label(sort: str | None) -> str:
+    """The sort field for analytics: a dynamic ``prefix.<name>`` collapses to
+    ``prefix.*`` so a user-named score never becomes a label; anything that
+    is not a known static or dynamic field collapses to ``""``."""
+    if not sort:
+        return ""
+    field = sort.split()[0]
+    for allowed in {a for fields in SORTABLE_FIELDS.values() for a in fields}:
+        if allowed.endswith(".*"):
+            if field.startswith(allowed[:-1]):
+                return allowed
+        elif field == allowed:
+            return field
+    return ""
+
+
 def sortable_names(entity_type: str) -> list[str]:
     """Human form of the sortable list: dynamic prefixes shown as ``x.<name>``."""
     return [f"{f[:-2]}.<name>" if f.endswith(".*") else f for f in SORTABLE_FIELDS[entity_type]]
@@ -168,5 +184,6 @@ __all__ = [
     "SortError",
     "compile_sort",
     "is_sortable",
+    "sort_field_label",
     "sortable_names",
 ]

--- a/src/opik_mcp/read_list/sorting.py
+++ b/src/opik_mcp/read_list/sorting.py
@@ -1,0 +1,172 @@
+"""``sort`` for the ``list`` tool — one field, one direction, validated locally.
+
+opik-backend's ``sorting`` query param takes ``[{field, direction}]``. Three
+of its behaviours make local validation necessary:
+
+- only the first field is honoured; extras are silently dropped;
+- an unknown field is silently ignored, not rejected — the agent would get an
+  unsorted page and no signal;
+- on very large workspaces sorting is dropped entirely and the page comes back
+  with an empty ``sortable_by`` (the ``list`` tool flags that in its header).
+
+The sortable lists mirror the backend's ``*SortingFactory`` classes. Entries
+ending in ``.*`` are dynamic prefixes: ``feedback_scores.accuracy``,
+``usage.total_tokens``, ``experiment_scores.<name>``, ``duration.p50``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from opik_mcp.read_list.errors import EntityArgValidationError
+
+_TRACE_SORTABLE: Final = (
+    "id",
+    "name",
+    "input",
+    "output",
+    "start_time",
+    "end_time",
+    "duration",
+    "ttft",
+    "metadata",
+    "thread_id",
+    "span_count",
+    "llm_span_count",
+    "usage.*",
+    "total_estimated_cost",
+    "tags",
+    "error_info",
+    "created_by",
+    "feedback_scores.*",
+    "experiment_id",
+    "environment",
+)
+_SPAN_SORTABLE: Final = (
+    "id",
+    "name",
+    "type",
+    "trace_id",
+    "parent_span_id",
+    "input",
+    "output",
+    "metadata",
+    "start_time",
+    "end_time",
+    "duration",
+    "ttft",
+    "usage.*",
+    "tags",
+    "created_at",
+    "last_updated_at",
+    "model",
+    "provider",
+    "total_estimated_cost",
+    "error_info",
+    "created_by",
+    "feedback_scores.*",
+    "environment",
+)
+_THREAD_SORTABLE: Final = (
+    "id",
+    "start_time",
+    "end_time",
+    "duration",
+    "number_of_messages",
+    "last_updated_at",
+    "created_by",
+    "created_at",
+    "usage.*",
+    "total_estimated_cost",
+    "feedback_scores.*",
+    "status",
+    "tags",
+    "environment",
+)
+_EXPERIMENT_SORTABLE: Final = (
+    "id",
+    "name",
+    "created_at",
+    "last_updated_at",
+    "created_by",
+    "last_updated_by",
+    "tags",
+    "trace_count",
+    "total_estimated_cost",
+    "total_estimated_cost_avg",
+    "feedback_scores.*",
+    "experiment_scores.*",
+    "duration.*",
+    "pass_rate",
+)
+
+SORTABLE_FIELDS: Final[dict[str, tuple[str, ...]]] = {
+    "trace": _TRACE_SORTABLE,
+    "span": _SPAN_SORTABLE,
+    "thread": _THREAD_SORTABLE,
+    "experiment": _EXPERIMENT_SORTABLE,
+}
+SORTABLE_ENTITIES: Final[tuple[str, ...]] = tuple(SORTABLE_FIELDS)
+
+SORT_FORM: Final = "<field> [asc|desc]"
+
+
+class SortError(EntityArgValidationError):
+    """The ``sort`` string does not validate (kind ``bad_sort`` in analytics)."""
+
+    kind: str = "bad_sort"
+
+
+def compile_sort(entity_type: str, sort: str) -> tuple[str, str]:
+    """Parse ``"<field> [asc|desc]"`` into ``(field, "ASC"|"DESC")``.
+
+    Direction defaults to ``DESC`` — "slowest / most expensive / most recent
+    first" is what a sort on a list is almost always for.
+    """
+    if entity_type not in SORTABLE_FIELDS:
+        raise SortError(
+            f"sort is not supported for {entity_type!r}. "
+            f"Sortable types: {', '.join(SORTABLE_ENTITIES)}."
+        )
+    parts = sort.split()
+    if not parts or len(parts) > 2:
+        raise SortError(f"Invalid sort {sort!r}: expected {SORT_FORM}, e.g. 'duration desc'.")
+    field = parts[0]
+    direction = parts[1].lower() if len(parts) == 2 else "desc"
+    if direction not in ("asc", "desc"):
+        raise SortError(
+            f"Invalid sort direction {parts[1]!r}: expected {SORT_FORM}, e.g. 'duration desc'."
+        )
+    if not is_sortable(entity_type, field):
+        raise SortError(
+            f"'{field}' is not sortable for {entity_type}. "
+            f"Sortable: {', '.join(sortable_names(entity_type))}."
+        )
+    return field, direction.upper()
+
+
+def is_sortable(entity_type: str, field: str) -> bool:
+    for allowed in SORTABLE_FIELDS[entity_type]:
+        if allowed.endswith(".*"):
+            prefix = allowed[:-1]  # "feedback_scores."
+            if field.startswith(prefix) and len(field) > len(prefix):
+                return True
+        elif field == allowed:
+            return True
+    return False
+
+
+def sortable_names(entity_type: str) -> list[str]:
+    """Human form of the sortable list: dynamic prefixes shown as ``x.<name>``."""
+    return [f"{f[:-2]}.<name>" if f.endswith(".*") else f for f in SORTABLE_FIELDS[entity_type]]
+
+
+__all__ = [
+    "SORTABLE_ENTITIES",
+    "SORTABLE_FIELDS",
+    "SORT_FORM",
+    "SortError",
+    "compile_sort",
+    "is_sortable",
+    "sortable_names",
+]

--- a/src/opik_mcp/read_list/sorting.py
+++ b/src/opik_mcp/read_list/sorting.py
@@ -112,9 +112,11 @@ SORT_FORM: Final = "<field> [asc|desc]"
 
 
 class SortError(EntityArgValidationError):
-    """The ``sort`` string does not validate (kind ``bad_sort`` in analytics)."""
+    """The ``sort`` string does not validate.
 
-    kind: str = "bad_sort"
+    Analytics buckets the failure by this class name (``cause_type``); the
+    offending string never leaves the process.
+    """
 
 
 def compile_sort(entity_type: str, sort: str) -> tuple[str, str]:

--- a/src/opik_mcp/read_list/window.py
+++ b/src/opik_mcp/read_list/window.py
@@ -40,26 +40,28 @@ def is_relative(value: str) -> bool:
     return _RELATIVE.match(value.strip()) is not None
 
 
-def to_minute(instant: str) -> str:
-    """``2026-08-09T11:03:11.376Z`` → ``2026-08-09T11:03Z`` for compact echoes."""
-    return instant[:16] + "Z"
+def to_minute(dt: datetime) -> str:
+    """``2026-08-09T11:03:11.376+00:00`` → ``2026-08-09T11:03Z`` for compact echoes."""
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%MZ")
+
+
+# The shape ``Instant.parse`` accepts: date, ``T``, hh:mm:ss, optional fraction,
+# ``Z`` or an offset. ``datetime.fromisoformat`` is looser (space separator,
+# hour-only time, bare date, naive time), so it is gated by this first.
+_INSTANT: Final = re.compile(r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(Z|[+-]\d\d:\d\d)$")
 
 
 def parse_instant(value: str) -> datetime | None:
-    """Parse a strict ISO-8601 instant: ``T`` separator, timezone required.
-
-    ``datetime.fromisoformat`` is looser than the backend's ``Instant.parse``
-    (it takes a space separator, a bare date, a naive time). Anything the
-    backend would 400 on is rejected here so the local check means something.
-    """
+    """Parse a strict ISO-8601 instant, the form the backend's ``Instant.parse``
+    accepts. Anything the backend would 400 on is rejected here so the local
+    check means something."""
     text = value.strip()
-    if "T" not in text:
+    if not _INSTANT.match(text):
         return None
     try:
-        parsed = datetime.fromisoformat(text)
+        return datetime.fromisoformat(text)
     except ValueError:
         return None
-    return parsed if parsed.tzinfo is not None else None
 
 
 def resolve_instant(param: str, value: str, *, now: datetime | None = None) -> datetime:

--- a/src/opik_mcp/read_list/window.py
+++ b/src/opik_mcp/read_list/window.py
@@ -35,6 +35,16 @@ class WindowError(EntityArgValidationError):
     """
 
 
+def is_relative(value: str) -> bool:
+    """True for the shorthand form (``30m``, ``1h``, ``7d``, ``2w``)."""
+    return _RELATIVE.match(value.strip()) is not None
+
+
+def to_minute(instant: str) -> str:
+    """``2026-08-09T11:03:11.376Z`` → ``2026-08-09T11:03Z`` for compact echoes."""
+    return instant[:16] + "Z"
+
+
 def parse_instant(value: str) -> datetime | None:
     """Parse a strict ISO-8601 instant: ``T`` separator, timezone required.
 
@@ -93,7 +103,9 @@ __all__ = [
     "WINDOW_FORMS",
     "WindowError",
     "format_instant",
+    "is_relative",
     "parse_instant",
     "resolve_instant",
     "resolve_window",
+    "to_minute",
 ]

--- a/src/opik_mcp/read_list/window.py
+++ b/src/opik_mcp/read_list/window.py
@@ -28,44 +28,72 @@ WINDOW_FORMS: Final = (
 
 
 class WindowError(EntityArgValidationError):
-    """``since`` / ``until`` does not validate (kind ``bad_window`` in analytics)."""
+    """``since`` / ``until`` does not validate.
 
-    kind: str = "bad_window"
+    Analytics buckets the failure by this class name (``cause_type``); the
+    offending value never leaves the process.
+    """
 
 
-def resolve_instant(param: str, value: str, *, now: datetime | None = None) -> str:
-    """Turn a ``since``/``until`` value into a UTC ``…Z`` instant string."""
+def parse_instant(value: str) -> datetime | None:
+    """Parse a strict ISO-8601 instant: ``T`` separator, timezone required.
+
+    ``datetime.fromisoformat`` is looser than the backend's ``Instant.parse``
+    (it takes a space separator, a bare date, a naive time). Anything the
+    backend would 400 on is rejected here so the local check means something.
+    """
+    text = value.strip()
+    if "T" not in text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else None
+
+
+def resolve_instant(param: str, value: str, *, now: datetime | None = None) -> datetime:
+    """Turn a ``since``/``until`` value into an aware UTC datetime."""
     now = now or datetime.now(UTC)
     m = _RELATIVE.match(value.strip())
     if m:
         amount, unit = int(m.group(1)), m.group(2)
-        return _format(now - timedelta(seconds=amount * _UNIT_SECONDS[unit]))
-    try:
-        parsed = datetime.fromisoformat(value.strip())
-    except ValueError:
-        parsed = None
-    if parsed is None or parsed.tzinfo is None:
+        return now - timedelta(seconds=amount * _UNIT_SECONDS[unit])
+    parsed = parse_instant(value)
+    if parsed is None:
         raise WindowError(f"Invalid {param} {value!r}: expected {WINDOW_FORMS}.")
-    return _format(parsed)
+    return parsed
 
 
 def resolve_window(
     since: str | None, until: str | None, *, now: datetime | None = None
 ) -> tuple[str | None, str | None]:
-    """Resolve both bounds and check their order."""
+    """Resolve both bounds to ``…Z`` strings and check their order."""
     now = now or datetime.now(UTC)
-    from_time = resolve_instant("since", since, now=now) if since is not None else None
-    to_time = resolve_instant("until", until, now=now) if until is not None else None
-    if from_time and to_time and to_time < from_time:
-        raise WindowError(f"until ({to_time}) is before since ({from_time}).")
-    return from_time, to_time
+    start = resolve_instant("since", since, now=now) if since is not None else None
+    end = resolve_instant("until", until, now=now) if until is not None else None
+    if start is not None and end is not None and end < start:
+        raise WindowError(
+            f"until ({format_instant(end)}) is before since ({format_instant(start)})."
+        )
+    return (
+        format_instant(start) if start is not None else None,
+        format_instant(end) if end is not None else None,
+    )
 
 
-def _format(dt: datetime) -> str:
+def format_instant(dt: datetime) -> str:
     dt = dt.astimezone(UTC)
     if dt.microsecond:
         return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-__all__ = ["WINDOW_FORMS", "WindowError", "resolve_instant", "resolve_window"]
+__all__ = [
+    "WINDOW_FORMS",
+    "WindowError",
+    "format_instant",
+    "parse_instant",
+    "resolve_instant",
+    "resolve_window",
+]

--- a/src/opik_mcp/read_list/window.py
+++ b/src/opik_mcp/read_list/window.py
@@ -1,0 +1,71 @@
+"""``since`` / ``until`` for the ``list`` tool.
+
+Each bound is either an ISO-8601 instant with a timezone or a relative
+shorthand — ``30m``, ``1h``, ``24h``, ``7d``, ``2w`` — resolved against the
+server's current UTC time. Agents usually know the date but not the exact
+moment, so "the last hour" is ``since="1h"`` rather than a timestamp they
+would have to compute.
+
+The bounds map to the backend's ``from_time`` / ``to_time`` query params.
+Those are UUIDv7 bounds on the record id, i.e. the *creation* time, which
+is index-aligned and cheap; for live traffic it agrees with ``start_time``
+within seconds. An exact ``start_time`` bound is still available in OQL.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Final
+
+from opik_mcp.read_list.errors import EntityArgValidationError
+
+_RELATIVE: Final = re.compile(r"^(\d+)([mhdw])$")
+_UNIT_SECONDS: Final = {"m": 60, "h": 3600, "d": 86400, "w": 7 * 86400}
+WINDOW_FORMS: Final = (
+    'a relative span like "1h", "24h", "7d" or an ISO-8601 instant like "2026-09-08T10:00:00Z"'
+)
+
+
+class WindowError(EntityArgValidationError):
+    """``since`` / ``until`` does not validate (kind ``bad_window`` in analytics)."""
+
+    kind: str = "bad_window"
+
+
+def resolve_instant(param: str, value: str, *, now: datetime | None = None) -> str:
+    """Turn a ``since``/``until`` value into a UTC ``…Z`` instant string."""
+    now = now or datetime.now(UTC)
+    m = _RELATIVE.match(value.strip())
+    if m:
+        amount, unit = int(m.group(1)), m.group(2)
+        return _format(now - timedelta(seconds=amount * _UNIT_SECONDS[unit]))
+    try:
+        parsed = datetime.fromisoformat(value.strip())
+    except ValueError:
+        parsed = None
+    if parsed is None or parsed.tzinfo is None:
+        raise WindowError(f"Invalid {param} {value!r}: expected {WINDOW_FORMS}.")
+    return _format(parsed)
+
+
+def resolve_window(
+    since: str | None, until: str | None, *, now: datetime | None = None
+) -> tuple[str | None, str | None]:
+    """Resolve both bounds and check their order."""
+    now = now or datetime.now(UTC)
+    from_time = resolve_instant("since", since, now=now) if since is not None else None
+    to_time = resolve_instant("until", until, now=now) if until is not None else None
+    if from_time and to_time and to_time < from_time:
+        raise WindowError(f"until ({to_time}) is before since ({from_time}).")
+    return from_time, to_time
+
+
+def _format(dt: datetime) -> str:
+    dt = dt.astimezone(UTC)
+    if dt.microsecond:
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = ["WINDOW_FORMS", "WindowError", "resolve_instant", "resolve_window"]

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -341,7 +341,8 @@ async def list_entities(
         Field(
             description=(
                 "Free text for trace, span, thread: matches anywhere in id, name, input, "
-                "output, metadata, tags, thread_id (spans: model, provider too)."
+                "output, metadata, tags, thread_id (spans: model, provider too). Expensive "
+                "on large projects; narrow with since first."
             ),
             max_length=500,
         ),

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -302,7 +302,7 @@ async def list_entities(
         str | None,
         Field(
             description=(
-                "Parent project UUID for project-scoped lists (trace, thread). "
+                "Parent project UUID for project-scoped lists (trace, span, thread). "
                 "Pass this OR project_name."
             )
         ),
@@ -311,7 +311,7 @@ async def list_entities(
         str | None,
         Field(
             description=(
-                "Parent project name — alternative to project_id for trace/thread "
+                "Parent project name — alternative to project_id for trace/span/thread "
                 "lists, so you don't need to resolve the UUID first."
             ),
             max_length=200,
@@ -336,6 +336,7 @@ async def list_entities(
 
     Project-scoped types require their parent:
     - trace: project_id or project_name
+    - span: project_id or project_name (searches spans across the project)
     - thread: project_id or project_name
     - test_suite_item: test_suite_id
     - prompt_version: prompt_id

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -298,14 +298,13 @@ async def list_entities(
         str | None,
         Field(
             description=(
-                "OQL filter for trace, span, thread, experiment. "
-                "<field>[.<key>] <op> <value> [AND ...]; ops: = != > >= < <= contains "
-                "not_contains starts_with ends_with is_empty is_not_empty in not_in. "
-                "Strings in double quotes, numbers bare, duration in ms. E.g. "
-                "'error_info is_not_empty AND duration > 5000' or "
+                "OQL filter for trace, span, thread, experiment: "
+                "<field>[.<key>] <op> <value> [AND ...]; ops = != > >= < <= contains "
+                "not_contains starts_with ends_with is_empty is_not_empty in not_in; "
+                "strings quoted, numbers bare (duration in ms). E.g. "
+                "'error_info is_not_empty AND duration > 5000', "
                 "'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. "
-                'trace/span/thread add source = "sdk" unless you name source. '
-                'Field reference: schema("list.trace").'
+                'Reference: schema("list.trace").'
             ),
             max_length=2000,
         ),

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -67,6 +67,7 @@ from opik_mcp.writes import (
     run_write,
 )
 from opik_mcp.writes.registry import WRITE_OPERATIONS
+from opik_mcp.writes.schema_tool import SCHEMA_KEYS
 
 logger = logging.getLogger("opik_mcp")
 
@@ -469,14 +470,21 @@ async def write(
     )
 
 
+SCHEMA_KEY_ENUM: list[str] = list(SCHEMA_KEYS)
+
+
 @mcp.tool(description=SCHEMA_TOOL_DESCRIPTION)
 @instrument_tool("schema", props_fn=_schema_props)
 async def schema(
     operation: Annotated[
         str,
         Field(
-            description="Operation whose schema to return.",
-            json_schema_extra={"enum": WRITE_OPERATION_ENUM},
+            description=(
+                "Write operation whose schema to return, or list.<entity> "
+                "(list.trace, list.span, list.thread, list.experiment) for the "
+                "filter and sort reference of the list tool."
+            ),
+            json_schema_extra={"enum": SCHEMA_KEY_ENUM},
         ),
     ],
     ctx: Context[ServerSession, None] | None = None,

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -50,7 +50,9 @@ from opik_mcp.credential_identity import (
 from opik_mcp.instructions import render_instructions
 from opik_mcp.oauth_identity import introspect_oauth_token
 from opik_mcp.read_list import run_list, run_read
+from opik_mcp.read_list.oql import filter_field_names
 from opik_mcp.read_list.registry import LISTABLE_TYPES, READABLE_TYPES
+from opik_mcp.read_list.sorting import sort_field_label
 from opik_mcp.read_list.uri import looks_like_thread_url
 from opik_mcp.skills_catalog import (
     SKILLS_URI_PREFIX,
@@ -102,11 +104,28 @@ def _read_props(_result: Any, kwargs: dict[str, Any]) -> dict[str, str]:
 
 
 def _list_props(_result: Any, kwargs: dict[str, Any]) -> dict[str, str]:
+    """Analytics labels for ``list``.
+
+    The search surface (OPIK-8283) is recorded as *shape* only: which filter
+    fields were used (names, never values or the ``.key`` a score or metadata
+    filter carries — those are user vocabulary), which field was sorted on
+    (dynamic ``feedback_scores.<name>`` collapses to its prefix), and whether
+    a window / free-text search was present. Failed validations don't reach
+    this function; they are bucketed by exception class in the wrapper.
+    """
+    filters = kwargs.get("filters")
+    sort = kwargs.get("sort")
     return {
         "entity_type": kwargs.get("entity_type", ""),
         "had_name_filter": str(kwargs.get("name") is not None).lower(),
         "page": str(kwargs.get("page", 1)),
         "size": str(kwargs.get("size", 25)),
+        "has_filters": str(bool(filters)).lower(),
+        "filter_fields": ",".join(filter_field_names(kwargs.get("entity_type", ""), filters)),
+        "has_sort": str(bool(sort)).lower(),
+        "sort_field": sort_field_label(sort),
+        "has_window": str(bool(kwargs.get("since") or kwargs.get("until"))).lower(),
+        "has_search": str(bool(kwargs.get("search"))).lower(),
     }
 
 

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -304,7 +304,7 @@ async def list_entities(
                 "strings quoted, numbers bare (duration in ms). E.g. "
                 "'error_info is_not_empty AND duration > 5000', "
                 "'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. "
-                'Reference: schema("list.trace").'
+                'trace/span/thread default to source = "sdk". Reference: schema("list.trace").'
             ),
             max_length=2000,
         ),

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -290,6 +290,17 @@ async def list_entities(
             max_length=2000,
         ),
     ] = None,
+    sort: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Sort for trace, span, thread, experiment: '<field> [asc|desc]', desc by "
+                "default. E.g. 'duration desc', 'total_estimated_cost', "
+                "'feedback_scores.accuracy asc', 'usage.total_tokens'. One field only."
+            ),
+            max_length=200,
+        ),
+    ] = None,
     page: Annotated[
         int,
         Field(description="Page number (1-indexed).", ge=1, le=10_000),
@@ -343,7 +354,7 @@ async def list_entities(
 
     Workspace-wide types (project, experiment, prompt, test_suite) accept
     an optional `name` substring filter. trace, span, thread, experiment
-    accept an OQL `filters` string.
+    accept an OQL `filters` string and a `sort`.
     """
     if ctx is not None:
         await ctx.info(f"list.called entity_type={entity_type} page={page} size={size}")
@@ -351,6 +362,7 @@ async def list_entities(
         entity_type=entity_type,
         name=name,
         filters=filters,
+        sort=sort,
         page=page,
         size=size,
         project_id=project_id,

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -274,6 +274,22 @@ async def list_entities(
             max_length=200,
         ),
     ] = None,
+    filters: Annotated[
+        str | None,
+        Field(
+            description=(
+                "OQL filter for trace, span, thread, experiment. "
+                "<field>[.<key>] <op> <value> [AND ...]; ops: = != > >= < <= contains "
+                "not_contains starts_with ends_with is_empty is_not_empty in not_in. "
+                "Strings in double quotes, numbers bare, duration in ms. E.g. "
+                "'error_info is_not_empty AND duration > 5000' or "
+                "'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. "
+                'trace/span/thread add source = "sdk" unless you name source. '
+                'Field reference: schema("list.trace").'
+            ),
+            max_length=2000,
+        ),
+    ] = None,
     page: Annotated[
         int,
         Field(description="Page number (1-indexed).", ge=1, le=10_000),
@@ -311,11 +327,12 @@ async def list_entities(
     ] = None,
     ctx: Context[ServerSession, None] | None = None,
 ) -> str:
-    """List Opik entities with optional name filter and pagination.
+    """List Opik entities with optional filters and pagination.
 
     Output is a pipe-delimited table with id, name, and a few entity-specific
-    columns, plus a pagination footer when more pages exist. Use read() to
-    get full details on any specific item.
+    columns, plus a pagination footer when more pages exist. When filters
+    apply, the first line echoes what was applied. Use read() to get full
+    details on any specific item.
 
     Project-scoped types require their parent:
     - trace: project_id or project_name
@@ -324,13 +341,15 @@ async def list_entities(
     - prompt_version: prompt_id
 
     Workspace-wide types (project, experiment, prompt, test_suite) accept
-    an optional `name` substring filter.
+    an optional `name` substring filter. trace, span, thread, experiment
+    accept an OQL `filters` string.
     """
     if ctx is not None:
         await ctx.info(f"list.called entity_type={entity_type} page={page} size={size}")
     return await run_list(
         entity_type=entity_type,
         name=name,
+        filters=filters,
         page=page,
         size=size,
         project_id=project_id,

--- a/src/opik_mcp/server.py
+++ b/src/opik_mcp/server.py
@@ -301,6 +301,32 @@ async def list_entities(
             max_length=200,
         ),
     ] = None,
+    since: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Start of the time window for trace, span, thread: a relative span "
+                "('30m', '1h', '24h', '7d') or an ISO-8601 instant with timezone. "
+                "Windows are by record creation time; for an exact start_time bound "
+                "use filters."
+            ),
+            max_length=40,
+        ),
+    ] = None,
+    until: Annotated[
+        str | None,
+        Field(description="End of the time window, same forms as since.", max_length=40),
+    ] = None,
+    search: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Free text for trace, span, thread: matches anywhere in id, name, input, "
+                "output, metadata, tags, thread_id (spans: model, provider too)."
+            ),
+            max_length=500,
+        ),
+    ] = None,
     page: Annotated[
         int,
         Field(description="Page number (1-indexed).", ge=1, le=10_000),
@@ -354,7 +380,8 @@ async def list_entities(
 
     Workspace-wide types (project, experiment, prompt, test_suite) accept
     an optional `name` substring filter. trace, span, thread, experiment
-    accept an OQL `filters` string and a `sort`.
+    accept an OQL `filters` string and a `sort`; trace, span, thread also
+    take a `since`/`until` window and free-text `search`.
     """
     if ctx is not None:
         await ctx.info(f"list.called entity_type={entity_type} page={page} size={size}")
@@ -363,6 +390,9 @@ async def list_entities(
         name=name,
         filters=filters,
         sort=sort,
+        since=since,
+        until=until,
+        search=search,
         page=page,
         size=size,
         project_id=project_id,

--- a/src/opik_mcp/skills/opik-diagnose/SKILL.md
+++ b/src/opik_mcp/skills/opik-diagnose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opik-diagnose
-description: Surface the Opik traces worth a developer's attention, ranked by signal — errors, failed tool calls, latency, regressions, and low online-eval scores — plus Diagnostics issues. Reads live/production traces via the SDK (search_traces and agent_insights) and works with no MCP; uses the MCP issue entity when connected. Returns a ranked shortlist, each item ready to hand to the explain skill. Use for "what is broken in production", "which traces need attention", "find failing or slow traces", "which tool calls are failing", "triage my agent". Not for offline experiment results (use evaluate or compare) and not for root-causing one trace (use explain).
+description: Surface the Opik traces worth a developer's attention, ranked by signal — errors, failed tool calls, latency, regressions, and low online-eval scores — plus Diagnostics issues. Reads live/production traces through the hosted Opik MCP when it is connected (list with filters, sort and a time window) and falls back to the SDK (search_traces and agent_insights) otherwise, so it works with no MCP. Returns a ranked shortlist, each item ready to hand to the explain skill. Use for "what is broken in production", "which traces need attention", "find failing or slow traces", "which tool calls are failing", "triage my agent". Not for offline experiment results (use evaluate or compare) and not for root-causing one trace (use explain).
 compatibility: Tested with Claude Code; works with any Agent Skills-compatible host (Cursor, VS Code Copilot, Codex). Requires a Python or TypeScript project with Opik configured and a project that has traces. Install the `opik` skill alongside this one — it holds the shared SDK and observability references; without it, this skill falls back to the public docs.
 allowed-tools:
   - Read
@@ -8,7 +8,7 @@ allowed-tools:
   - Glob
   - Bash
 metadata:
-  last_updated: "2026-08-24"
+  last_updated: "2026-09-08"
   source_commit: "2.0.0"
   argument-hint: "[optional: project name, or what to look for]"
 ---
@@ -32,17 +32,37 @@ Ask only at a genuine, non-inferable blocker (see **Blockers**).
 ### 1. Resolve scope
 Project (from config/repo) + a recent window. Confirm Opik is reachable: if `~/.opik.config` exists or `OPIK_API_KEY` is set, use it. Otherwise → **Blocker** ("run `opik configure`, then rerun").
 
-### 2. Pull candidate traces (SDK-first)
-The SDK is the primary path and needs no MCP.
+### 2. Pull candidate traces — MCP first, SDK fallback
+Check whether the hosted Opik MCP is connected and prefer it; fall back to SDK scripting when it isn't.
 
-```python
-import opik
-client = opik.Opik()
+- **MCP connected:** one `list` call per signal. The backend does the filtering and ordering, so each call returns a short, already-ranked page — no SDK, no client-side sorting. `since` takes `"1h"`, `"24h"`, `"7d"`; `filters` is an OQL string; `sort` is `"<field> [asc|desc]"` (desc by default). Trace lists hide evaluator/playground/experiment traces (`source = "sdk"`) unless you name `source`.
 
-traces = client.search_traces(project_name="<project>", max_results=200)  # recent window
-# Narrow server-side first when the volume is large; otherwise rank client-side (step 3).
-# Each trace carries the fields you rank on: error info, duration, feedback_scores.
-```
+  ```
+  list(entity_type="trace", project_name="<project>", since="24h",
+       filters="error_info is_not_empty", sort="start_time desc")         # errored
+  list(entity_type="span",  project_name="<project>", since="24h",
+       filters='type = "tool" AND error_info is_not_empty', sort="start_time desc")  # failed tool calls
+  list(entity_type="trace", project_name="<project>", since="24h",
+       sort="duration desc")                                              # latency outliers (ms)
+  list(entity_type="trace", project_name="<project>", since="24h",
+       filters="feedback_scores.<metric> < 0.5", sort="feedback_scores.<metric> asc")  # low online-eval score
+  list(entity_type="trace", project_name="<project>", since="7d", until="24h",
+       sort="duration desc")                                              # prior window, for regressions
+  ```
+
+  The table carries `duration`, `error_type` and cost by default plus every field you sorted or filtered on. A rejected filter comes back with what fixes it; `schema("list.trace")` is the full field reference.
+
+- **No MCP:** fall back to the SDK.
+
+  ```python
+  import opik
+  client = opik.Opik()
+
+  traces = client.search_traces(project_name="<project>", max_results=200)  # recent window
+  # Narrow server-side with filter_string='error_info is_not_empty' when the volume is
+  # large; otherwise rank client-side (step 3). Each trace carries the fields you rank
+  # on: error info, duration, feedback_scores.
+  ```
 
 ### 3. Rank by signal
 Score each candidate and keep the top few. Priority order:
@@ -93,7 +113,7 @@ Invariants: `found` carries a non-empty `shortlist`, each item with a `signal`, 
 
 ## Examples
 
-**Triage a project.** `/opik-diagnose`. `search_traces` on the project; two traces errored, one is 5x the p90 duration, one scored 0.2 on Hallucination. Shortlist = the two errors (rank 1-2), the latency outlier (3), the low-score trace (4), each with its signal; next step = "explain the top trace". → **`found`**.
+**Triage a project.** `/opik-diagnose`. `list('trace', since="24h", filters="error_info is_not_empty")`, `list('trace', since="24h", sort="duration desc")` and a low-score list on the project (or `search_traces` without the MCP); two traces errored, one is 5x the p90 duration, one scored 0.2 on Hallucination. Shortlist = the two errors (rank 1-2), the latency outlier (3), the low-score trace (4), each with its signal; next step = "explain the top trace". → **`found`**.
 
 **Nothing wrong.** `/opik-diagnose`. Reads fine, but no trace errored, ran slow, or scored low. → **`empty`**: "No traces crossed a threshold in the recent window."
 
@@ -104,6 +124,6 @@ Dumping every trace instead of a ranked shortlist; surfacing offline experiment/
 
 ## References
 
-SDK and observability detail live in the `opik` skill, installed beside this one. Read the files directly — paths are relative to this file: `../opik/references/production.md` (`search_traces`, Diagnostics, online-eval scores, error/latency analysis), `../opik/references/tracing-python.md` (SDK read APIs), `../opik/references/observability.md` (span/score model). If your host lays skills out differently, locate the `opik` skill's `references/` directory.
+SDK and observability detail live in the `opik` skill, installed beside this one. Read the files directly — paths are relative to this file: `../opik/SKILL.md` (**Searching traces** — the OQL filter grammar shared by the MCP `list` tool and `search_traces`), `../opik/references/production.md` (`search_traces`, Diagnostics, online-eval scores, error/latency analysis), `../opik/references/tracing-python.md` (SDK read APIs), `../opik/references/observability.md` (span/score model). If your host lays skills out differently, locate the `opik` skill's `references/` directory.
 
 If the `opik` skill isn't installed, say so in the report and use <https://www.comet.com/docs/opik/> rather than working from memory.

--- a/src/opik_mcp/skills/opik-explain/SKILL.md
+++ b/src/opik_mcp/skills/opik-explain/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Glob
   - Bash
 metadata:
-  last_updated: "2026-08-24"
+  last_updated: "2026-09-08"
   source_commit: "2.0.0"
   argument-hint: "[trace id, or a description of the behavior to explain]"
 ---
@@ -52,10 +52,23 @@ spans = client.search_spans(trace_id=tid)   # spans come from a SEPARATE call, n
 # Your anchor is the first span that errored, returned wrong output, or dominates the duration.
 ```
 
-For a **pattern**, pull the matching set scoped to the project, then look for the shared failing span across them:
+For a **pattern**, pull the matching set scoped to the project, then look for the shared failing span across them. With the MCP, one `list` call does the filtering and ordering server-side — `filters` is an OQL string, `sort` is `"<field> [asc|desc]"`, `since` takes `"1h"` / `"7d"`:
+
+```
+list(entity_type="trace", project_name="<project>", since="7d",
+     filters="error_info is_not_empty", sort="start_time desc")        # error traces
+list(entity_type="trace", project_name="<project>", since="7d",
+     sort="duration desc")                                             # slow traces (duration in ms)
+list(entity_type="trace", project_name="<project>", since="7d",
+     filters="feedback_scores.hallucination > 0.5")                    # low-scored traces
+list(entity_type="span",  project_name="<project>", since="7d",
+     filters='name = "<span name>" AND error_info is_not_empty')       # the shared failing span, across traces
+```
+
+The applied filter is echoed on the first line; a rejected one comes back with what fixes it (`schema("list.trace")` is the full field reference). Without the MCP, the SDK takes the same grammar:
 
 ```python
-traces = client.search_traces(project_name="<project>", filters={...})  # e.g. error traces, low-score traces, high-duration traces
+traces = client.search_traces(project_name="<project>", filter_string="error_info is_not_empty")
 ```
 
 Traces are asynchronous; if you just produced the trace, allow a few seconds and confirm the flush ran.
@@ -92,7 +105,7 @@ Invariants: `explained` must carry a `root_cause` **and** at least one evidence 
 
 **Single trace — tool failure.** `/opik-explain 019fd8a7-...`. Fetch trace + spans; the `retrieve` (`tool`) span returned empty and the `llm` span then hallucinated. Open `retrieve()` in the repo: the query filter is wrong. Root cause = the retrieval filter, evidence = the empty `tool` span feeding the `llm` span; next step = "fix the filter in `retrieve()` (or `/opik-test` it)". → **`explained`**.
 
-**Pattern — slowness.** `/opik-explain why responses got slow this week`. `search_traces` for high-duration traces; the same external `tool` span dominates each. Root cause = that call's latency; evidence = the shared slow span across N traces; next step = "add a timeout/cache around it". → **`explained`**.
+**Pattern — slowness.** `/opik-explain why responses got slow this week`. `list('trace', since="7d", sort="duration desc")` (or `search_traces` without the MCP) for the slowest traces; the same external `tool` span dominates each. Root cause = that call's latency; evidence = the shared slow span across N traces; next step = "add a timeout/cache around it". → **`explained`**.
 
 **Blocked — bad id.** `/opik-explain 123`. `get_trace_content` finds nothing. → **`not_found`**: "No trace `123` in project `X` — confirm the id/project and rerun." (No code touched.)
 
@@ -101,6 +114,6 @@ Dumping the span tree without naming a cause; guessing a cause without reading t
 
 ## References
 
-SDK and observability detail live in the `opik` skill, installed beside this one. Read the files directly — paths are relative to this file: `../opik/references/production.md` (`search_traces`, error/latency/cost analysis), `../opik/references/tracing-python.md` (SDK read APIs), `../opik/references/observability.md` (span-type model). If your host lays skills out differently, locate the `opik` skill's `references/` directory.
+SDK and observability detail live in the `opik` skill, installed beside this one. Read the files directly — paths are relative to this file: `../opik/SKILL.md` (**Searching traces** — the OQL filter grammar shared by the MCP `list` tool and `search_traces`), `../opik/references/production.md` (`search_traces`, error/latency/cost analysis), `../opik/references/tracing-python.md` (SDK read APIs), `../opik/references/observability.md` (span-type model). If your host lays skills out differently, locate the `opik` skill's `references/` directory.
 
 If the `opik` skill isn't installed, say so in the report and use <https://www.comet.com/docs/opik/> rather than working from memory.

--- a/src/opik_mcp/skills/opik/SKILL.md
+++ b/src/opik_mcp/skills/opik/SKILL.md
@@ -2,7 +2,7 @@
 name: opik
 description: Reference for the Opik SDK — tracing, span types, framework integrations, threads, and the prompt library (Python, TypeScript, REST). Use for "what span types exist", "how do I flush", "track_openai", "add OpikTracer", "version a prompt". To instrument a repo end to end, use the `opik-instrument` skill.
 metadata:
-  last_updated: "2026-07-27"
+  last_updated: "2026-09-08"
   source_commit: "TODO — pin to the Opik release this was verified against (OPIK-7471)"
 ---
 
@@ -116,6 +116,46 @@ def run(question: str) -> str:
         metadata={"model": "gpt-4o", "temperature": 0.7},
     )
     return llm(p.format(product="Opik"), model=p.metadata["model"])
+```
+
+## Searching traces
+
+One filter grammar, OQL, serves both the hosted MCP's `list` tool and the
+SDK's `search_traces` / `search_spans` / `search_threads`:
+
+```
+<field>[.<key>] <op> <value> [AND ...]
+ops: = != > >= < <= contains not_contains starts_with ends_with is_empty is_not_empty in not_in
+```
+
+Strings in double quotes, numbers bare, `duration` in **milliseconds**, dates as
+ISO-8601 instants with a timezone (`"2026-09-08T10:00:00Z"`). Scores and
+dictionaries take a key: `feedback_scores.accuracy < 0.5`,
+`metadata.environment = "prod"`. `AND` is the only connector.
+
+```
+error_info is_not_empty AND duration > 5000
+type = "llm" AND usage.total_tokens > 10000            # spans
+feedback_scores.hallucination > 0.5 AND start_time >= "2026-09-08T00:00:00Z"
+```
+
+With the MCP connected, prefer `list` — it also sorts (`sort="duration desc"`),
+windows (`since="1h"`, `"7d"`), and searches free text (`search="order-42"`):
+
+```
+list(entity_type="trace", project_name="<project>", since="1h",
+     filters="error_info is_not_empty", sort="duration desc")
+```
+
+Trace, span and thread lists add `source = "sdk"` unless you name `source`, so
+evaluator, playground and experiment traces stay out of the way. A rejected
+filter comes back with what fixes it; `schema("list.trace")` (or `list.span`,
+`list.thread`, `list.experiment`) is the full field and operator reference.
+
+Without the MCP, the same string goes to the SDK:
+
+```python
+client.search_traces(project_name="<project>", filter_string="error_info is_not_empty")
 ```
 
 ## Anti-patterns

--- a/src/opik_mcp/writes/description.py
+++ b/src/opik_mcp/writes/description.py
@@ -50,7 +50,9 @@ def build_write_description() -> str:
 WRITE_TOOL_DESCRIPTION: Final[str] = build_write_description()
 SCHEMA_TOOL_DESCRIPTION: Final[str] = (
     "Return the JSON Schema, OAuth scope, and one validated example for a "
-    "write operation's `data` payload. Pure lookup — no backend call."
+    "write operation's `data` payload, or — for `list.trace` / `list.span` / "
+    "`list.thread` / `list.experiment` — the list tool's filterable fields with "
+    "their operators and its sortable fields. Pure lookup — no backend call."
 )
 
 

--- a/src/opik_mcp/writes/schema_tool.py
+++ b/src/opik_mcp/writes/schema_tool.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from mcp.server.fastmcp.exceptions import ToolError
 
+from opik_mcp.read_list.reference import LIST_SCHEMA_KEYS, list_reference
 from opik_mcp.writes.errors import UnknownOperationError
 from opik_mcp.writes.registry import WRITE_OPERATIONS, WRITE_REGISTRY
 
@@ -34,9 +35,16 @@ _UNIVERSAL_FAILURE_MODES: tuple[str, ...] = (
 )
 
 
+SCHEMA_KEYS: tuple[str, ...] = (*WRITE_OPERATIONS, *LIST_SCHEMA_KEYS)
+"""Everything ``schema`` answers for: write operations plus ``list.<entity>``."""
+
+
 def run_schema(operation: str) -> dict[str, Any]:
     """Return ``{schema, example, oauth_scope, supports_batch, parent_id_fields,
-    failure_modes, description}``."""
+    failure_modes, description}`` for a write operation, or the filter/sort
+    reference for a ``list.<entity>`` key."""
+    if operation in LIST_SCHEMA_KEYS:
+        return list_reference(operation.removeprefix("list."))
     op = WRITE_REGISTRY.get(operation)
     if op is None:
         # Mirror the structured envelope ``write`` raises so callers get
@@ -44,7 +52,7 @@ def run_schema(operation: str) -> dict[str, Any]:
         # ``did_you_mean``) on either tool — no asymmetric error shapes
         # for the model to learn. The ``from err`` chain lets analytics
         # unwrap to the typed cause and bucket as validation/400.
-        err = UnknownOperationError.build(operation, WRITE_OPERATIONS)
+        err = UnknownOperationError.build(operation, SCHEMA_KEYS)
         raise ToolError(err.to_json()) from err
     return {
         "operation": op.name,
@@ -62,4 +70,4 @@ def run_schema(operation: str) -> dict[str, Any]:
     }
 
 
-__all__ = ["run_schema"]
+__all__ = ["SCHEMA_KEYS", "run_schema"]

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -103,7 +103,7 @@
         }
       ],
       "default": null,
-      "description": "Free text for trace, span, thread: matches anywhere in id, name, input, output, metadata, tags, thread_id (spans: model, provider too).",
+      "description": "Free text for trace, span, thread: matches anywhere in id, name, input, output, metadata, tags, thread_id (spans: model, provider too). Expensive on large projects; narrow with since first.",
       "title": "Search"
     },
     "since": {

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -1,12 +1,13 @@
 {
   "properties": {
     "entity_type": {
-      "description": "One of: experiment, project, prompt, prompt_version, test_suite, test_suite_item, thread, trace.",
+      "description": "One of: experiment, project, prompt, prompt_version, span, test_suite, test_suite_item, thread, trace.",
       "enum": [
         "experiment",
         "project",
         "prompt",
         "prompt_version",
+        "span",
         "test_suite",
         "test_suite_item",
         "thread",
@@ -61,7 +62,7 @@
         }
       ],
       "default": null,
-      "description": "Parent project UUID for project-scoped lists (trace, thread). Pass this OR project_name.",
+      "description": "Parent project UUID for project-scoped lists (trace, span, thread). Pass this OR project_name.",
       "title": "Project Id"
     },
     "project_name": {
@@ -75,7 +76,7 @@
         }
       ],
       "default": null,
-      "description": "Parent project name \u2014 alternative to project_id for trace/thread lists, so you don't need to resolve the UUID first.",
+      "description": "Parent project name \u2014 alternative to project_id for trace/span/thread lists, so you don't need to resolve the UUID first.",
       "title": "Project Name"
     },
     "prompt_id": {

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -27,7 +27,7 @@
         }
       ],
       "default": null,
-      "description": "OQL filter for trace, span, thread, experiment. <field>[.<key>] <op> <value> [AND ...]; ops: = != > >= < <= contains not_contains starts_with ends_with is_empty is_not_empty in not_in. Strings in double quotes, numbers bare, duration in ms. E.g. 'error_info is_not_empty AND duration > 5000' or 'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. trace/span/thread add source = \"sdk\" unless you name source. Field reference: schema(\"list.trace\").",
+      "description": "OQL filter for trace, span, thread, experiment: <field>[.<key>] <op> <value> [AND ...]; ops = != > >= < <= contains not_contains starts_with ends_with is_empty is_not_empty in not_in; strings quoted, numbers bare (duration in ms). E.g. 'error_info is_not_empty AND duration > 5000', 'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. Reference: schema(\"list.trace\").",
       "title": "Filters"
     },
     "name": {

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -100,6 +100,20 @@
       "title": "Size",
       "type": "integer"
     },
+    "sort": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Sort for trace, span, thread, experiment: '<field> [asc|desc]', desc by default. E.g. 'duration desc', 'total_estimated_cost', 'feedback_scores.accuracy asc', 'usage.total_tokens'. One field only.",
+      "title": "Sort"
+    },
     "test_suite_id": {
       "anyOf": [
         {

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -27,7 +27,7 @@
         }
       ],
       "default": null,
-      "description": "OQL filter for trace, span, thread, experiment: <field>[.<key>] <op> <value> [AND ...]; ops = != > >= < <= contains not_contains starts_with ends_with is_empty is_not_empty in not_in; strings quoted, numbers bare (duration in ms). E.g. 'error_info is_not_empty AND duration > 5000', 'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. Reference: schema(\"list.trace\").",
+      "description": "OQL filter for trace, span, thread, experiment: <field>[.<key>] <op> <value> [AND ...]; ops = != > >= < <= contains not_contains starts_with ends_with is_empty is_not_empty in not_in; strings quoted, numbers bare (duration in ms). E.g. 'error_info is_not_empty AND duration > 5000', 'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. trace/span/thread default to source = \"sdk\". Reference: schema(\"list.trace\").",
       "title": "Filters"
     },
     "name": {

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -92,6 +92,34 @@
       "description": "Required when listing prompt_versions. UUID of the prompt.",
       "title": "Prompt Id"
     },
+    "search": {
+      "anyOf": [
+        {
+          "maxLength": 500,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Free text for trace, span, thread: matches anywhere in id, name, input, output, metadata, tags, thread_id (spans: model, provider too).",
+      "title": "Search"
+    },
+    "since": {
+      "anyOf": [
+        {
+          "maxLength": 40,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Start of the time window for trace, span, thread: a relative span ('30m', '1h', '24h', '7d') or an ISO-8601 instant with timezone. Windows are by record creation time; for an exact start_time bound use filters.",
+      "title": "Since"
+    },
     "size": {
       "default": 25,
       "description": "Items per page. Capped at 100.",
@@ -126,6 +154,20 @@
       "default": null,
       "description": "Required when listing test_suite_items. UUID of the suite.",
       "title": "Test Suite Id"
+    },
+    "until": {
+      "anyOf": [
+        {
+          "maxLength": 40,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "End of the time window, same forms as since.",
+      "title": "Until"
     }
   },
   "required": [

--- a/tests/conformance/snapshots/list.json
+++ b/tests/conformance/snapshots/list.json
@@ -15,6 +15,20 @@
       "title": "Entity Type",
       "type": "string"
     },
+    "filters": {
+      "anyOf": [
+        {
+          "maxLength": 2000,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "OQL filter for trace, span, thread, experiment. <field>[.<key>] <op> <value> [AND ...]; ops: = != > >= < <= contains not_contains starts_with ends_with is_empty is_not_empty in not_in. Strings in double quotes, numbers bare, duration in ms. E.g. 'error_info is_not_empty AND duration > 5000' or 'feedback_scores.accuracy < 0.5 AND start_time >= \"2026-09-08T00:00:00Z\"'. trace/span/thread add source = \"sdk\" unless you name source. Field reference: schema(\"list.trace\").",
+      "title": "Filters"
+    },
     "name": {
       "anyOf": [
         {

--- a/tests/conformance/snapshots/schema.json
+++ b/tests/conformance/snapshots/schema.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "operation": {
-      "description": "Operation whose schema to return.",
+      "description": "Write operation whose schema to return, or list.<entity> (list.trace, list.span, list.thread, list.experiment) for the filter and sort reference of the list tool.",
       "enum": [
         "trace.create",
         "trace.update",
@@ -14,7 +14,11 @@
         "experiment.create",
         "experiment_item.create",
         "thread.close",
-        "thread.open"
+        "thread.open",
+        "list.trace",
+        "list.span",
+        "list.thread",
+        "list.experiment"
       ],
       "title": "Operation",
       "type": "string"

--- a/tests/test_analytics_privacy.py
+++ b/tests/test_analytics_privacy.py
@@ -283,6 +283,95 @@ async def test_list_props_emits_had_name_filter_false_when_absent(
     assert props["had_name_filter"] == "false"
 
 
+@pytest.mark.anyio
+async def test_list_props_record_the_search_shape_without_values(
+    recorder: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Filter field names, sort field, window and search are shape signals;
+    filter values, search text and metadata/score keys never leave the process."""
+    from opik_mcp import server
+
+    monkeypatch.setattr(
+        "opik_mcp.server.run_list",
+        lambda **_kw: _noop_coroutine("[list: trace | filters: …]\n"),
+    )
+
+    await server.list_entities(
+        entity_type="trace",
+        project_name=FORBIDDEN[4],
+        filters=(
+            f'metadata."{FORBIDDEN[0]}" = "{FORBIDDEN[1]}" AND feedback_scores.'
+            f'"{FORBIDDEN[2]}" < 1 AND duration > 5000 AND tags contains "{FORBIDDEN[3]}"'
+        ),
+        sort=f"feedback_scores.{FORBIDDEN[5]} desc",
+        since="1h",
+        search=FORBIDDEN[6],
+    )
+    _assert_no_leak(recorder.events)
+    props = _tool_called(recorder.events)
+    assert props["has_filters"] == "true"
+    assert props["filter_fields"] == "duration,feedback_scores,metadata,tags"
+    assert props["has_sort"] == "true"
+    assert props["sort_field"] == "feedback_scores.*"
+    assert props["has_window"] == "true"
+    assert props["has_search"] == "true"
+
+
+@pytest.mark.anyio
+async def test_list_props_shape_signals_are_false_on_a_bare_call(
+    recorder: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from opik_mcp import server
+
+    monkeypatch.setattr(
+        "opik_mcp.server.run_list",
+        lambda **_kw: _noop_coroutine("[list: trace | filters: …]\n"),
+    )
+    await server.list_entities(entity_type="trace", project_id="p-1")
+    props = _tool_called(recorder.events)
+    assert props["has_filters"] == "false"
+    assert props["filter_fields"] == ""
+    assert props["has_sort"] == "false"
+    assert props["sort_field"] == ""
+    assert props["has_window"] == "false"
+    assert props["has_search"] == "false"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_cause"),
+    [
+        # A field name must be a bare word; the canary is made one so the
+        # failure is the *unknown field* path, not a syntax error on '-'.
+        ({"filters": f"{FORBIDDEN[0].replace('-', '_')} > 5"}, "OQLUnknownFieldError"),
+        ({"filters": f"name = {FORBIDDEN[1]}"}, "OQLSyntaxError"),
+        ({"filters": f'error_info = "{FORBIDDEN[2]}"'}, "OQLBadOperatorError"),
+        ({"filters": f'start_time > "{FORBIDDEN[3]}"'}, "OQLBadValueError"),
+        ({"sort": FORBIDDEN[5]}, "SortError"),
+        ({"since": FORBIDDEN[6]}, "WindowError"),
+    ],
+)
+@pytest.mark.anyio
+async def test_list_validation_failures_record_their_class_and_nothing_else(
+    recorder: _Recorder, kwargs: dict[str, str], expected_cause: str
+) -> None:
+    """A rejected filter/sort/window is bucketed by exception class only — the
+    offending string (which may carry customer data) never reaches analytics."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    from opik_mcp import server
+
+    with pytest.raises(ToolError):
+        await server.list_entities(entity_type="trace", project_id="p-1", **kwargs)
+    _assert_no_leak(recorder.events)
+    payload = json.dumps(recorder.events)
+    for value in kwargs.values():
+        assert value not in payload, f"PRIVACY BREACH: {value!r} leaked into analytics"
+    props = _tool_called(recorder.events)
+    assert props["success"] == "false"
+    assert props["error_kind"] == "validation"
+    assert props["cause_type"] == expected_cause
+
+
 # --- failure paths: error_kind / exception_type / http_status MUST be bucketed -- #
 #
 # When a tool raises, the wrapper emits ``error_kind`` + ``exception_type`` (+

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -116,6 +116,17 @@ def test_render_mentions_tool_selection_guidance() -> None:
     assert "read_skill" in out
 
 
+def test_render_tells_the_agent_list_can_filter_sort_and_window() -> None:
+    """Hosts that inject instructions but lazy-load tool schemas would otherwise
+    leave the agent paging through traces and sorting in its head."""
+    out = render_instructions(_settings())
+    assert "filters" in out and "OQL" in out
+    assert "sort" in out and "since" in out and "search" in out
+    assert 'since="1h"' in out and 'sort="duration desc"' in out
+    assert 'schema("list.trace")' in out
+    assert "optional name filter, page, size" not in out
+
+
 # --- the blob must describe only what this connection advertises ---------- #
 
 

--- a/tests/test_opik_client_search.py
+++ b/tests/test_opik_client_search.py
@@ -1,0 +1,90 @@
+"""Search-parameter coverage for the four searchable list endpoints.
+
+The ``list`` tool's filter / sort / window / search surface rides these query
+params. Each client method must forward a param only when set — the backend
+treats an empty ``filters=`` as malformed JSON and 400s — and ``list_spans``
+must work project-wide, without a ``trace_id``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from opik_mcp.opik_client import OpikClient
+
+OPIK_BASE = "https://opik.test"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _client() -> OpikClient:
+    return OpikClient(base_url=OPIK_BASE, api_key="key-abc", workspace="ws")
+
+
+def _page(items: list[dict[str, Any]], total: int | None = None) -> dict[str, Any]:
+    return {
+        "content": items,
+        "page": 1,
+        "size": len(items),
+        "total": total if total is not None else len(items),
+    }
+
+
+_SEARCH_PARAMS: dict[str, Any] = {
+    "filters": '[{"field":"error_info","operator":"is_not_empty","key":"","value":""}]',
+    "sorting": '[{"field":"duration","direction":"DESC"}]',
+    "search": "order-42",
+    "from_time": "2026-09-08T00:00:00Z",
+    "to_time": "2026-09-08T12:00:00Z",
+    "truncate": True,
+}
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "scope"),
+    [
+        ("list_traces", "/v1/private/traces", {"project_id": "p-1"}),
+        ("list_spans", "/v1/private/spans", {"project_id": "p-1"}),
+        ("list_threads", "/v1/private/traces/threads", {"project_id": "p-1"}),
+        ("list_experiments", "/v1/private/experiments", {}),
+    ],
+)
+@pytest.mark.anyio
+async def test_list_forwards_search_params_only_when_set(
+    method: str, path: str, scope: dict[str, str]
+) -> None:
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get(path).mock(return_value=httpx.Response(200, json=_page([])))
+        await getattr(_client(), method)(**scope)
+        bare = dict(route.calls.last.request.url.params)
+        for key in _SEARCH_PARAMS:
+            assert key not in bare, f"{method} sent {key} without being asked"
+
+        await getattr(_client(), method)(**scope, **_SEARCH_PARAMS)
+    params = dict(route.calls.last.request.url.params)
+    assert params["filters"] == _SEARCH_PARAMS["filters"]
+    assert params["sorting"] == _SEARCH_PARAMS["sorting"]
+    assert params["search"] == "order-42"
+    assert params["from_time"] == "2026-09-08T00:00:00Z"
+    assert params["to_time"] == "2026-09-08T12:00:00Z"
+    assert params["truncate"] == "true"
+
+
+@pytest.mark.anyio
+async def test_list_spans_across_a_project_without_trace_id() -> None:
+    """Project-wide span search: ``trace_id`` is optional on ``GET /spans``."""
+    with respx.mock(base_url=OPIK_BASE) as mock:
+        route = mock.get("/v1/private/spans").mock(
+            return_value=httpx.Response(200, json=_page([{"id": "sp-1"}], total=1)),
+        )
+        body = await _client().list_spans(project_name="demo", page=2, size=50)
+    params = dict(route.calls.last.request.url.params)
+    assert params == {"project_name": "demo", "page": "2", "size": "50"}
+    assert body["content"][0]["id"] == "sp-1"

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -175,3 +175,61 @@ async def test_trace_rows_carry_triage_columns_by_default() -> None:
     assert "id | name | start_time | duration | error_type | total_estimated_cost" in out
     assert "t-1 | chat | 2026-09-08T10:00:00Z | 7123.5 | TimeoutError | 0.0042" in out
     assert "t-2 | chat |  | 120 |  | " in out
+
+
+# --- span: project-wide search --------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_span_list_requires_project_scope() -> None:
+    with pytest.raises(ToolError, match=r"list\('span'\) requires project_id \(or project_name\)"):
+        await run_list("span", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_span_filters_search_the_whole_project() -> None:
+    fake = FakeOpikClient()
+    await run_list(
+        "span",
+        project_name="demo",
+        filters='type = "llm" AND usage.total_tokens > 10000',
+        client=fake,
+    )
+    assert fake.last_kwargs.get("project_name") == "demo"
+    assert "trace_id" not in fake.last_kwargs
+    assert _sent_filters(fake) == [
+        {"field": "type", "operator": "=", "key": "", "value": "llm"},
+        {"field": "usage.total_tokens", "operator": ">", "key": "", "value": "10000"},
+        SDK_SOURCE,
+    ]
+
+
+@pytest.mark.anyio
+async def test_span_rejects_trace_only_fields_with_the_span_field_list() -> None:
+    with pytest.raises(ToolError) as ei:
+        await run_list("span", project_id="p-1", filters='thread_id = "t"', client=FakeOpikClient())
+    message = str(ei.value)
+    assert "Unknown field 'thread_id'" in message
+    assert "provider" in message and "llm_span_count" not in message
+
+
+@pytest.mark.anyio
+async def test_span_rows_carry_span_columns_by_default() -> None:
+    fake = FakeOpikClient(
+        spans=_page(
+            [
+                {
+                    "id": "s-1",
+                    "name": "openai.chat",
+                    "type": "llm",
+                    "trace_id": "t-1",
+                    "duration": 812.0,
+                    "model": "gpt-4o",
+                    "error_info": {"exception_type": "RateLimitError"},
+                }
+            ]
+        )
+    )
+    out = await run_list("span", project_id="p-1", client=fake)
+    assert "id | name | type | trace_id | duration | model | error_type" in out
+    assert "s-1 | openai.chat | llm | t-1 | 812.0 | gpt-4o | RateLimitError" in out

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -151,6 +151,36 @@ async def test_filters_on_an_unsupported_type_name_the_supported_ones() -> None:
         await run_list("project", filters='name = "x"', client=FakeOpikClient())
 
 
+@pytest.mark.anyio
+async def test_empty_filters_on_an_unsupported_type_is_the_same_as_none() -> None:
+    fake = FakeOpikClient(projects=_page([{"id": "p-1", "name": "demo"}]))
+    out = await run_list("project", filters="", client=fake)
+    assert "filters" not in fake.last_kwargs
+    assert "truncate" not in fake.last_kwargs
+    assert out.startswith("Found 1 projects")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("query", "fragment"),
+    [
+        ("duration > five", "Syntax error at position"),
+        ("metadata.env >= 5", "'>=' is not valid for 'metadata' (dictionary)"),
+        ('start_time > "yesterday"', "ISO-8601 instant with a timezone"),
+        ('durration > 5 AND error_info = "x"', "2. Operator '='"),
+    ],
+)
+async def test_every_error_class_reaches_the_agent_through_the_tool(
+    query: str, fragment: str
+) -> None:
+    with pytest.raises(ToolError) as ei:
+        await run_list("trace", project_id="p-1", filters=query, client=FakeOpikClient())
+    message = str(ei.value)
+    assert message.startswith("Invalid filters for trace:")
+    assert fragment in message
+    assert 'schema("list.trace")' in message
+
+
 # --- default columns ----------------------------------------------------- #
 
 
@@ -295,6 +325,29 @@ async def test_until_before_since_is_rejected_locally() -> None:
 
 
 @pytest.mark.anyio
+async def test_window_order_is_checked_on_instants_not_strings() -> None:
+    """A sub-second ``until`` sorts before ``since`` as text ('.' < 'Z') but is
+    later in time; the bounds must be compared as instants."""
+    fake = FakeOpikClient()
+    await run_list(
+        "trace",
+        project_id="p-1",
+        since="2026-09-08T10:00:00Z",
+        until="2026-09-08T10:00:00.500Z",
+        client=fake,
+    )
+    assert fake.last_kwargs["to_time"] == "2026-09-08T10:00:00.500Z"
+
+
+@pytest.mark.anyio
+async def test_space_separated_date_is_rejected_before_the_backend_would() -> None:
+    with pytest.raises(ToolError, match="Invalid since"):
+        await run_list(
+            "trace", project_id="p-1", since="2026-09-08 10:00:00Z", client=FakeOpikClient()
+        )
+
+
+@pytest.mark.anyio
 async def test_window_on_experiment_is_rejected_with_a_clear_message() -> None:
     with pytest.raises(ToolError, match="experiments have no time window"):
         await run_list("experiment", since="1h", client=FakeOpikClient())
@@ -387,6 +440,24 @@ async def test_header_echoes_the_sort_and_flags_a_dropped_one() -> None:
     out = await run_list("trace", project_id="p-1", sort="duration", client=dropped)
     assert (
         "sort: duration desc (dropped by the backend for this workspace size" in out.splitlines()[0]
+    )
+
+
+@pytest.mark.anyio
+async def test_header_lists_filters_sort_window_search_in_that_order() -> None:
+    fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
+    out = await run_list(
+        "trace",
+        project_id="p-1",
+        filters="duration > 5000",
+        sort="duration",
+        since="2026-09-08T00:00:00Z",
+        search="order-42",
+        client=fake,
+    )
+    assert out.splitlines()[0] == (
+        '[list: trace | filters: duration > 5000 AND source = "sdk" | sort: duration desc'
+        ' | since: 2026-09-08T00:00:00Z | search: "order-42"]'
     )
 
 

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -390,6 +390,91 @@ async def test_header_echoes_the_sort_and_flags_a_dropped_one() -> None:
     )
 
 
+# --- columns follow the sort and filters ------------------------------------ #
+
+
+@pytest.mark.anyio
+async def test_sort_field_becomes_a_column_resolved_from_the_usage_map() -> None:
+    fake = FakeOpikClient(
+        traces=_page(
+            [
+                {
+                    "id": "t-1",
+                    "name": "chat",
+                    "usage": {"total_tokens": 4321, "prompt_tokens": 4000},
+                },
+                {"id": "t-2", "name": "chat"},
+            ]
+        )
+    )
+    out = await run_list("trace", project_id="p-1", sort="usage.total_tokens", client=fake)
+    header = out.splitlines()[3]
+    assert header == (
+        "id | name | start_time | duration | error_type | total_estimated_cost | usage.total_tokens"
+    )
+    assert "t-1 | chat |  |  |  |  | 4321" in out
+    assert "t-2 | chat |  |  |  |  | " in out
+
+
+@pytest.mark.anyio
+async def test_filter_fields_become_columns_deduplicated_and_in_order() -> None:
+    fake = FakeOpikClient(
+        traces=_page(
+            [
+                {
+                    "id": "t-1",
+                    "name": "chat",
+                    "duration": 9000,
+                    "tags": ["prod", "beta"],
+                    "metadata": {"environment": "staging", "region": "eu"},
+                    "feedback_scores": [{"name": "accuracy", "value": 0.42}],
+                }
+            ]
+        )
+    )
+    out = await run_list(
+        "trace",
+        project_id="p-1",
+        filters=(
+            'duration > 5000 AND tags contains "prod" AND metadata.environment = "staging" '
+            "AND feedback_scores.accuracy < 0.5 AND tags is_not_empty"
+        ),
+        sort="feedback_scores.accuracy asc",
+        client=fake,
+    )
+    header = out.splitlines()[3]
+    assert header == (
+        "id | name | start_time | duration | error_type | total_estimated_cost"
+        " | feedback_scores.accuracy | tags | metadata.environment"
+    )
+    assert "t-1 | chat |  | 9000 |  |  | 0.42 | ['prod', 'beta'] | staging" in out
+
+
+@pytest.mark.anyio
+async def test_body_and_source_fields_are_never_appended_as_columns() -> None:
+    fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
+    out = await run_list(
+        "trace",
+        project_id="p-1",
+        filters='input contains "hello" AND error_info is_not_empty AND source = "evaluator"',
+        client=fake,
+    )
+    header = out.splitlines()[3]
+    assert header == "id | name | start_time | duration | error_type | total_estimated_cost"
+
+
+@pytest.mark.anyio
+async def test_dynamic_columns_still_truncate_long_values() -> None:
+    fake = FakeOpikClient(
+        spans=_page([{"id": "s-1", "name": "llm", "metadata": {"prompt": "x" * 200}}])
+    )
+    out = await run_list(
+        "span", project_id="p-1", filters='metadata.prompt contains "x"', client=fake
+    )
+    assert "x" * 57 + "..." in out
+    assert "x" * 58 not in out
+
+
 # --- thread / experiment ---------------------------------------------------- #
 
 

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -1,0 +1,177 @@
+"""``list`` tool — filters, sort, time window and search (OPIK-8283).
+
+Everything here is observed through ``run_list`` with a fake client: the
+arguments that reach the backend, the table text, and the error text.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from opik_mcp.read_list.list_tool import run_list
+from opik_mcp.read_list.oql import OQLError
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _page(items: list[dict[str, Any]], **extra: Any) -> dict[str, Any]:
+    return {"content": items, "page": 1, "size": len(items), "total": len(items), **extra}
+
+
+@dataclass
+class FakeOpikClient:
+    """Captures the kwargs each searchable list endpoint receives."""
+
+    traces: dict[str, Any] = field(default_factory=lambda: _page([]))
+    spans: dict[str, Any] = field(default_factory=lambda: _page([]))
+    threads: dict[str, Any] = field(default_factory=lambda: _page([]))
+    experiments: dict[str, Any] = field(default_factory=lambda: _page([]))
+    projects: dict[str, Any] = field(default_factory=lambda: _page([]))
+    last_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    async def list_traces(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.traces
+
+    async def list_spans(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.spans
+
+    async def list_threads(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.threads
+
+    async def list_experiments(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.experiments
+
+    async def list_projects(self, **kw: Any) -> dict[str, Any]:
+        self.last_kwargs = kw
+        return self.projects
+
+    async def list_prompts(self, **kw: Any) -> dict[str, Any]:
+        return _page([])
+
+    async def list_test_suites(self, **kw: Any) -> dict[str, Any]:
+        return _page([])
+
+    async def list_test_suite_items(self, test_suite_id: str, **kw: Any) -> dict[str, Any]:
+        return _page([])
+
+    async def list_prompt_versions(self, prompt_id: str, **kw: Any) -> dict[str, Any]:
+        return _page([])
+
+
+def _sent_filters(fake: FakeOpikClient) -> list[dict[str, str]]:
+    raw = fake.last_kwargs.get("filters")
+    assert isinstance(raw, str), f"filters not sent as a JSON string: {fake.last_kwargs!r}"
+    parsed: list[dict[str, str]] = json.loads(raw)
+    return parsed
+
+
+SDK_SOURCE = {"field": "source", "operator": "=", "key": "", "value": "sdk"}
+
+
+# --- filters reach the backend ------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_trace_filters_compile_to_the_backend_array_plus_sdk_source() -> None:
+    fake = FakeOpikClient()
+    await run_list(
+        "trace",
+        project_name="demo",
+        filters="error_info is_not_empty AND duration > 5000",
+        client=fake,
+    )
+    assert _sent_filters(fake) == [
+        {"field": "error_info", "operator": "is_not_empty", "key": "", "value": ""},
+        {"field": "duration", "operator": ">", "key": "", "value": "5000"},
+        SDK_SOURCE,
+    ]
+
+
+@pytest.mark.anyio
+async def test_trace_list_without_filters_still_hides_non_sdk_sources() -> None:
+    """Mirrors the UI's Logs page: evaluator/playground/experiment traces are
+    not application traffic and would otherwise dominate a triage list."""
+    fake = FakeOpikClient()
+    await run_list("trace", project_id="p-1", client=fake)
+    assert _sent_filters(fake) == [SDK_SOURCE]
+    assert fake.last_kwargs.get("truncate") is True
+
+
+@pytest.mark.anyio
+async def test_naming_source_disables_the_default() -> None:
+    fake = FakeOpikClient()
+    await run_list("trace", project_id="p-1", filters='source = "evaluator"', client=fake)
+    assert _sent_filters(fake) == [
+        {"field": "source", "operator": "=", "key": "", "value": "evaluator"}
+    ]
+
+
+@pytest.mark.anyio
+async def test_header_echoes_the_applied_filter_including_the_default() -> None:
+    fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
+    out = await run_list("trace", project_id="p-1", filters="duration > 5000", client=fake)
+    first_line = out.splitlines()[0]
+    assert first_line == '[list: trace | filters: duration > 5000 AND source = "sdk"]'
+
+
+@pytest.mark.anyio
+async def test_header_shows_the_default_source_alone_when_nothing_was_asked() -> None:
+    fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
+    out = await run_list("trace", project_id="p-1", client=fake)
+    assert out.splitlines()[0] == '[list: trace | filters: source = "sdk"]'
+
+
+# --- errors -------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_invalid_filters_surface_the_self_healing_message() -> None:
+    with pytest.raises(ToolError) as ei:
+        await run_list("trace", project_id="p-1", filters="durration > 5", client=FakeOpikClient())
+    assert "Did you mean 'duration'?" in str(ei.value)
+    assert isinstance(ei.value.__cause__, OQLError)
+
+
+@pytest.mark.anyio
+async def test_filters_on_an_unsupported_type_name_the_supported_ones() -> None:
+    with pytest.raises(ToolError, match="Filterable types: trace, span, thread, experiment"):
+        await run_list("project", filters='name = "x"', client=FakeOpikClient())
+
+
+# --- default columns ----------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_trace_rows_carry_triage_columns_by_default() -> None:
+    fake = FakeOpikClient(
+        traces=_page(
+            [
+                {
+                    "id": "t-1",
+                    "name": "chat",
+                    "start_time": "2026-09-08T10:00:00Z",
+                    "end_time": "2026-09-08T10:00:07Z",
+                    "duration": 7123.5,
+                    "total_estimated_cost": 0.0042,
+                    "error_info": {"exception_type": "TimeoutError", "message": "upstream"},
+                },
+                {"id": "t-2", "name": "chat", "duration": 120},
+            ]
+        )
+    )
+    out = await run_list("trace", project_id="p-1", client=fake)
+    assert "id | name | start_time | duration | error_type | total_estimated_cost" in out
+    assert "t-1 | chat | 2026-09-08T10:00:00Z | 7123.5 | TimeoutError | 0.0042" in out
+    assert "t-2 | chat |  | 120 |  | " in out

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -233,6 +234,93 @@ async def test_span_rows_carry_span_columns_by_default() -> None:
     out = await run_list("span", project_id="p-1", client=fake)
     assert "id | name | type | trace_id | duration | model | error_type" in out
     assert "s-1 | openai.chat | llm | t-1 | 812.0 | gpt-4o | RateLimitError" in out
+
+
+# --- since / until window, search ------------------------------------------- #
+
+
+def _instant(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(("shorthand", "delta"), [("1h", 3600), ("30m", 1800), ("7d", 7 * 86400)])
+async def test_relative_since_resolves_against_now(shorthand: str, delta: int) -> None:
+    fake = FakeOpikClient()
+    before = datetime.now(UTC)
+    await run_list("trace", project_id="p-1", since=shorthand, client=fake)
+    sent = fake.last_kwargs["from_time"]
+    assert sent.endswith("Z")
+    assert abs((before - _instant(sent)).total_seconds() - delta) < 5
+    assert "to_time" not in fake.last_kwargs
+
+
+@pytest.mark.anyio
+async def test_iso_window_passes_through_and_is_echoed() -> None:
+    fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
+    out = await run_list(
+        "trace",
+        project_id="p-1",
+        since="2026-09-08T00:00:00Z",
+        until="2026-09-08T12:00:00+00:00",
+        client=fake,
+    )
+    assert fake.last_kwargs["from_time"] == "2026-09-08T00:00:00Z"
+    assert fake.last_kwargs["to_time"] == "2026-09-08T12:00:00Z"
+    assert out.splitlines()[0] == (
+        '[list: trace | filters: source = "sdk" | since: 2026-09-08T00:00:00Z'
+        " | until: 2026-09-08T12:00:00Z]"
+    )
+
+
+@pytest.mark.anyio
+async def test_malformed_window_value_names_both_accepted_forms() -> None:
+    with pytest.raises(ToolError) as ei:
+        await run_list("trace", project_id="p-1", since="yesterday", client=FakeOpikClient())
+    message = str(ei.value)
+    assert "since" in message and "'yesterday'" in message
+    assert "1h" in message and "2026-09-08T10:00:00Z" in message
+
+
+@pytest.mark.anyio
+async def test_until_before_since_is_rejected_locally() -> None:
+    with pytest.raises(ToolError, match=r"until .* is before since"):
+        await run_list(
+            "trace",
+            project_id="p-1",
+            since="2026-09-08T12:00:00Z",
+            until="2026-09-08T00:00:00Z",
+            client=FakeOpikClient(),
+        )
+
+
+@pytest.mark.anyio
+async def test_window_on_experiment_is_rejected_with_a_clear_message() -> None:
+    with pytest.raises(ToolError, match="experiments have no time window"):
+        await run_list("experiment", since="1h", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_window_on_thread_is_forwarded() -> None:
+    fake = FakeOpikClient()
+    await run_list("thread", project_id="p-1", since="2026-09-08T00:00:00Z", client=fake)
+    assert fake.last_kwargs["from_time"] == "2026-09-08T00:00:00Z"
+
+
+@pytest.mark.anyio
+async def test_search_is_forwarded_for_spans_and_echoed() -> None:
+    fake = FakeOpikClient(spans=_page([{"id": "s-1", "name": "tool"}]))
+    out = await run_list("span", project_id="p-1", search="order-42", client=fake)
+    assert fake.last_kwargs["search"] == "order-42"
+    assert out.splitlines()[0] == '[list: span | filters: source = "sdk" | search: "order-42"]'
+
+
+@pytest.mark.anyio
+async def test_search_on_a_type_without_it_is_dropped_with_a_note() -> None:
+    fake = FakeOpikClient(projects=_page([{"id": "p-1", "name": "demo"}]))
+    out = await run_list("project", search="demo", client=fake)
+    assert "search" not in fake.last_kwargs
+    assert out.splitlines()[0] == "[list: project | search ignored (only trace, span, thread)]"
 
 
 # --- sort ------------------------------------------------------------------ #

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -235,6 +235,73 @@ async def test_span_rows_carry_span_columns_by_default() -> None:
     assert "s-1 | openai.chat | llm | t-1 | 812.0 | gpt-4o | RateLimitError" in out
 
 
+# --- sort ------------------------------------------------------------------ #
+
+
+@pytest.mark.anyio
+async def test_sort_reaches_the_backend_as_one_sorting_field() -> None:
+    fake = FakeOpikClient()
+    await run_list("trace", project_id="p-1", sort="duration desc", client=fake)
+    assert json.loads(fake.last_kwargs["sorting"]) == [{"field": "duration", "direction": "DESC"}]
+
+
+@pytest.mark.anyio
+async def test_sort_direction_defaults_to_desc_and_is_case_insensitive() -> None:
+    fake = FakeOpikClient()
+    await run_list("trace", project_id="p-1", sort="total_estimated_cost", client=fake)
+    assert json.loads(fake.last_kwargs["sorting"])[0]["direction"] == "DESC"
+    await run_list("trace", project_id="p-1", sort="start_time ASC", client=fake)
+    assert json.loads(fake.last_kwargs["sorting"])[0]["direction"] == "ASC"
+
+
+@pytest.mark.anyio
+async def test_sort_accepts_dynamic_score_and_usage_fields() -> None:
+    fake = FakeOpikClient()
+    await run_list("trace", project_id="p-1", sort="feedback_scores.accuracy asc", client=fake)
+    assert json.loads(fake.last_kwargs["sorting"]) == [
+        {"field": "feedback_scores.accuracy", "direction": "ASC"}
+    ]
+    await run_list("span", project_id="p-1", sort="usage.total_tokens", client=fake)
+    assert json.loads(fake.last_kwargs["sorting"])[0]["field"] == "usage.total_tokens"
+
+
+@pytest.mark.anyio
+async def test_sort_on_an_unsupported_field_lists_the_sortable_ones() -> None:
+    with pytest.raises(ToolError) as ei:
+        await run_list("trace", project_id="p-1", sort="error_type", client=FakeOpikClient())
+    message = str(ei.value)
+    assert "'error_type' is not sortable for trace" in message
+    assert "Sortable: " in message
+    assert "duration" in message and "feedback_scores.<name>" in message
+
+
+@pytest.mark.anyio
+async def test_sort_with_a_bad_direction_names_the_accepted_forms() -> None:
+    with pytest.raises(ToolError, match=r"<field> \[asc\|desc\]"):
+        await run_list("trace", project_id="p-1", sort="duration sideways", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_sort_on_an_unsupported_type_names_the_supported_ones() -> None:
+    with pytest.raises(ToolError, match="Sortable types: trace, span, thread, experiment"):
+        await run_list("project", sort="name", client=FakeOpikClient())
+
+
+@pytest.mark.anyio
+async def test_header_echoes_the_sort_and_flags_a_dropped_one() -> None:
+    honoured = FakeOpikClient(
+        traces=_page([{"id": "t-1", "name": "chat"}], sortable_by=["duration", "start_time"])
+    )
+    out = await run_list("trace", project_id="p-1", sort="duration", client=honoured)
+    assert out.splitlines()[0] == '[list: trace | filters: source = "sdk" | sort: duration desc]'
+
+    dropped = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}], sortable_by=[]))
+    out = await run_list("trace", project_id="p-1", sort="duration", client=dropped)
+    assert (
+        "sort: duration desc (dropped by the backend for this workspace size" in out.splitlines()[0]
+    )
+
+
 # --- thread / experiment ---------------------------------------------------- #
 
 

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
@@ -120,6 +121,35 @@ async def test_naming_source_disables_the_default() -> None:
 
 
 @pytest.mark.anyio
+async def test_empty_result_under_the_default_source_says_how_to_widen_it() -> None:
+    """Seen live: a project holding only experiment traces answers 'No traces
+    found' under the sdk default. The agent needs to learn why in that reply."""
+    out = await run_list("trace", project_id="p-1", client=FakeOpikClient())
+    assert out.splitlines()[0] == '[list: trace | filters: source = "sdk"]'
+    assert "No traces found." in out
+    assert 'source = "experiment"' in out and "evaluator" in out and "playground" in out
+
+
+@pytest.mark.anyio
+async def test_empty_result_with_an_explicit_source_carries_no_hint() -> None:
+    out = await run_list(
+        "trace", project_id="p-1", filters='source = "evaluator"', client=FakeOpikClient()
+    )
+    assert "No traces found." in out
+    assert "playground" not in out
+
+
+@pytest.mark.anyio
+async def test_empty_result_under_the_agents_own_constraints_carries_no_hint() -> None:
+    """With a window or filters of the agent's own, those are the likelier
+    reason for an empty page; the source hint would point the wrong way."""
+    out = await run_list("trace", project_id="p-1", since="30d", client=FakeOpikClient())
+    assert "No traces found." in out and "playground" not in out
+    out = await run_list("trace", project_id="p-1", filters="duration > 5", client=FakeOpikClient())
+    assert "No traces found." in out and "playground" not in out
+
+
+@pytest.mark.anyio
 async def test_header_echoes_the_applied_filter_including_the_default() -> None:
     fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
     out = await run_list("trace", project_id="p-1", filters="duration > 5000", client=fake)
@@ -179,6 +209,35 @@ async def test_every_error_class_reaches_the_agent_through_the_tool(
     assert message.startswith("Invalid filters for trace:")
     assert fragment in message
     assert 'schema("list.trace")' in message
+
+
+@pytest.mark.anyio
+async def test_backend_timeout_is_reported_with_a_way_out() -> None:
+    """``httpx.ReadTimeout`` stringifies to '' — seen live when a free-text
+    search took longer than the client timeout. The agent must get a message
+    that says what happened and how to narrow the query."""
+
+    class TimingOut(FakeOpikClient):
+        async def list_traces(self, **kw: Any) -> dict[str, Any]:
+            raise httpx.ReadTimeout("")
+
+    with pytest.raises(ToolError) as ei:
+        await run_list("trace", project_id="p-1", search="order-42", client=TimingOut())
+    message = str(ei.value)
+    assert "did not answer in time" in message
+    assert "list(trace" in message
+    assert "since" in message and "size" in message
+    assert isinstance(ei.value.__cause__, httpx.ReadTimeout)
+
+
+@pytest.mark.anyio
+async def test_backend_unreachable_is_reported_with_the_reason() -> None:
+    class Unreachable(FakeOpikClient):
+        async def list_traces(self, **kw: Any) -> dict[str, Any]:
+            raise httpx.ConnectError("nodename nor servname provided")
+
+    with pytest.raises(ToolError, match=r"Could not reach Opik.*nodename nor servname"):
+        await run_list("trace", project_id="p-1", client=Unreachable())
 
 
 # --- default columns ----------------------------------------------------- #

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -233,3 +233,106 @@ async def test_span_rows_carry_span_columns_by_default() -> None:
     out = await run_list("span", project_id="p-1", client=fake)
     assert "id | name | type | trace_id | duration | model | error_type" in out
     assert "s-1 | openai.chat | llm | t-1 | 812.0 | gpt-4o | RateLimitError" in out
+
+
+# --- thread / experiment ---------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_thread_filters_reach_the_backend_with_the_sdk_default() -> None:
+    fake = FakeOpikClient()
+    await run_list(
+        "thread",
+        project_name="demo",
+        filters=(
+            'status = "active" AND number_of_messages > 20 AND feedback_scores.helpfulness < 0.5'
+        ),
+        client=fake,
+    )
+    assert _sent_filters(fake) == [
+        {"field": "status", "operator": "=", "key": "", "value": "active"},
+        {"field": "number_of_messages", "operator": ">", "key": "", "value": "20"},
+        {"field": "feedback_scores", "operator": "<", "key": "helpfulness", "value": "0.5"},
+        SDK_SOURCE,
+    ]
+
+
+@pytest.mark.anyio
+async def test_experiment_filters_reach_the_backend_without_a_source_default() -> None:
+    fake = FakeOpikClient()
+    await run_list(
+        "experiment",
+        name="rerank",
+        filters='dataset_id = "ds-1" AND tags contains "baseline"',
+        client=fake,
+    )
+    assert fake.last_kwargs.get("name") == "rerank"
+    assert _sent_filters(fake) == [
+        {"field": "dataset_id", "operator": "=", "key": "", "value": "ds-1"},
+        {"field": "tags", "operator": "contains", "key": "", "value": "baseline"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_experiment_list_without_filters_sends_none() -> None:
+    fake = FakeOpikClient()
+    out = await run_list("experiment", client=fake)
+    assert "filters" not in fake.last_kwargs
+    assert not out.startswith("[list:")
+
+
+@pytest.mark.anyio
+async def test_thread_and_experiment_unknown_fields_list_their_own_fields() -> None:
+    with pytest.raises(ToolError) as ei:
+        await run_list("thread", project_id="p-1", filters='model = "x"', client=FakeOpikClient())
+    assert "first_message" in str(ei.value) and "model" in str(ei.value)
+
+    with pytest.raises(ToolError) as ei:
+        await run_list("experiment", filters="duration > 5", client=FakeOpikClient())
+    assert "experiment_scores" in str(ei.value) and "Unknown field 'duration'" in str(ei.value)
+
+
+@pytest.mark.anyio
+async def test_thread_rows_carry_duration() -> None:
+    fake = FakeOpikClient(
+        threads=_page(
+            [
+                {
+                    "id": "th-1",
+                    "status": "inactive",
+                    "number_of_messages": 12,
+                    "duration": 91000.0,
+                    "last_updated_at": "2026-09-08T09:00:00Z",
+                }
+            ]
+        )
+    )
+    out = await run_list("thread", project_id="p-1", client=fake)
+    assert "id | status | number_of_messages | duration | last_updated_at" in out
+    assert "th-1 | inactive | 12 | 91000.0 | 2026-09-08T09:00:00Z" in out
+
+
+@pytest.mark.anyio
+async def test_experiment_rows_summarise_feedback_scores() -> None:
+    fake = FakeOpikClient(
+        experiments=_page(
+            [
+                {
+                    "id": "e-1",
+                    "name": "rerank-v2",
+                    "dataset_name": "golden",
+                    "created_at": "2026-09-01T00:00:00Z",
+                    "feedback_scores": [
+                        {"name": "accuracy", "value": 0.8125},
+                        {"name": "hallucination", "value": 0.1},
+                    ],
+                }
+            ]
+        )
+    )
+    out = await run_list("experiment", client=fake)
+    assert "id | name | dataset_name | created_at | feedback_scores" in out
+    assert (
+        "e-1 | rerank-v2 | golden | 2026-09-01T00:00:00Z | accuracy=0.8125, hallucination=0.1"
+        in out
+    )

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -145,13 +145,31 @@ async def test_empty_result_with_an_explicit_source_carries_no_hint() -> None:
 
 
 @pytest.mark.anyio
-async def test_empty_result_under_the_agents_own_constraints_carries_no_hint() -> None:
-    """With a window or filters of the agent's own, those are the likelier
-    reason for an empty page; the source hint would point the wrong way."""
-    out = await run_list("trace", project_id="p-1", since="30d", client=FakeOpikClient())
-    assert "No traces found." in out and "playground" not in out
+async def test_empty_result_under_the_agents_own_filters_carries_no_hint() -> None:
+    """With filters of the agent's own, those are the likelier reason for an
+    empty page; the source hint would point the wrong way."""
     out = await run_list("trace", project_id="p-1", filters="duration > 5", client=FakeOpikClient())
     assert "No traces found." in out and "playground" not in out
+
+
+@pytest.mark.anyio
+async def test_a_sort_does_not_suppress_the_source_hint() -> None:
+    """Sorting changes order, not membership — the empty page still needs the why."""
+    out = await run_list("trace", project_id="p-1", sort="duration desc", client=FakeOpikClient())
+    assert "playground" in out
+
+
+@pytest.mark.anyio
+async def test_window_with_traffic_inside_it_points_at_the_source_default() -> None:
+    """The project's last trace is inside the window yet the page is empty: the
+    sdk default hid it (experiment/evaluator traces). Say so."""
+    fake = FakeOpikClient(
+        projects=_page(
+            [{"id": "p-1", "name": "demo", "last_updated_trace_at": "2026-09-08T10:00:00Z"}]
+        )
+    )
+    out = await run_list("trace", project_name="demo", since="2026-09-08T00:00:00Z", client=fake)
+    assert "playground" in out and "before your window" not in out
 
 
 @pytest.mark.anyio
@@ -294,6 +312,33 @@ async def test_cells_are_compact_seconds_whole_ms_and_plain_decimals() -> None:
     assert "t-1 | completion | 2026-07-31T11:26:45Z | 82 | " in out
     assert "| 0.0000135 | 2026-07-31T11:26:46Z" in out
     assert "e-05" not in out
+
+
+@pytest.mark.anyio
+async def test_half_milliseconds_round_up_and_non_finite_values_render_empty() -> None:
+    fake = FakeOpikClient(
+        traces=_page(
+            [
+                {"id": "t-1", "name": "a", "duration": 82.5},
+                {"id": "t-2", "name": "b", "duration": float("nan")},
+                {"id": "t-3", "name": "c", "duration": float("inf"), "total_estimated_cost": -0.5},
+            ]
+        )
+    )
+    out = await run_list("trace", project_id="p-1", client=fake)
+    assert "t-1 | a |  | 83 |  | " in out
+    assert "t-2 | b |  |  |  | " in out
+    assert "t-3 | c |  |  |  | -0.5" in out
+
+
+@pytest.mark.anyio
+async def test_a_404_that_is_not_about_the_project_keeps_the_backend_message() -> None:
+    class SomethingElseMissing(FakeOpikClient):
+        async def list_traces(self, **kw: Any) -> dict[str, Any]:
+            raise OpikNotFoundError("traces not found (404). — Workspace 'ws' not found")
+
+    with pytest.raises(ToolError, match=r"Failed to list traces: .*Workspace 'ws' not found"):
+        await run_list("trace", project_name="demo", client=SomethingElseMissing())
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_list_filters.py
+++ b/tests/test_read_list/test_list_filters.py
@@ -7,6 +7,7 @@ arguments that reach the backend, the table text, and the error text.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -15,6 +16,7 @@ import httpx
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
 
+from opik_mcp.opik_client import OpikNotFoundError
 from opik_mcp.read_list.list_tool import run_list
 from opik_mcp.read_list.oql import OQLError
 
@@ -38,6 +40,9 @@ class FakeOpikClient:
     experiments: dict[str, Any] = field(default_factory=lambda: _page([]))
     projects: dict[str, Any] = field(default_factory=lambda: _page([]))
     last_kwargs: dict[str, Any] = field(default_factory=dict)
+    project_kwargs: dict[str, Any] = field(default_factory=dict)
+    """``list_projects`` records separately: the tool also calls it on the side
+    (project-name recovery, last-trace hint) after the main list call."""
 
     async def list_traces(self, **kw: Any) -> dict[str, Any]:
         self.last_kwargs = kw
@@ -56,7 +61,7 @@ class FakeOpikClient:
         return self.experiments
 
     async def list_projects(self, **kw: Any) -> dict[str, Any]:
-        self.last_kwargs = kw
+        self.project_kwargs = kw
         return self.projects
 
     async def list_prompts(self, **kw: Any) -> dict[str, Any]:
@@ -185,8 +190,8 @@ async def test_filters_on_an_unsupported_type_name_the_supported_ones() -> None:
 async def test_empty_filters_on_an_unsupported_type_is_the_same_as_none() -> None:
     fake = FakeOpikClient(projects=_page([{"id": "p-1", "name": "demo"}]))
     out = await run_list("project", filters="", client=fake)
-    assert "filters" not in fake.last_kwargs
-    assert "truncate" not in fake.last_kwargs
+    assert "filters" not in fake.project_kwargs
+    assert "truncate" not in fake.project_kwargs
     assert out.startswith("Found 1 projects")
 
 
@@ -262,9 +267,66 @@ async def test_trace_rows_carry_triage_columns_by_default() -> None:
         )
     )
     out = await run_list("trace", project_id="p-1", client=fake)
-    assert "id | name | start_time | duration | error_type | total_estimated_cost" in out
-    assert "t-1 | chat | 2026-09-08T10:00:00Z | 7123.5 | TimeoutError | 0.0042" in out
+    assert "id | name | start_time | duration_ms | error_type | total_estimated_cost" in out
+    assert "t-1 | chat | 2026-09-08T10:00:00Z | 7124 | TimeoutError | 0.0042" in out
     assert "t-2 | chat |  | 120 |  | " in out
+
+
+@pytest.mark.anyio
+async def test_cells_are_compact_seconds_whole_ms_and_plain_decimals() -> None:
+    """Row density is paid on every page: microseconds, sub-millisecond
+    durations and scientific notation cost tokens and tell the agent nothing."""
+    fake = FakeOpikClient(
+        traces=_page(
+            [
+                {
+                    "id": "t-1",
+                    "name": "completion",
+                    "start_time": "2026-07-31T11:26:45.360141Z",
+                    "duration": 82.461,
+                    "total_estimated_cost": 1.35e-05,
+                    "end_time": "2026-07-31T11:26:46.000+00:00",
+                }
+            ]
+        )
+    )
+    out = await run_list("trace", project_id="p-1", sort="end_time", client=fake)
+    assert "t-1 | completion | 2026-07-31T11:26:45Z | 82 | " in out
+    assert "| 0.0000135 | 2026-07-31T11:26:46Z" in out
+    assert "e-05" not in out
+
+
+@pytest.mark.anyio
+async def test_dynamic_duration_columns_carry_the_ms_label() -> None:
+    fake = FakeOpikClient(spans=_page([{"id": "s-1", "name": "llm", "ttft": 412.9}]))
+    out = await run_list("span", project_id="p-1", sort="ttft desc", client=fake)
+    header = out.splitlines()[3]
+    assert header.endswith("| error_type | ttft_ms")
+    assert "| 413" in out
+    # The field keeps its backend name in the header echo and in the request.
+    assert "sort: ttft desc" in out.splitlines()[0]
+    assert json.loads(fake.last_kwargs["sorting"])[0]["field"] == "ttft"
+
+
+@pytest.mark.anyio
+async def test_project_rows_show_when_the_last_trace_landed() -> None:
+    fake = FakeOpikClient(
+        projects=_page(
+            [
+                {
+                    "id": "p-1",
+                    "name": "demo",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "last_updated_trace_at": "2026-09-08T09:15:22.123456Z",
+                },
+                {"id": "p-2", "name": "empty", "created_at": "2026-02-01T00:00:00Z"},
+            ]
+        )
+    )
+    out = await run_list("project", client=fake)
+    assert "id | name | created_at | last_updated_trace_at" in out
+    assert "p-1 | demo | 2026-01-01T00:00:00Z | 2026-09-08T09:15:22Z" in out
+    assert "p-2 | empty | 2026-02-01T00:00:00Z | " in out
 
 
 # --- span: project-wide search --------------------------------------------- #
@@ -321,8 +383,8 @@ async def test_span_rows_carry_span_columns_by_default() -> None:
         )
     )
     out = await run_list("span", project_id="p-1", client=fake)
-    assert "id | name | type | trace_id | duration | model | error_type" in out
-    assert "s-1 | openai.chat | llm | t-1 | 812.0 | gpt-4o | RateLimitError" in out
+    assert "id | name | type | trace_id | duration_ms | model | error_type" in out
+    assert "s-1 | openai.chat | llm | t-1 | 812 | gpt-4o | RateLimitError" in out
 
 
 # --- since / until window, search ------------------------------------------- #
@@ -345,6 +407,90 @@ async def test_relative_since_resolves_against_now(shorthand: str, delta: int) -
 
 
 @pytest.mark.anyio
+async def test_relative_since_is_echoed_as_written_plus_the_bound() -> None:
+    fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
+    out = await run_list("trace", project_id="p-1", since="30d", client=fake)
+    assert re.search(r"\| since: 30d \(\d{4}-\d\d-\d\dT\d\d:\d\dZ\)\]$", out.splitlines()[0])
+
+
+@pytest.mark.anyio
+async def test_empty_windowed_page_reports_the_projects_last_trace() -> None:
+    """Seen live: since="30d" on a project whose traffic ended weeks earlier
+    looks the same as a project with no traffic. One project read tells them apart."""
+    fake = FakeOpikClient(
+        projects=_page(
+            [{"id": "p-1", "name": "demo", "last_updated_trace_at": "2026-07-31T11:26:45.360141Z"}]
+        )
+    )
+    out = await run_list("trace", project_name="demo", since="2026-08-09T00:00:00Z", client=fake)
+    assert "No traces found." in out
+    assert "Last trace in this project: 2026-07-31T11:26Z, before your window." in out
+    assert fake.project_kwargs.get("name") == "demo"
+
+
+@pytest.mark.anyio
+async def test_empty_windowed_page_on_a_project_without_traces_says_so() -> None:
+    fake = FakeOpikClient(projects=_page([{"id": "p-1", "name": "demo"}]))
+    out = await run_list("trace", project_id="p-1", since="1h", client=fake)
+    assert "This project has no traces yet." in out
+
+
+@pytest.mark.anyio
+async def test_empty_windowed_page_with_traffic_inside_the_window_adds_nothing() -> None:
+    fake = FakeOpikClient(
+        projects=_page(
+            [{"id": "p-1", "name": "demo", "last_updated_trace_at": "2026-09-08T10:00:00Z"}]
+        )
+    )
+    out = await run_list(
+        "trace",
+        project_name="demo",
+        since="2026-09-08T00:00:00Z",
+        filters="duration > 5",
+        client=fake,
+    )
+    assert out.endswith("No traces found.")
+
+
+@pytest.mark.anyio
+async def test_unknown_project_name_suggests_the_closest_one() -> None:
+    class NoSuchProject(FakeOpikClient):
+        async def list_traces(self, **kw: Any) -> dict[str, Any]:
+            raise OpikNotFoundError(
+                "traces not found (404). — Project name: Defualt Project not found"
+            )
+
+    fake = NoSuchProject(
+        projects=_page([{"id": "p-1", "name": "Default Project"}, {"id": "p-2", "name": "probe"}])
+    )
+    with pytest.raises(ToolError) as ei:
+        await run_list("trace", project_name="Defualt Project", client=fake)
+    message = str(ei.value)
+    assert "Project 'Defualt Project' not found." in message
+    assert "Did you mean 'Default Project'?" in message
+    assert "Projects: Default Project, probe" in message
+    assert isinstance(ei.value.__cause__, OpikNotFoundError)
+
+
+@pytest.mark.anyio
+async def test_search_calls_get_a_longer_client_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cold full-text search took 32 s live; other calls must keep the 30 s guard."""
+    from opik_mcp.read_list import list_tool
+
+    seen: list[float | None] = []
+
+    def fake_factory(settings: Any, *, timeout: float | None = None) -> FakeOpikClient:
+        seen.append(timeout)
+        return FakeOpikClient()
+
+    monkeypatch.setattr(list_tool, "make_opik_client", fake_factory)
+    monkeypatch.setattr(list_tool, "get_settings", lambda: object())
+    await run_list("trace", project_id="p-1", search="order-42")
+    await run_list("trace", project_id="p-1")
+    assert seen == [60.0, None]
+
+
+@pytest.mark.anyio
 async def test_iso_window_passes_through_and_is_echoed() -> None:
     fake = FakeOpikClient(traces=_page([{"id": "t-1", "name": "chat"}]))
     out = await run_list(
@@ -357,8 +503,8 @@ async def test_iso_window_passes_through_and_is_echoed() -> None:
     assert fake.last_kwargs["from_time"] == "2026-09-08T00:00:00Z"
     assert fake.last_kwargs["to_time"] == "2026-09-08T12:00:00Z"
     assert out.splitlines()[0] == (
-        '[list: trace | filters: source = "sdk" | since: 2026-09-08T00:00:00Z'
-        " | until: 2026-09-08T12:00:00Z]"
+        '[list: trace | filters: source = "sdk" | since: 2026-09-08T00:00Z'
+        " | until: 2026-09-08T12:00Z]"
     )
 
 
@@ -431,7 +577,7 @@ async def test_search_is_forwarded_for_spans_and_echoed() -> None:
 async def test_search_on_a_type_without_it_is_dropped_with_a_note() -> None:
     fake = FakeOpikClient(projects=_page([{"id": "p-1", "name": "demo"}]))
     out = await run_list("project", search="demo", client=fake)
-    assert "search" not in fake.last_kwargs
+    assert "search" not in fake.project_kwargs
     assert out.splitlines()[0] == "[list: project | search ignored (only trace, span, thread)]"
 
 
@@ -516,7 +662,7 @@ async def test_header_lists_filters_sort_window_search_in_that_order() -> None:
     )
     assert out.splitlines()[0] == (
         '[list: trace | filters: duration > 5000 AND source = "sdk" | sort: duration desc'
-        ' | since: 2026-09-08T00:00:00Z | search: "order-42"]'
+        ' | since: 2026-09-08T00:00Z | search: "order-42"]'
     )
 
 
@@ -540,7 +686,8 @@ async def test_sort_field_becomes_a_column_resolved_from_the_usage_map() -> None
     out = await run_list("trace", project_id="p-1", sort="usage.total_tokens", client=fake)
     header = out.splitlines()[3]
     assert header == (
-        "id | name | start_time | duration | error_type | total_estimated_cost | usage.total_tokens"
+        "id | name | start_time | duration_ms | error_type | total_estimated_cost"
+        " | usage.total_tokens"
     )
     assert "t-1 | chat |  |  |  |  | 4321" in out
     assert "t-2 | chat |  |  |  |  | " in out
@@ -574,7 +721,7 @@ async def test_filter_fields_become_columns_deduplicated_and_in_order() -> None:
     )
     header = out.splitlines()[3]
     assert header == (
-        "id | name | start_time | duration | error_type | total_estimated_cost"
+        "id | name | start_time | duration_ms | error_type | total_estimated_cost"
         " | feedback_scores.accuracy | tags | metadata.environment"
     )
     assert "t-1 | chat |  | 9000 |  |  | 0.42 | ['prod', 'beta'] | staging" in out
@@ -590,7 +737,7 @@ async def test_body_and_source_fields_are_never_appended_as_columns() -> None:
         client=fake,
     )
     header = out.splitlines()[3]
-    assert header == "id | name | start_time | duration | error_type | total_estimated_cost"
+    assert header == "id | name | start_time | duration_ms | error_type | total_estimated_cost"
 
 
 @pytest.mark.anyio
@@ -669,6 +816,9 @@ async def test_thread_rows_carry_duration() -> None:
             [
                 {
                     "id": "th-1",
+                    "first_message": (
+                        "Hi, my order #4411 never arrived and support is not answering"
+                    ),
                     "status": "inactive",
                     "number_of_messages": 12,
                     "duration": 91000.0,
@@ -678,8 +828,11 @@ async def test_thread_rows_carry_duration() -> None:
         )
     )
     out = await run_list("thread", project_id="p-1", client=fake)
-    assert "id | status | number_of_messages | duration | last_updated_at" in out
-    assert "th-1 | inactive | 12 | 91000.0 | 2026-09-08T09:00:00Z" in out
+    assert "id | first_message | status | number_of_messages | duration_ms | last_updated_at" in out
+    assert (
+        "th-1 | Hi, my order #4411 never arrived and support is not answe... | inactive | 12"
+        " | 91000 | 2026-09-08T09:00:00Z"
+    ) in out
 
 
 @pytest.mark.anyio

--- a/tests/test_read_list/test_list_schema.py
+++ b/tests/test_read_list/test_list_schema.py
@@ -1,0 +1,72 @@
+"""``schema("list.<entity>")`` — the full filter/sort reference for one entity.
+
+The tool description for ``list`` carries only two lines of grammar; this is
+where an agent looks the fields up on purpose. The reference is generated
+from the same tables the validator uses, so it cannot drift from what
+``list`` accepts.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from opik_mcp.read_list.oql import FILTERABLE_FIELDS, OPERATORS_BY_TYPE
+from opik_mcp.read_list.sorting import sortable_names
+from opik_mcp.writes.errors import UnknownOperationError
+from opik_mcp.writes.schema_tool import run_schema
+
+
+def test_list_trace_reference_carries_fields_operators_sort_window_search() -> None:
+    ref = run_schema("list.trace")
+    assert ref["operation"] == "list.trace"
+    assert ref["entity_type"] == "trace"
+
+    duration = ref["filters"]["fields"]["duration"]
+    assert duration == {
+        "type": "number",
+        "operators": ["=", "!=", ">", ">=", "<", "<="],
+        "unit": "milliseconds",
+    }
+    metadata = ref["filters"]["fields"]["metadata"]
+    assert metadata["type"] == "dictionary"
+    assert metadata["key"] == "required"
+    assert ">=" not in metadata["operators"]
+    assert ref["filters"]["fields"]["error_info"]["operators"] == ["is_empty", "is_not_empty"]
+
+    assert "<field>[.<key>] <op> <value> [AND ...]" in ref["filters"]["grammar"]
+    assert len(ref["filters"]["examples"]) == 2
+    assert ref["filters"]["default"] == 'source = "sdk" unless you name source'
+
+    assert ref["sort"]["form"] == "<field> [asc|desc]"
+    assert "feedback_scores.<name>" in ref["sort"]["fields"]
+    assert ref["window"] is True
+    assert ref["search"] is True
+
+
+def test_list_experiment_reference_has_no_window_search_or_source_default() -> None:
+    ref = run_schema("list.experiment")
+    assert ref["window"] is False
+    assert ref["search"] is False
+    assert "default" not in ref["filters"]
+    assert set(ref["filters"]["fields"]) == set(FILTERABLE_FIELDS["experiment"])
+
+
+@pytest.mark.parametrize("entity_type", ["trace", "span", "thread", "experiment"])
+def test_reference_matches_the_validator_tables_exactly(entity_type: str) -> None:
+    ref = run_schema(f"list.{entity_type}")
+    fields = ref["filters"]["fields"]
+    assert set(fields) == set(FILTERABLE_FIELDS[entity_type])
+    for name, spec in fields.items():
+        expected_type = FILTERABLE_FIELDS[entity_type][name]
+        assert spec["type"] == expected_type
+        assert spec["operators"] == list(OPERATORS_BY_TYPE[expected_type])
+    assert ref["sort"]["fields"] == sortable_names(entity_type)
+
+
+def test_unknown_list_key_recovers_with_the_list_keys_listed() -> None:
+    with pytest.raises(ToolError) as ei:
+        run_schema("list.widget")
+    assert isinstance(ei.value.__cause__, UnknownOperationError)
+    assert "list.trace" in str(ei.value)
+    assert "score.create" in str(ei.value)

--- a/tests/test_read_list/test_list_tool.py
+++ b/tests/test_read_list/test_list_tool.py
@@ -222,13 +222,6 @@ async def test_list_rejects_unknown_entity_type() -> None:
         await run_list("widget", client=FakeOpikClient())
 
 
-@pytest.mark.anyio
-async def test_list_rejects_span_singleton_entity() -> None:
-    """``span`` has no list_fn — it's id-only."""
-    with pytest.raises(ToolError, match="Cannot list 'span'"):
-        await run_list("span", client=FakeOpikClient())
-
-
 # --- size / page clamping ------------------------------------------------ #
 
 

--- a/tests/test_read_list/test_oql.py
+++ b/tests/test_read_list/test_oql.py
@@ -1,0 +1,259 @@
+"""OQL (Opik Query Language) parser — the ``filters`` string of the ``list`` tool.
+
+Grammar cases are ported from the Opik Python SDK's parser tests so the MCP
+accepts exactly what ``search_traces(filter_string=...)`` accepts. The
+backend-alignment cases are ours: the field/operator tables come from
+opik-backend's enums, not the SDK's, so a string that passes here does not
+400 server-side.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opik_mcp.read_list.errors import EntityArgValidationError
+from opik_mcp.read_list.oql import OQLError, compile_filters
+
+
+def _clause(field: str, operator: str, value: str = "", key: str = "") -> dict[str, str]:
+    return {"field": field, "operator": operator, "key": key, "value": value}
+
+
+# --- grammar (ported from the SDK) ---------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ('name = "test"', [_clause("name", "=", "test")]),
+        ("usage.total_tokens > 100", [_clause("usage.total_tokens", ">", "100")]),
+        ('tags contains "important"', [_clause("tags", "contains", "important")]),
+        ('output not_contains "error"', [_clause("output", "not_contains", "error")]),
+        (
+            'feedback_scores."Answer Relevance" < 0.8',
+            [_clause("feedback_scores", "<", "0.8", key="Answer Relevance")],
+        ),
+        (
+            'feedback_scores."Escaped ""Quote""" < 0.8',
+            [_clause("feedback_scores", "<", "0.8", key='Escaped "Quote"')],
+        ),
+        (
+            'name = "test" AND tags contains "important"  ',
+            [_clause("name", "=", "test"), _clause("tags", "contains", "important")],
+        ),
+        (
+            'id starts_with "123456" and id ends_with "789012"',
+            [_clause("id", "starts_with", "123456"), _clause("id", "ends_with", "789012")],
+        ),
+        ('thread_id = "thread_123"', [_clause("thread_id", "=", "thread_123")]),
+        ("llm_span_count > 5", [_clause("llm_span_count", ">", "5")]),
+        (
+            "span_feedback_scores.accuracy > 0.9",
+            [_clause("span_feedback_scores", ">", "0.9", key="accuracy")],
+        ),
+        (
+            "span_feedback_scores.my_metric is_empty",
+            [_clause("span_feedback_scores", "is_empty", key="my_metric")],
+        ),
+        (
+            'annotation_queue_ids contains "queue_1"',
+            [_clause("annotation_queue_ids", "contains", "queue_1")],
+        ),
+        (
+            "total_estimated_cost > 0 AND duration > 100",
+            [_clause("total_estimated_cost", ">", "0"), _clause("duration", ">", "100")],
+        ),
+        ('input_json.model = "gpt-4"', [_clause("input_json", "=", "gpt-4", key="model")]),
+        (
+            'output_json.result contains "success"',
+            [_clause("output_json", "contains", "success", key="result")],
+        ),
+        (
+            "feedback_scores.my_metric is_empty AND feedback_scores.other_metric > 0.5",
+            [
+                _clause("feedback_scores", "is_empty", key="my_metric"),
+                _clause("feedback_scores", ">", "0.5", key="other_metric"),
+            ],
+        ),
+        ("error_info is_empty", [_clause("error_info", "is_empty")]),
+        ("error_info is_not_empty", [_clause("error_info", "is_not_empty")]),
+        ("tags is_empty", [_clause("tags", "is_empty")]),
+        ("tags is_not_empty", [_clause("tags", "is_not_empty")]),
+        # negative numbers
+        ("duration > -5", [_clause("duration", ">", "-5")]),
+        ("total_estimated_cost < -0.1", [_clause("total_estimated_cost", "<", "-0.1")]),
+        # escaped quotes in values
+        ('name = "say ""hi"" there"', [_clause("name", "=", 'say "hi" there')]),
+        ('name = """quoted"""', [_clause("name", "=", '"quoted"')]),
+        # in / not_in take a parenthesised list, serialised comma-joined
+        (
+            'environment in ("prod", "staging")',
+            [_clause("environment", "in", "prod,staging")],
+        ),
+        ('environment not_in ("debug")', [_clause("environment", "not_in", "debug")]),
+        (
+            'environment in ("a") AND input contains "hello"',
+            [_clause("environment", "in", "a"), _clause("input", "contains", "hello")],
+        ),
+        # date-time values are quoted ISO-8601 instants
+        (
+            'start_time >= "2026-09-08T00:00:00Z"',
+            [_clause("start_time", ">=", "2026-09-08T00:00:00Z")],
+        ),
+    ],
+)
+def test_trace_grammar_compiles_to_backend_filter_array(
+    query: str, expected: list[dict[str, str]]
+) -> None:
+    assert compile_filters("trace", query) == expected
+
+
+@pytest.mark.parametrize("query", ["", "   "])
+def test_empty_query_compiles_to_no_filters(query: str) -> None:
+    assert compile_filters("trace", query) == []
+
+
+@pytest.mark.parametrize(
+    ("query", "kind", "fragment"),
+    [
+        ("name = test", "syntax", "double quotes"),
+        ('name = "test" extra_stuff', "syntax", "trailing"),
+        ('name = "test" OR name = "other"', "syntax", "OR is not supported"),
+        ('feedback_scores."Unterminated Quote < 0.8', "syntax", "closing quote"),
+        ('name = "hello', "syntax", "closing quote"),
+        ("duration >", "syntax", "unexpected end"),
+        ("name =", "syntax", "unexpected end"),
+        ("duration > 5 and", "syntax", "unexpected end"),
+        ("id", "syntax", "unexpected end"),
+        ("duration > -", "syntax", "number after '-'"),
+        ("duration > 5.", "syntax", "digits after decimal point"),
+        ("environment in prod", "syntax", "'('"),
+        ('environment in ("unterminated"', "syntax", "missing ')'"),
+        ("environment in (unquoted)", "syntax", "quoted strings"),
+        ("environment in ()", "syntax", "at least one item"),
+        ("usage.invalid_metric = 100", "unknown_field", "usage.total_tokens"),
+        ('invalid_field.key = "value"', "unknown_field", "invalid_field"),
+        ('error_info = "something"', "bad_operator", "error_info"),
+    ],
+)
+def test_sdk_rejections_are_kept(query: str, kind: str, fragment: str) -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", query)
+    assert ei.value.kinds == (kind,)
+    assert fragment in str(ei.value)
+
+
+# --- self-healing: the message carries what is needed to fix the string --- #
+
+
+def test_oql_error_is_a_typed_validation_error() -> None:
+    with pytest.raises(EntityArgValidationError):
+        compile_filters("trace", 'name = "test" extra')
+
+
+def test_syntax_error_marks_the_position_and_shows_the_grammar() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", "error_info is_not_empty AND duration > five")
+    message = str(ei.value)
+    # The offending string is echoed with a caret under the failing position.
+    assert "error_info is_not_empty AND duration > five" in message
+    assert "\n" + " " * len("error_info is_not_empty AND duration > ") + "^" in message
+    assert "<field>[.<key>] <op> <value> [AND ...]" in message
+
+
+def test_unknown_field_suggests_the_closest_name_and_lists_the_fields() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", "durration > 5")
+    message = str(ei.value)
+    assert "Unknown field 'durration'" in message
+    assert "Did you mean 'duration'?" in message
+    # Names only — the full type/operator table lives behind schema("list.trace").
+    assert "Fields: " in message
+    assert "thread_id" in message
+    assert "date_time" not in message
+
+
+def test_bad_operator_names_the_type_and_the_valid_operators() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", "metadata.env >= 5")
+    message = str(ei.value)
+    assert "'>=' is not valid for 'metadata' (dictionary)" in message
+    assert (
+        "Valid: =, !=, contains, not_contains, starts_with, ends_with, >, <, is_empty, is_not_empty"
+        in message
+    )
+
+
+def test_bad_date_value_shows_the_expected_format() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", 'start_time > "2026-09-08"')
+    assert ei.value.kinds == ("bad_value",)
+    assert 'ISO-8601 instant with a timezone, e.g. "2026-09-08T10:00:00Z"' in str(ei.value)
+
+
+def test_bad_number_value_on_duration_mentions_milliseconds() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", 'duration > "5s"')
+    message = str(ei.value)
+    assert ei.value.kinds == ("bad_value",)
+    assert "milliseconds" in message
+
+
+def test_score_and_dictionary_fields_require_a_key() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", 'feedback_scores > 0.5 AND metadata = "x"')
+    message = str(ei.value)
+    assert ei.value.kinds == ("bad_value", "bad_value")
+    assert "feedback_scores.<name>" in message
+    assert "metadata.<key>" in message
+
+
+def test_all_problems_are_reported_together() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", 'durration > 5 AND error_info = "x" AND start_time > "yesterday"')
+    assert ei.value.kinds == ("unknown_field", "bad_operator", "bad_value")
+    message = str(ei.value)
+    assert "1." in message and "2." in message and "3." in message
+
+
+# --- backend alignment (where the SDK's tables are wrong or short) --------- #
+
+
+def test_dictionary_fields_have_no_gte_lte_but_do_have_emptiness() -> None:
+    with pytest.raises(OQLError):
+        compile_filters("trace", "metadata.x <= 5")
+    assert compile_filters("trace", "metadata.x is_empty") == [
+        _clause("metadata", "is_empty", key="x")
+    ]
+
+
+def test_enum_fields_accept_emptiness_operators() -> None:
+    assert compile_filters("trace", "environment is_not_empty") == [
+        _clause("environment", "is_not_empty")
+    ]
+
+
+def test_source_accepts_only_equality() -> None:
+    assert compile_filters("trace", 'source = "sdk"') == [_clause("source", "=", "sdk")]
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", 'source in ("sdk")')
+    assert ei.value.kinds == ("bad_operator",)
+
+
+def test_backend_only_trace_fields_are_known() -> None:
+    assert compile_filters("trace", 'error_type = "TimeoutError" AND ttft > 200') == [
+        _clause("error_type", "=", "TimeoutError"),
+        _clause("ttft", ">", "200"),
+    ]
+
+
+def test_unknown_top_level_field_is_rejected_not_defaulted_to_string() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", 'model = "gpt-4"')
+    assert ei.value.kinds == ("unknown_field",)
+
+
+def test_unknown_entity_type_is_rejected() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("project", 'name = "x"')
+    assert "trace, span, thread, experiment" in str(ei.value)

--- a/tests/test_read_list/test_oql.py
+++ b/tests/test_read_list/test_oql.py
@@ -263,7 +263,13 @@ def test_usage_without_a_metric_names_the_usage_fields() -> None:
 
 @pytest.mark.parametrize(
     "value",
-    ["2026-09-08 10:00:00Z", "2026-09-08", "2026-09-08T10:00:00"],
+    [
+        "2026-09-08 10:00:00Z",
+        "2026-09-08",
+        "2026-09-08T10:00:00",
+        "2026-09-08T10Z",
+        "2026-09-08T10:00Z",
+    ],
 )
 def test_dates_the_backend_would_refuse_are_rejected_locally(value: str) -> None:
     """``Instant.parse`` wants a ``T`` separator and a timezone; Python's

--- a/tests/test_read_list/test_oql.py
+++ b/tests/test_read_list/test_oql.py
@@ -253,6 +253,26 @@ def test_unknown_top_level_field_is_rejected_not_defaulted_to_string() -> None:
     assert ei.value.kinds == ("unknown_field",)
 
 
+def test_usage_without_a_metric_names_the_usage_fields() -> None:
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", "usage > 5")
+    assert ei.value.kinds == ("unknown_field",)
+    assert "Unknown field 'usage'" in str(ei.value)
+    assert "usage.total_tokens" in str(ei.value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["2026-09-08 10:00:00Z", "2026-09-08", "2026-09-08T10:00:00"],
+)
+def test_dates_the_backend_would_refuse_are_rejected_locally(value: str) -> None:
+    """``Instant.parse`` wants a ``T`` separator and a timezone; Python's
+    ``fromisoformat`` is looser, so the local check must be stricter than it."""
+    with pytest.raises(OQLError) as ei:
+        compile_filters("trace", f'start_time > "{value}"')
+    assert ei.value.kinds == ("bad_value",)
+
+
 def test_unknown_entity_type_is_rejected() -> None:
     with pytest.raises(OQLError) as ei:
         compile_filters("project", 'name = "x"')

--- a/tests/test_read_list/test_read_tool.py
+++ b/tests/test_read_list/test_read_tool.py
@@ -64,13 +64,14 @@ class FakeOpikClient:
     async def list_spans(
         self,
         *,
-        trace_id: str,
+        trace_id: str | None = None,
         project_id: str | None = None,
         project_name: str | None = None,
         page: int = 1,
         size: int = 100,
+        **_search: Any,
     ) -> dict[str, Any]:
-        content = self.trace_spans.get(trace_id, [])
+        content = self.trace_spans.get(trace_id or "", [])
         return {"content": content, "page": page, "size": len(content), "total": len(content)}
 
     async def get_span(self, span_id: str) -> dict[str, Any]:
@@ -85,6 +86,7 @@ class FakeOpikClient:
         name: str | None = None,
         page: int = 1,
         size: int = 10,
+        **_search: Any,
     ) -> dict[str, Any]:
         content = self.experiments_by_name.get(name or "", [])
         return {"content": content, "page": page, "size": len(content), "total": len(content)}
@@ -131,6 +133,7 @@ class FakeOpikClient:
         filters: str | None = None,
         page: int = 1,
         size: int = 10,
+        **_search: Any,
     ) -> dict[str, Any]:
         if self.fail_list_traces:
             raise OpikServerError("boom")

--- a/tests/test_read_list/test_registry.py
+++ b/tests/test_read_list/test_registry.py
@@ -18,9 +18,11 @@ def test_list_only_entities_excluded_from_readable() -> None:
     assert "prompt_version" not in READABLE_TYPES
 
 
-def test_singletons_with_no_list_endpoint_excluded_from_listable() -> None:
-    """``span`` is fetchable by id but not enumerable — verify the dispatcher knows."""
-    assert "span" not in LISTABLE_TYPES
+def test_span_is_listable_with_project_scope() -> None:
+    """``span`` is enumerable project-wide (OPIK-8283); the project requirement
+    is what the ``list`` tool enforces before calling the backend."""
+    assert "span" in LISTABLE_TYPES
+    assert ENTITY_REGISTRY["span"].list_required_kwargs == ("project_id",)
 
 
 def test_id_only_flag_set_for_trace_span_prompt_version_test_suite_item() -> None:


### PR DESCRIPTION
## Details

The agent could only page through a project's latest traces: `list` took a name substring, a page and a size. The UI filters the same data on ~30 fields, sorts it, scopes it to a window and searches it; through the MCP 97% of `list` calls carried no filter because there was none to carry, and spans could not be listed at all. Our own skills fell back to SDK scripts for "failed traces in the last hour".

`list` now takes, for `trace`, `span`, `thread` and `experiment`:

- **`filters`** — an OQL string, the same grammar as the SDK's `search_traces(filter_string=…)`: `error_info is_not_empty AND duration > 5000`. The parser is ported into `read_list/oql.py` (no `opik` dependency); the field and operator tables come from opik-backend's enums, not the SDK's copies, which fixes two SDK mistakes (`dictionary` has no `>=`/`<=`, `enum` has `is_empty`) and adds `source`, `error_type`, `ttft`, `environment` and the whole experiment surface. Unknown fields are rejected locally.
- **`sort`** — `"<field> [asc|desc]"`, one field, validated against the backend's sortable lists because the backend silently ignores unknown sort fields. The header says when the backend dropped the sort for workspace size.
- **`since` / `until`** — `"1h"`, `"7d"` or an ISO instant, mapped to the backend's cheap UUIDv7 creation-time bounds (`from_time`/`to_time`). Experiments have no window and say so.
- **`search`** — free text across id, name, input, output, metadata, tags, thread_id. Those calls get a 60 s client timeout (a cold search took 32 s live).
- **`span`** is a listable type, searched project-wide; `trace_id` and `type` are OQL fields.

Behaviour the agent sees:

- Like the UI's Logs page, trace/span/thread lists add `source = "sdk"` unless the caller names `source`. The first output line echoes everything applied: `[list: trace | filters: … AND source = "sdk" | sort: duration desc | since: 30d (2026-08-09T11:03Z)]`.
- Validation errors are collected and returned together with what fixes them: a caret under a syntax error, "did you mean" plus the entity's field names, the valid operators for a field's type, the expected value format. `schema("list.trace")` (and `list.span`, `list.thread`, `list.experiment`) is the full reference, so the tool description stays two lines of grammar.
- Rows carry triage columns by default (`duration_ms`, `error_type`, cost; spans add `type`, `trace_id`, `model`; threads add `first_message`; projects add `last_updated_trace_at`) plus a column for every field named in `sort`/`filters`, including `feedback_scores.x`, `usage.x`, `metadata.x`. Durations are whole milliseconds under a `_ms` label, timestamps to the second, costs as plain decimals.
- Empty pages explain themselves: under the `source` default, how to see other sources; under a window, when the project's last trace landed. A misspelled `project_name` comes back with the closest existing name.
- Timeouts and transport errors on the list path get readable messages (`httpx.ReadTimeout` stringifies to `''`).
- Session instructions mention the search surface with one example.
- `opik-diagnose` and `opik-explain` are MCP-first for these questions with the SDK as fallback; the `opik` reference skill documents OQL once for both paths (own commit).
- Analytics records the shape of each call (`has_filters`, `filter_fields` as names only, `has_sort`, `sort_field` with dynamic prefixes collapsed, `has_window`, `has_search`); validation failures are bucketed by exception class (`OQLSyntaxError`, `OQLUnknownFieldError`, `OQLBadOperatorError`, `OQLBadValueError`, `SortError`, `WindowError`). No filter values, search text or metadata keys ever reach analytics.

Wire contract: five optional parameters added to `list`; `span` added to its entity enum; `schema` accepts `list.<entity>` keys. Existing calls behave as before except that trace/span/thread lists now default to `source = "sdk"` and trace/thread rows have richer default columns. Snapshots for `list` and `schema` are regenerated in the diff.

## Change checklist
- [x] User facing
- [x] Documentation updated (README: `list`, `schema`; skills: opik-diagnose, opik-explain, opik)
- [x] Tests added/updated (OQL parser suite ported from the SDK plus backend-alignment cases; `run_list` scenarios; client query params via respx; analytics privacy; schema reference round-trip; instructions)
- [x] Breaking changes documented: none on the wire. Trace/span/thread lists now apply `source = "sdk"` by default (echoed in the header, documented in README and the tool description).

## Issues
- OPIK-8283

## Testing

- `make check`: ruff, mypy, 1376 tests green. `make e2e`: 10 stdio tests green.
- Built the wheel and ran it as a customer would (`uvx --from <wheel> opik-mcp`) over stdio against a real Comet workspace with an API key. ~50 scenarios across three passes on a project with 38k SDK traces, 44k spans and a thread: filtered/sorted/windowed traces, project-wide spans, spans of one trace via OQL, threads, experiments, free-text search, paging, every self-healing error, `schema("list.*")`, and the empty-page hints. Final pass exercised every tool: `list` (7 entity types), `read` (project, trace, span, thread, experiment), `schema` (write op and `list.span`), `write` (dry run), `read_skill`.
- Two problems found only by the live run and fixed here: a cold free-text search exceeding the 30 s timeout surfaced as an error with no text, and a project holding only experiment traces answered `No traces found` with nothing to explain why.
- Two code-review passes (standards + spec) with fixes committed: instant ordering compared as strings, `usage` without a metric, hour-only dates passing local validation, NaN in a duration cell, the source hint suppressed by a sort, project-name 404 relabelling.

## Documentation

README `### list` and `### schema` sections; `src/opik_mcp/skills/opik/SKILL.md` "Searching traces"; `opik-diagnose` and `opik-explain` step 2. Design notes for reviewers: the `since`/`until` window is by record creation time (index-aligned, agrees with `start_time` within seconds for live traffic); an exact `start_time` bound is available in OQL. The backend honours one sort field and drops sorting on very large workspaces, which is why the sort is validated locally and the header flags a dropped sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
